### PR TITLE
Hive: Fix uppercase bug and determine catalog from table properties

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -58,6 +58,8 @@ public final class Catalogs {
 
   // For use in HiveIcebergSerDe and HiveIcebergStorageHandler
   public static Table loadTable(Configuration conf, Properties props) {
+    Optional.ofNullable(props.getProperty(InputFormatConfig.CATALOG))
+        .ifPresent(x -> conf.set(InputFormatConfig.CATALOG, x));
     return loadTable(conf, props.getProperty(NAME), props.getProperty(LOCATION));
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
@@ -125,7 +125,7 @@ public final class IcebergRecordObjectInspector extends StructObjectInspector {
 
     @Override
     public String getFieldName() {
-      return field.name();
+      return field.name().toLowerCase();
     }
 
     @Override


### PR DESCRIPTION
For more details about the uppercased bug: https://github.com/apache/iceberg/issues/1445

Currently catalog (such as HiveCatalog, HadoopCatalog) are set through session properties. This behavior will continue, but rather if the catalog is set through table property, that will be given a higher priority. 