### PR TITLE
Add external schema mappings for files written with name-based schemas

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.mapping.NameMapping;
 
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION_DEFAULT;
@@ -170,6 +171,7 @@ public class Avro {
     private final ClassLoader defaultLoader = Thread.currentThread().getContextClassLoader();
     private final InputFile file;
     private final Map<String, String> renames = Maps.newLinkedHashMap();
+    private NameMapping nameMapping;
     private boolean reuseContainers = false;
     private org.apache.iceberg.Schema schema = null;
     private Function<Schema, DatumReader<?>> createReaderFunc = readSchema -> {
@@ -223,10 +225,15 @@ public class Avro {
       return this;
     }
 
+    public ReadBuilder nameMapping(NameMapping newNameMapping) {
+      this.nameMapping = newNameMapping;
+      return this;
+    }
+
     public <D> AvroIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
       return new AvroIterable<>(file,
-          new ProjectionDatumReader<>(createReaderFunc, schema, renames),
+          new ProjectionDatumReader<>(createReaderFunc, schema, renames, nameMapping),
           start, length, reuseContainers);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -216,7 +216,7 @@ public class AvroSchemaUtil {
     if (id != null) {
       return toInt(id);
     } else {
-      Preconditions.checkState(nameMapping != null,
+      Preconditions.checkArgument(nameMapping != null,
           "Schema does not have field id and name mapping not specified");
       MappedField mappedField = nameMapping.find(names);
       if (mappedField != null) {
@@ -286,7 +286,7 @@ public class AvroSchemaUtil {
     if (id != null) {
       return toInt(id);
     } else {
-      Preconditions.checkState(nameMapping != null, "Field schema does not have id and name mapping not specified");
+      Preconditions.checkArgument(nameMapping != null, "Field schema does not have id and name mapping not specified");
       List<String> names = Lists.newArrayList(parentFieldNames);
       names.add(field.name());
       MappedField mappedField = nameMapping.find(names);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -199,15 +199,13 @@ public class AvroSchemaUtil {
     return LogicalMap.get().addToSchema(Schema.createArray(keyValueRecord));
   }
 
-
-  static Integer getId(Schema schema, String propertyName) {
+  private static Integer getId(Schema schema, String propertyName) {
     Integer id = getId(schema, propertyName, null, null);
     Preconditions.checkNotNull(id, "Missing expected '%s' property", propertyName);
     return id;
   }
 
-  static Integer getId(Schema schema, String propertyName,
-                   NameMapping nameMapping, List<String> names) {
+  private static Integer getId(Schema schema, String propertyName, NameMapping nameMapping, List<String> names) {
     if (schema.getType() == UNION) {
       return getId(fromOption(schema), propertyName, nameMapping, names);
     }
@@ -215,15 +213,14 @@ public class AvroSchemaUtil {
     Object id = schema.getObjectProp(propertyName);
     if (id != null) {
       return toInt(id);
-    } else {
-      Preconditions.checkArgument(nameMapping != null,
-          "Schema does not have field id and name mapping not specified");
+    } else if (nameMapping != null) {
       MappedField mappedField = nameMapping.find(names);
       if (mappedField != null) {
         return mappedField.id();
       }
-      return null;
     }
+
+    return null;
   }
 
   static boolean hasProperty(Schema schema, String propertyName) {
@@ -285,8 +282,7 @@ public class AvroSchemaUtil {
     Object id = field.getObjectProp(FIELD_ID_PROP);
     if (id != null) {
       return toInt(id);
-    } else {
-      Preconditions.checkArgument(nameMapping != null, "Field schema does not have id and name mapping not specified");
+    } else if (nameMapping != null) {
       List<String> names = Lists.newArrayList(parentFieldNames);
       names.add(field.name());
       MappedField mappedField = nameMapping.find(names);
@@ -294,6 +290,7 @@ public class AvroSchemaUtil {
         return mappedField.id();
       }
     }
+
     return null;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -165,14 +165,13 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       try {
         Schema keyValueSchema = array.getElementType();
         Schema.Field keyField = keyValueSchema.getFields().get(0);
-        Schema.Field keyProjection = element.get().getField("key");
         Schema.Field valueField = keyValueSchema.getFields().get(1);
         Schema.Field valueProjection = element.get().getField("value");
 
         // element was changed, create a new array
-        if (keyProjection.schema() != keyField.schema() || valueProjection.schema() != valueField.schema()) {
+        if (valueProjection.schema() != valueField.schema()) {
           return AvroSchemaUtil.createProjectionMap(keyValueSchema.getFullName(),
-              AvroSchemaUtil.getFieldId(keyField), keyField.name(), keyProjection.schema(),
+              AvroSchemaUtil.getFieldId(keyField), keyField.name(), keyField.schema(),
               AvroSchemaUtil.getFieldId(valueField), valueField.name(), valueProjection.schema());
         } else if (!(array.getLogicalType() instanceof LogicalMap)) {
           return AvroSchemaUtil.createProjectionMap(keyValueSchema.getFullName(),

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -165,13 +165,14 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       try {
         Schema keyValueSchema = array.getElementType();
         Schema.Field keyField = keyValueSchema.getFields().get(0);
+        Schema.Field keyProjection = element.get().getField("key");
         Schema.Field valueField = keyValueSchema.getFields().get(1);
         Schema.Field valueProjection = element.get().getField("value");
 
         // element was changed, create a new array
-        if (valueProjection.schema() != valueField.schema()) {
+        if (keyProjection.schema() != keyField.schema() || valueProjection.schema() != valueField.schema()) {
           return AvroSchemaUtil.createProjectionMap(keyValueSchema.getFullName(),
-              AvroSchemaUtil.getFieldId(keyField), keyField.name(), keyField.schema(),
+              AvroSchemaUtil.getFieldId(keyField), keyField.name(), keyProjection.schema(),
               AvroSchemaUtil.getFieldId(valueField), valueField.name(), valueProjection.schema());
         } else if (!(array.getLogicalType() instanceof LogicalMap)) {
           return AvroSchemaUtil.createProjectionMap(keyValueSchema.getFullName(),
@@ -195,6 +196,8 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
         // element was changed, create a new array
         if (elementSchema != array.getElementType()) {
+          // TODO: we do not copy field ids here. Probably not required,
+          //  but we do at other places in this class.
           return Schema.createArray(elementSchema);
         }
 
@@ -219,6 +222,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
       // element was changed, create a new map
       if (valueSchema != map.getValueType()) {
+        // TODO: we do not copy field ids here
         return Schema.createMap(valueSchema);
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -196,8 +196,6 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
         // element was changed, create a new array
         if (elementSchema != array.getElementType()) {
-          // TODO: we do not copy field ids here. Probably not required,
-          //  but we do at other places in this class.
           return Schema.createArray(elementSchema);
         }
 
@@ -222,7 +220,6 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
       // element was changed, create a new map
       if (valueSchema != map.getValueType()) {
-        // TODO: we do not copy field ids here
         return Schema.createMap(valueSchema);
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -28,8 +28,12 @@ import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.iceberg.mapping.MappedField;
 import org.apache.iceberg.mapping.NameMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class PruneColumns extends AvroSchemaVisitor<Schema> {
+  private static final Logger LOG = LoggerFactory.getLogger(PruneColumns.class);
+
   private final Set<Integer> selectedIds;
   private final NameMapping nameMapping;
 
@@ -119,7 +123,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       Integer keyId = fieldId(keyValue.getField("key"));
       Integer valueId = fieldId(keyValue.getField("value"));
       if (keyId == null) {
-        Preconditions.checkState(valueId == null, "Map schema %s has value id but not key id", array);
+        LOG.warn("Map schema %s has value id but not key id", array);
         return null;
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -167,7 +167,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     Integer keyId = id(map, AvroSchemaUtil.KEY_ID_PROP, "key");
     Integer valueId = id(map, AvroSchemaUtil.VALUE_ID_PROP, "value");
     if (keyId == null) {
-      Preconditions.checkState(valueId == null, "Map schema %s has value-id but not key-id", map);
+      LOG.warn("Map schema {} has value-id but not key-id", map);
       return null;
     }
     // if either key or value is selected, the whole map must be projected

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -128,6 +128,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
         }
         return null;
       }
+
       // if either key or value is selected, the whole map must be projected
       if (selectedIds.contains(keyId) || selectedIds.contains(valueId)) {
         return complexMapWithIds(array, keyId, valueId);
@@ -174,6 +175,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       }
       return null;
     }
+
     // if either key or value is selected, the whole map must be projected
     if (selectedIds.contains(keyId) || selectedIds.contains(valueId)) {
       // Assign ids. Ids may not always be present in the schema,

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -58,11 +58,13 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     for (Schema.Field field : record.getFields()) {
       Integer fieldId = AvroSchemaUtil.getFieldId(field, nameMapping, fieldNames());
       if (fieldId == null) {
-        // both the schema and the nameMapping does not have field id. We prune this field.
+        // Both the schema and the nameMapping does not have field id. We prune this field.
         continue;
       }
 
       if (!AvroSchemaUtil.hasFieldId(field)) {
+        // fieldId was resolved from nameMapping, we updated hasChange
+        // flag to make sure a new field is created with the field id
         hasChange = true;
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -123,7 +123,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       Integer keyId = fieldId(keyValue.getField("key"));
       Integer valueId = fieldId(keyValue.getField("value"));
       if (keyId == null) {
-        LOG.warn("Map schema %s has value id but not key id", array);
+        LOG.warn("Map schema {} has value id but not key id", array);
         return null;
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -123,7 +123,9 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       Integer keyId = fieldId(keyValue.getField("key"));
       Integer valueId = fieldId(keyValue.getField("value"));
       if (keyId == null) {
-        LOG.warn("Map schema {} has value id but not key id", array);
+        if (valueId != null) {
+          LOG.warn("Map schema {} has value id but not key id", array);
+        }
         return null;
       }
 
@@ -167,7 +169,9 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     Integer keyId = id(map, AvroSchemaUtil.KEY_ID_PROP, "key");
     Integer valueId = id(map, AvroSchemaUtil.VALUE_ID_PROP, "value");
     if (keyId == null) {
-      LOG.warn("Map schema {} has value-id but not key-id", map);
+      if (valueId != null) {
+        LOG.warn("Map schema {} has value-id but not key-id", map);
+      }
       return null;
     }
     // if either key or value is selected, the whole map must be projected

--- a/core/src/test/java/org/apache/iceberg/avro/RemoveIds.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RemoveIds.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+
+class RemoveIds extends AvroSchemaVisitor<Schema> {
+  @Override
+  public Schema record(Schema record, List<String> names, List<Schema> types) {
+    List<Schema.Field> fields = record.getFields();
+    int length = fields.size();
+    List<Schema.Field> newFields = Lists.newArrayListWithExpectedSize(length);
+    for (int i = 0; i < length; i += 1) {
+      newFields.add(copyField(fields.get(i), types.get(i)));
+    }
+    return AvroSchemaUtil.copyRecord(record, newFields, null);
+  }
+
+  @Override
+  public Schema map(Schema map, Schema valueType) {
+    return Schema.createMap(valueType);
+  }
+
+  @Override
+  public Schema array(Schema array, Schema element) {
+    return Schema.createArray(element);
+  }
+
+  @Override
+  public Schema primitive(Schema primitive) {
+    return Schema.create(primitive.getType());
+  }
+
+  @Override
+  public Schema union(Schema union, List<Schema> options) {
+    return Schema.createUnion(options);
+  }
+
+  private static Schema.Field copyField(Schema.Field field, Schema newSchema) {
+    Schema.Field copy = new Schema.Field(field.name(), newSchema, field.doc(), field.defaultVal(), field.order());
+    for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
+      String key = prop.getKey();
+      if (key != AvroSchemaUtil.FIELD_ID_PROP) {
+        copy.addProp(key, prop.getValue());
+      }
+    }
+    return copy;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestAvroNameMapping extends TestAvroReadProjection {
+  @Override
+  protected GenericData.Record writeAndRead(String desc,
+                                            Schema writeSchema,
+                                            Schema readSchema,
+                                            GenericData.Record inputRecord) throws IOException {
+
+    // Use all existing TestAvroReadProjection tests to verify that
+    // we get the same projected (Avro) read schema whether we use
+    // NameMapping together with file schema without field-ids or we
+    // use a file schema having field-ids
+    GenericData.Record record = super.writeAndRead(desc, writeSchema, readSchema, inputRecord);
+    org.apache.avro.Schema expected = record.getSchema();
+    org.apache.avro.Schema actual = projectWithNameMapping(writeSchema, readSchema, MappingUtil.create(writeSchema));
+    Assert.assertEquals(expected, actual);
+    return record;
+  }
+
+  @Test
+  public void testNameMappingProjections() {
+    Schema fileSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StringType.get(),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                Types.NestedField.required(2, "long", Types.FloatType.get())
+            )
+        )));
+
+    // Table mapping does not project `locations` map
+    NameMapping nameMapping = MappingUtil.create(new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get())));
+
+    // Table read schema projects `locations` map's value
+    Schema readSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StringType.get(),
+            Types.StructType.of(
+                Types.NestedField.required(2, "long", Types.FloatType.get())
+            )
+        )));
+
+    check(fileSchema, readSchema, nameMapping);
+  }
+
+  @Test
+  public void testMissingFields() {
+    Schema fileSchema = new Schema(
+        Types.NestedField.required(19, "x", Types.IntegerType.get()),
+        Types.NestedField.optional(18, "y", Types.IntegerType.get()));
+
+    // table mapping not projecting a required field 'x'
+    NameMapping nameMapping = MappingUtil.create(new Schema(
+        Types.NestedField.optional(18, "y", Types.IntegerType.get())));
+
+    Schema readSchema = fileSchema;
+    AssertHelpers.assertThrows("Missing required field in nameMapping",
+        IllegalArgumentException.class, "Missing required field: x",
+        // In this case, pruneColumns result is an empty record
+        () -> projectWithNameMapping(fileSchema, readSchema, nameMapping));
+  }
+
+  @Test
+  public void testComplexMapKeys() {
+    Schema fileSchema = new Schema(
+        Types.NestedField.required(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StructType.of(
+                Types.NestedField.required(3, "k1", Types.StringType.get()),
+                Types.NestedField.optional(4, "k2", Types.StringType.get())
+            ),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                Types.NestedField.optional(2, "long", Types.FloatType.get())
+            )
+        )));
+
+    // project a subset of the map's key and value columns in NameMapping
+    NameMapping nameMapping = MappingUtil.create(new Schema(
+        Types.NestedField.required(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StructType.of(
+                Types.NestedField.required(3, "k1", Types.StringType.get())
+            ),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get())
+            )
+        ))));
+
+    Schema readSchema = new Schema(
+        Types.NestedField.required(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StructType.of(
+                Types.NestedField.required(3, "k1", Types.StringType.get()),
+                Types.NestedField.optional(4, "k2", Types.StringType.get())
+            ),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                Types.NestedField.optional(2, "long", Types.FloatType.get())
+            )
+        )));
+
+    check(fileSchema, readSchema, nameMapping);
+  }
+
+  //TODO: add tests on
+  // 1. aliases in namemapping
+  // 2. arrays
+
+  private static org.apache.avro.Schema project(Schema writeSchema, Schema readSchema) {
+    // Build a read schema when file schema has field ids
+    org.apache.avro.Schema avroFileSchema = AvroSchemaUtil.convert(writeSchema.asStruct(), "table");
+    Set<Integer> projectedIds = TypeUtil.getProjectedIds(readSchema);
+    org.apache.avro.Schema prunedFileSchema = AvroSchemaUtil.pruneColumns(avroFileSchema, projectedIds, null);
+    return AvroSchemaUtil.buildAvroProjection(prunedFileSchema, readSchema, Collections.emptyMap());
+  }
+
+  private static org.apache.avro.Schema projectWithNameMapping(
+      Schema writeSchema, Schema readSchema, NameMapping nameMapping) {
+    // Build a read schema when file schema does not have field ids . The field ids are provided by `nameMapping`
+    org.apache.avro.Schema avroFileSchema = removeIds(writeSchema);
+    Set<Integer> projectedIds = TypeUtil.getProjectedIds(readSchema);
+    org.apache.avro.Schema prunedFileSchema = AvroSchemaUtil.pruneColumns(avroFileSchema, projectedIds, nameMapping);
+    return AvroSchemaUtil.buildAvroProjection(prunedFileSchema, readSchema, Collections.emptyMap());
+  }
+
+  private void check(Schema writeSchema, Schema readSchema, NameMapping nameMapping) {
+    org.apache.avro.Schema expected = project(writeSchema, readSchema);
+    org.apache.avro.Schema actual = projectWithNameMapping(writeSchema, readSchema, nameMapping);
+
+    // projected/read schema built using external mapping should match projected/read schema
+    // built with file schema having field ids
+
+    // `BuildAvroProjection` can skip adding fields ids in some cases.
+    // e.g when creating a map if the value is modified. This leads to test failures
+    // For now I've removed ids to perform equality testing.
+    Assert.assertEquals(removeIds(expected), removeIds(actual));
+    // Projected/read schema built using external mapping will always match expected Iceberg schema
+    Assert.assertEquals(removeIds(actual), removeIds(AvroSchemaUtil.convert(readSchema, "table")));
+  }
+
+  private static org.apache.avro.Schema removeIds(Schema schema) {
+    return AvroSchemaVisitor.visit(AvroSchemaUtil.convert(schema.asStruct(), "table"), new RemoveIds());
+  }
+
+  private static org.apache.avro.Schema removeIds(org.apache.avro.Schema schema) {
+    return AvroSchemaVisitor.visit(schema, new RemoveIds());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -19,11 +19,10 @@
 
 package org.apache.iceberg.avro;
 
+import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
-
-import com.google.common.collect.Lists;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
@@ -170,7 +169,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
     check(writeSchema, readSchema, nameMapping);
 
     // points array is partially projected
-    nameMapping = MappingUtil.create( new Schema(
+    nameMapping = MappingUtil.create(new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
         Types.NestedField.optional(22, "points",
             Types.ListType.ofOptional(21, Types.StructType.of(

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -110,11 +110,12 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
             )
         )));
 
-    // project a subset of the map's key and value columns in NameMapping
+    // project a subset of the map's value columns in NameMapping
     NameMapping nameMapping = MappingUtil.create(new Schema(
         Types.NestedField.required(5, "locations", Types.MapType.ofOptional(6, 7,
             Types.StructType.of(
-                Types.NestedField.required(3, "k1", Types.StringType.get())
+                Types.NestedField.required(3, "k1", Types.StringType.get()),
+                Types.NestedField.optional(4, "k2", Types.StringType.get())
             ),
             Types.StructType.of(
                 Types.NestedField.required(1, "lat", Types.FloatType.get())

--- a/data/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
+++ b/data/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
@@ -166,7 +166,7 @@ public class IcebergDecoder<D> extends MessageDecoder.BaseDecoder<D> {
      * @param writeSchema the schema used to decode buffers
      */
     private RawDecoder(org.apache.iceberg.Schema readSchema, org.apache.avro.Schema writeSchema) {
-      this.reader = new ProjectionDatumReader<>(DataReader::create, readSchema, ImmutableMap.of());
+      this.reader = new ProjectionDatumReader<>(DataReader::create, readSchema, ImmutableMap.of(), null);
       this.reader.setSchema(writeSchema);
     }
 


### PR DESCRIPTION
This includes the latest changes which have been reviewed upstream
I've not implemented a fallback - which can read old Avro data when no table level mapping is specified. Once this is reviewed, I'll add that change