### PR TITLE
Row level filtering: Allow table scans to pass a row level filter for ORC files 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -169,7 +169,7 @@ public class BaseFileScanTask implements FileScanTask {
     }
   }
 
-  private static final class SplitScanTask implements FileScanTask {
+  public static final class SplitScanTask implements FileScanTask {
     private final long len;
     private final long offset;
     private final FileScanTask fileScanTask;
@@ -208,6 +208,10 @@ public class BaseFileScanTask implements FileScanTask {
     @Override
     public Iterable<FileScanTask> split(long splitSize) {
       throw new UnsupportedOperationException("Cannot split a task which is already split");
+    }
+
+    public FileScanTask underlyingFileScanTask() {
+      return fileScanTask;
     }
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -89,7 +89,7 @@ public class GenericOrcReader implements OrcValueReader<Record> {
   @Override
   public Record read(VectorizedRowBatch batch, int row) {
     Record rowRecord = GenericRecord.create(schema);
-    for (int c = 0; c < batch.cols.length; ++c) {
+    for (int c = 0; c < converters.length; ++c) {
       rowRecord.set(c, converters[c].convert(batch.cols[c], row));
     }
     return rowRecord;

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestOrcRowLevelFiltering.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestOrcRowLevelFiltering.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data.orc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.DataTestHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.orc.OrcRowFilter;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestOrcRowLevelFiltering {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private static final Schema SCHEMA = new Schema(
+      required(100, "id", Types.LongType.get()),
+      required(101, "data1", Types.StringType.get()),
+      required(102, "data2", Types.StringType.get())
+  );
+
+  private static final List<Record> RECORDS = LongStream.range(0, 100).mapToObj(i -> {
+    Record record = GenericRecord.create(SCHEMA);
+    record.set(0, i);
+    record.set(1, "data1:" + i);
+    record.set(2, "data2:" + i);
+    return record;
+  }).collect(Collectors.toList());
+
+  @Test
+  public void testReadOrcWithRowFilterNoProjection() throws IOException {
+    testReadOrcWithRowFilter(SCHEMA, rowFilterId(), RECORDS.subList(75, 100));
+  }
+
+  @Test
+  public void testReadOrcWithRowFilterProjection() throws IOException {
+    Schema projectedSchema = new Schema(
+        required(101, "data1", Types.StringType.get())
+    );
+
+    List<Record> expected = RECORDS.subList(75, 100).stream().map(r -> {
+      Record record = GenericRecord.create(projectedSchema);
+      record.set(0, r.get(1));
+      return record;
+    }).collect(Collectors.toList());
+
+    testReadOrcWithRowFilter(projectedSchema, rowFilterId(), expected);
+  }
+
+  @Test
+  public void testReadOrcWithRowFilterPartialFilterColumns() throws IOException {
+    Schema projectedSchema = new Schema(
+        required(101, "data1", Types.StringType.get()),
+        required(102, "data2", Types.StringType.get())
+    );
+
+    List<Record> expected = RECORDS.subList(25, 75).stream().map(r -> {
+      Record record = GenericRecord.create(projectedSchema);
+      record.set(0, r.get(1));
+      record.set(1, r.get(2));
+      return record;
+    }).collect(Collectors.toList());
+
+    testReadOrcWithRowFilter(projectedSchema, rowFilterIdAndData1(), expected);
+  }
+
+  @Test
+  public void testReadOrcWithRowFilterNonExistentColumn() throws IOException {
+    testReadOrcWithRowFilter(SCHEMA, rowFilterData3(), ImmutableList.of());
+  }
+
+  private void testReadOrcWithRowFilter(Schema schema, OrcRowFilter rowFilter, List<Record> expected)
+      throws IOException {
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+    try (FileAppender<Record> writer = ORC.write(Files.localOutput(testFile))
+        .schema(SCHEMA)
+        .createWriterFunc(GenericOrcWriter::buildWriter)
+        .build()) {
+      for (Record rec : RECORDS) {
+        writer.add(rec);
+      }
+    }
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader = ORC.read(Files.localInput(testFile))
+        .project(schema)
+        .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+        .rowFilter(rowFilter)
+        .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      DataTestHelpers.assertEquals(schema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+
+  private OrcRowFilter rowFilterId() {
+    return new OrcRowFilter() {
+      @Override
+      public Schema requiredSchema() {
+        return new Schema(
+            required(100, "id", Types.LongType.get())
+        );
+      }
+
+      @Override
+      public boolean shouldKeep(Object[] values) {
+        return (Long) values[0] >= 75;
+      }
+    };
+  }
+
+  private OrcRowFilter rowFilterIdAndData1() {
+    return new OrcRowFilter() {
+      @Override
+      public Schema requiredSchema() {
+        return new Schema(
+            SCHEMA.findField("id"),
+            SCHEMA.findField("data1")
+        );
+      }
+
+      @Override
+      public boolean shouldKeep(Object[] values) {
+        return (Long) values[0] >= 25 && ((String) values[1]).compareTo("data1:75") < 0;
+      }
+    };
+  }
+
+  private OrcRowFilter rowFilterData3() {
+    return new OrcRowFilter() {
+      @Override
+      public Schema requiredSchema() {
+        return new Schema(
+            optional(104, "data3", Types.LongType.get())
+        );
+      }
+
+      @Override
+      public boolean shouldKeep(Object[] values) {
+        return values[0] != null && (Long) values[0] >= 25;
+      }
+    };
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -122,6 +122,7 @@ public class ORC {
     private org.apache.iceberg.Schema schema = null;
     private Long start = null;
     private Long length = null;
+    private OrcRowFilter rowFilter = null;
 
     private Function<TypeDescription, OrcValueReader<?>> readerFunc;
 
@@ -168,9 +169,14 @@ public class ORC {
       return this;
     }
 
+    public ReadBuilder rowFilter(OrcRowFilter newRowFilter) {
+      this.rowFilter = newRowFilter;
+      return this;
+    }
+
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
-      return new OrcIterable<>(file, conf, schema, start, length, readerFunc);
+      return new OrcIterable<>(file, conf, schema, start, length, readerFunc, rowFilter);
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowFilter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.io.Serializable;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Type;
+
+/**
+ * [LINKEDIN ONLY]
+ * Represents a filter which can be applied to every row
+ * <p>
+ * Currently Row filter evaluation is only supported in Spark on unpartitioned tables for top level primitives
+ */
+public interface OrcRowFilter extends Serializable {
+
+  /**
+   * Returns a {@link Schema} which includes all fields required from the table {@link Schema} to evaluate this
+   * filter.
+   */
+  Schema requiredSchema();
+
+  /**
+   * Decides whether the row described by the provided field values should be kept or not.
+   * <p>
+   * The order of field values inside the values array is the same as the order of field ids returned by
+   * {@link #requiredSchema()}. The java class of the field value is dictated by {@link Type.TypeID#javaClass()}.
+   */
+  boolean shouldKeep(Object[] values);
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowFilterableFileScanTask.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowFilterableFileScanTask.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import org.apache.iceberg.FileScanTask;
+
+public interface OrcRowFilterableFileScanTask extends FileScanTask {
+
+  /**
+   * [LINKEDIN ONLY] Returns a row filter to be applied to rows in a file scan
+   */
+  OrcRowFilter orcRowFilter();
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/RowFilterValueReader.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/RowFilterValueReader.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+
+class RowFilterValueReader implements OrcValueReader<Object[]> {
+
+  private final Converter[] converters;
+  private final List<TypeDescription> columns;
+  private final int[] filterSchemaToReadSchemaColumnIndex;
+
+  RowFilterValueReader(TypeDescription readSchema, TypeDescription filterSchema) {
+    columns = filterSchema.getChildren();
+    converters = buildConverters();
+    filterSchemaToReadSchemaColumnIndex = buildFilterSchemaToReadSchemaColumnIndex(readSchema, filterSchema);
+  }
+
+  private int[] buildFilterSchemaToReadSchemaColumnIndex(TypeDescription readSchema, TypeDescription filterSchema) {
+    int[] index = new int[filterSchema.getChildren().size()];
+    List<String> filterFieldNames = filterSchema.getFieldNames();
+    List<String> readSchemaFieldNames = readSchema.getFieldNames();
+    Map<String, Integer> readSchemaFieldNameToIndex = new HashMap<>();
+    for (int i = 0; i < readSchemaFieldNames.size(); i++) {
+      readSchemaFieldNameToIndex.put(readSchemaFieldNames.get(i), i);
+    }
+    for (int i = 0; i < filterFieldNames.size(); i++) {
+      index[i] = readSchemaFieldNameToIndex.get(filterFieldNames.get(i));
+    }
+    return index;
+  }
+
+  @Override
+  public Object[] read(VectorizedRowBatch batch, int row) {
+    Object[] rowFields = new Object[converters.length];
+    for (int c = 0; c < converters.length; ++c) {
+      rowFields[c] = converters[c].convert(batch.cols[filterSchemaToReadSchemaColumnIndex[c]], row);
+    }
+    return rowFields;
+  }
+
+  interface Converter<T> {
+    default T convert(ColumnVector vector, int row) {
+      int rowIndex = vector.isRepeating ? 0 : row;
+      if (!vector.noNulls && vector.isNull[rowIndex]) {
+        return null;
+      } else {
+        return convertNonNullValue(vector, rowIndex);
+      }
+    }
+
+    T convertNonNullValue(ColumnVector vector, int row);
+  }
+
+  private Converter[] buildConverters() {
+    Converter[] newConverters = new Converter[columns.size()];
+    for (int c = 0; c < newConverters.length; ++c) {
+      newConverters[c] = buildConverter(columns.get(c));
+    }
+    return newConverters;
+  }
+
+  private static Converter buildConverter(final TypeDescription schema) {
+    switch (schema.getCategory()) {
+      case INT:
+        return new IntConverter();
+      case LONG:
+        String longAttributeValue = schema.getAttributeValue(ORCSchemaUtil.ICEBERG_LONG_TYPE_ATTRIBUTE);
+        ORCSchemaUtil.LongType longType = longAttributeValue == null ? ORCSchemaUtil.LongType.LONG :
+            ORCSchemaUtil.LongType.valueOf(longAttributeValue);
+        switch (longType) {
+          case LONG:
+            return new LongConverter();
+          default:
+            throw new IllegalStateException("Unhandled Long type found in ORC type attribute: " + longType);
+        }
+      case STRING:
+      case CHAR:
+      case VARCHAR:
+        return new StringConverter();
+      default:
+        throw new IllegalArgumentException("Unhandled type " + schema);
+    }
+  }
+
+  private static class IntConverter implements Converter<Integer> {
+    @Override
+    public Integer convertNonNullValue(ColumnVector vector, int row) {
+      return (int) ((LongColumnVector) vector).vector[row];
+    }
+  }
+
+  private static class LongConverter implements Converter<Long> {
+    @Override
+    public Long convertNonNullValue(ColumnVector vector, int row) {
+      return ((LongColumnVector) vector).vector[row];
+    }
+  }
+
+  private static class StringConverter implements Converter<String> {
+    @Override
+    public String convertNonNullValue(ColumnVector vector, int row) {
+      BytesColumnVector bytesVector = (BytesColumnVector) vector;
+      return new String(bytesVector.vector[row], bytesVector.start[row], bytesVector.length[row],
+          StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -76,7 +76,7 @@ public class SparkOrcReader implements OrcValueReader<InternalRow> {
   public InternalRow read(VectorizedRowBatch batch, int row) {
     rowWriter.reset();
     rowWriter.zeroOutNullBytes();
-    for (int c = 0; c < batch.cols.length; ++c) {
+    for (int c = 0; c < converters.length; ++c) {
       converters[c].convert(rowWriter, c, batch.cols[c], row);
     }
     return rowWriter.getRow();


### PR DESCRIPTION
Usage:
`TableScan`s which need row level filtering will implement `OrcRowFilterableFileScanTask` for the `FileScanTask`s which they return in `planTasks()`. Spark's `RowDataReader` will check if the task it wants to read implements this interface and provides the desired `OrcRowFilter` to ORC file readers.