### PR TITLE
Simplify CustomHiveCatalog

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
 public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
-  private final HiveClientPool clients;
-  private final Configuration conf;
+  protected final HiveClientPool clients;
+  protected final Configuration conf;
   private final StackTraceElement[] createStack;
   private boolean closed;
 

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
 public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
-  protected final HiveClientPool clients;
-  protected final Configuration conf;
+  private final HiveClientPool clients;
+  private final Configuration conf;
   private final StackTraceElement[] createStack;
   private boolean closed;
 
@@ -54,6 +54,14 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
     this.conf = conf;
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;
+  }
+
+  protected HiveClientPool clientPool() {
+    return clients;
+  }
+
+  protected Configuration conf() {
+    return conf;
   }
 
   @Override

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -33,7 +33,7 @@ public final class HiveCatalogs {
       .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
       .build();
 
-  private static final Cache<String, CustomHiveCatalog> CUSTOM_CATALOG_CACHE = Caffeine.newBuilder()
+  private static final Cache<String, HiveMetadataPreservingCatalog> HIVE_METADATA_PRESERVING_CATALOG_CACHE = Caffeine.newBuilder()
       .expireAfterAccess(10, TimeUnit.MINUTES)
       .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
       .build();
@@ -46,9 +46,17 @@ public final class HiveCatalogs {
     return CATALOG_CACHE.get(metastoreUri, uri -> new HiveCatalog(conf));
   }
 
+  /**
+   * Use {@link #loadHiveMetadataPreservingCatalog(Configuration)} instead
+   */
+  @Deprecated
   public static HiveCatalog loadCustomCatalog(Configuration conf) {
+    return loadHiveMetadataPreservingCatalog(conf);
+  }
+
+  public static HiveCatalog loadHiveMetadataPreservingCatalog(Configuration conf) {
     // metastore URI can be null in local mode
     String metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
-    return CUSTOM_CATALOG_CACHE.get(metastoreUri, uri -> new CustomHiveCatalog(conf));
+    return HIVE_METADATA_PRESERVING_CATALOG_CACHE.get(metastoreUri, uri -> new HiveMetadataPreservingCatalog(conf));
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -33,10 +33,11 @@ public final class HiveCatalogs {
       .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
       .build();
 
-  private static final Cache<String, HiveMetadataPreservingCatalog> HIVE_METADATA_PRESERVING_CATALOG_CACHE = Caffeine.newBuilder()
-      .expireAfterAccess(10, TimeUnit.MINUTES)
-      .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
-      .build();
+  private static final Cache<String, HiveMetadataPreservingCatalog> HIVE_METADATA_PRESERVING_CATALOG_CACHE =
+      Caffeine.newBuilder()
+          .expireAfterAccess(10, TimeUnit.MINUTES)
+          .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
+          .build();
 
   private HiveCatalogs() {}
 
@@ -47,7 +48,7 @@ public final class HiveCatalogs {
   }
 
   /**
-   * Use {@link #loadHiveMetadataPreservingCatalog(Configuration)} instead
+   * @deprecated Use {@link #loadHiveMetadataPreservingCatalog(Configuration)} instead
    */
   @Deprecated
   public static HiveCatalog loadCustomCatalog(Configuration conf) {

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingCatalog.java
@@ -40,6 +40,6 @@ public class HiveMetadataPreservingCatalog extends HiveCatalog {
   public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    return new HiveMetadataPreservingTableOperations(conf, clients, dbName, tableName);
+    return new HiveMetadataPreservingTableOperations(conf(), clientPool(), dbName, tableName);
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingCatalog.java
@@ -25,25 +25,21 @@ import org.apache.iceberg.catalog.TableIdentifier;
 
 
 /**
- * A {@link HiveCatalog} which uses {@link CustomHiveTableOperations} underneath.
+ * A {@link HiveCatalog} which uses {@link HiveMetadataPreservingTableOperations} underneath.
  *
- * This catalog is especially useful if the Iceberg operations are being performed in response to Hive operations
+ * This catalog should be only be used by metadata publishers wanting to publish/update Iceberg metadata to an existing
+ * Hive table while preserving the current Hive metadata
  */
-public class CustomHiveCatalog extends HiveCatalog {
+public class HiveMetadataPreservingCatalog extends HiveCatalog {
 
-  private final HiveClientPool clients;
-  private final Configuration conf;
-
-  public CustomHiveCatalog(Configuration conf) {
+  public HiveMetadataPreservingCatalog(Configuration conf) {
     super(conf);
-    this.clients = new HiveClientPool(2, conf);
-    this.conf = conf;
   }
 
   @Override
   public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    return new CustomHiveTableOperations(conf, clients, dbName, tableName);
+    return new HiveMetadataPreservingTableOperations(conf, clients, dbName, tableName);
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -210,7 +210,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     }
   }
 
-  private void setParameters(String newMetadataLocation, Table tbl) {
+  void setParameters(String newMetadataLocation, Table tbl) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
@@ -227,7 +227,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     tbl.setParameters(parameters);
   }
 
-  private StorageDescriptor storageDescriptor(TableMetadata metadata) {
+  StorageDescriptor storageDescriptor(TableMetadata metadata) {
 
     final StorageDescriptor storageDescriptor = new StorageDescriptor();
     storageDescriptor.setCols(columns(metadata.schema()));
@@ -246,7 +246,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         .collect(Collectors.toList());
   }
 
-  private long acquireLock() throws UnknownHostException, TException, InterruptedException {
+  long acquireLock() throws UnknownHostException, TException, InterruptedException {
     final LockComponent lockComponent = new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, database);
     lockComponent.setTablename(tableName);
     final LockRequest lockRequest = new LockRequest(Lists.newArrayList(lockComponent),
@@ -285,7 +285,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return lockId;
   }
 
-  private void unlock(Optional<Long> lockId) {
+  void unlock(Optional<Long> lockId) {
     if (lockId.isPresent()) {
       try {
         metaClients.run(client -> {

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetadataPreservingCatalog.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetadataPreservingCatalog.java
@@ -44,7 +44,7 @@ import org.junit.rules.TemporaryFolder;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 
-public class TestCustomHiveCatalog extends HiveMetastoreTest {
+public class TestHiveMetadataPreservingCatalog extends HiveMetastoreTest {
 
   private static final String TABLE_NAME = "tbl";
   private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DB_NAME, TABLE_NAME);
@@ -60,7 +60,7 @@ public class TestCustomHiveCatalog extends HiveMetastoreTest {
 
   @BeforeClass
   public static void setCustomHiveCatalog() {
-    catalog = new CustomHiveCatalog(hiveConf);
+    catalog = new HiveMetadataPreservingCatalog(hiveConf);
   }
 
   @Before


### PR DESCRIPTION
- Rename CustomHiveCatalog to HiveMetadataPreservingCatalog to be more descriptive of the catalog behaviour
- Change access of a few variables in HiveCatalog which are required by the custom catalog to reduce code dup
- Change access of a few methods in HiveTableOperations which are required by the custom table ops to reduce code dup
- Update custom table ops code with changes from upstream
- Make Linkedin-specific changes more explicit by keeping the original lines but commenting them out