### PR TITLE
Fix for Hive 1.1 spawned mr job failures

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -27,8 +27,11 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Writable;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 
@@ -38,10 +41,15 @@ public class HiveIcebergSerDe extends AbstractSerDe {
 
   @Override
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties) throws SerDeException {
-    Table table = Catalogs.loadTable(configuration, serDeProperties);
-
+    Schema tableSchema;
+    if (configuration.get(InputFormatConfig.TABLE_SCHEMA) != null) {
+      tableSchema = SchemaParser.fromJson(configuration.get(InputFormatConfig.TABLE_SCHEMA));
+    } else {
+      Table table = Catalogs.loadTable(configuration, serDeProperties);
+      tableSchema = table.schema();
+    }
     try {
-      this.inspector = IcebergObjectInspector.create(table.schema());
+      this.inspector = IcebergObjectInspector.create(tableSchema);
     } catch (Exception e) {
       throw new SerDeException(e);
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -93,7 +93,12 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
+    Properties props = tableDesc.getProperties();
+    Table table = Catalogs.loadTable(conf, props);
 
+    jobConf.set(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(NAME));
+    jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
+    jobConf.set(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
   }
 
   @Override


### PR DESCRIPTION
There are two fixes in this PR:
1) Mappers when initializing SerDe and getting schema, query the schema from metastore, even though it is present as a serialized jobconf. Note that, the call to metastore is still required if jobconf is not set, because serde is also initialized during query compile time, (see the error if the call is removed: https://paste.corp.linkedin.com/show/2631991/)
2) JobConf (with table schema, table identifier) is not correctly set  if the properties are just set with `configureInputJobProperties()`. Which causes getRecordReader to fail on the mapper (see the error: https://paste.corp.linkedin.com/show/2676189/). I also checked that this fix works on the cluster. 