### PR TITLE
Serialize schema in InputSplit and pull upstream changes in #1557, 1564

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -27,8 +27,11 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Writable;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 
@@ -38,10 +41,15 @@ public class HiveIcebergSerDe extends AbstractSerDe {
 
   @Override
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties) throws SerDeException {
-    Table table = Catalogs.loadTable(configuration, serDeProperties);
-
+    Schema tableSchema;
+    if (configuration.get(InputFormatConfig.TABLE_SCHEMA) != null) {
+      tableSchema = SchemaParser.fromJson(configuration.get(InputFormatConfig.TABLE_SCHEMA));
+    } else {
+      Table table = Catalogs.loadTable(configuration, serDeProperties);
+      tableSchema = table.schema();
+    }
     try {
-      this.inspector = IcebergObjectInspector.create(table.schema());
+      this.inspector = IcebergObjectInspector.create(tableSchema);
     } catch (Exception e) {
       throw new SerDeException(e);
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -93,7 +93,12 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
+    Properties props = tableDesc.getProperties();
+    Table table = Catalogs.loadTable(conf, props);
 
+    jobConf.set(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(NAME));
+    jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
+    jobConf.set(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -171,9 +171,10 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
       Configuration conf = newContext.getConfiguration();
       // For now IcebergInputFormat does its own split planning and does not accept FileSplit instances
       CombinedScanTask task = ((IcebergSplit) split).task();
+      String tableSchemaStr = ((IcebergSplit) split).schemaStr();
       this.context = newContext;
       this.tasks = task.files().iterator();
-      this.tableSchema = SchemaParser.fromJson(conf.get(InputFormatConfig.TABLE_SCHEMA));
+      this.tableSchema = SchemaParser.fromJson(tableSchemaStr);
       String readSchemaStr = conf.get(InputFormatConfig.READ_SCHEMA);
       this.expectedSchema = readSchemaStr != null ? SchemaParser.fromJson(readSchemaStr) : tableSchema;
       this.reuseContainers = conf.getBoolean(InputFormatConfig.REUSE_CONTAINERS, false);

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -40,6 +40,7 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
 
   private transient String[] locations;
   private transient Configuration conf;
+  private transient String schemaStr;
 
   // public no-argument constructor for deserialization
   public IcebergSplit() {}
@@ -47,10 +48,15 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
   IcebergSplit(Configuration conf, CombinedScanTask task) {
     this.task = task;
     this.conf = conf;
+    this.schemaStr = conf.get(InputFormatConfig.TABLE_SCHEMA);
   }
 
   public CombinedScanTask task() {
     return task;
+  }
+
+  public String schemaStr() {
+    return schemaStr;
   }
 
   @Override
@@ -78,6 +84,9 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
     byte[] data = SerializationUtil.serializeToBytes(this.task);
     out.writeInt(data.length);
     out.write(data);
+    byte[] schemaStrBytes = SerializationUtil.serializeToBytes(this.schemaStr);
+    out.writeInt(schemaStrBytes.length);
+    out.write(schemaStrBytes);
   }
 
   @Override
@@ -85,5 +94,8 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
     byte[] data = new byte[in.readInt()];
     in.readFully(data);
     this.task = SerializationUtil.deserializeFromBytes(data);
+    byte[] schemaStrBytes = new byte[in.readInt()];
+    in.readFully(schemaStrBytes);
+    this.schemaStr = SerializationUtil.deserializeFromBytes(schemaStrBytes);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.hive.HiveCatalogs;
+import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.rules.TemporaryFolder;
+
+
+public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata extends TestHiveIcebergStorageHandlerWithHiveCatalog {
+
+  private HiveCatalog _hiveCatalog;
+  private TemporaryFolder _temporaryFolder;
+  private final FileFormat _fileFormat = FileFormat.PARQUET;
+
+  @Override
+  public TestTables testTables(Configuration conf, TemporaryFolder temp) {
+    _hiveCatalog = HiveCatalogs.loadCatalog(conf);
+    _temporaryFolder = temp;
+    return super.testTables(conf, temp);
+  }
+
+  @Override
+  protected Table createIcebergTable(String tableName, Schema schema, List<Record> records) throws IOException {
+    // This code is derived from TestTables. There was no easy way to alter table location without changing
+    // bunch of interfaces. With this code the same outcome is achieved.
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default." + tableName);
+    Table table = _hiveCatalog.createTable(
+        tableIdentifier,
+        schema,
+        PartitionSpec.unpartitioned(),
+        getLocationWithoutURI(tableIdentifier),
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, _fileFormat.name()));
+
+    if (!records.isEmpty()) {
+      table
+          .newAppend()
+          .appendFile(TestHelper.writeFile(table, null, records, _fileFormat, _temporaryFolder.newFile()))
+          .commit();
+    }
+    return table;
+  }
+
+  private String getLocationWithoutURI(TableIdentifier tableIdentifier) {
+    try {
+      String location =  DynMethods.builder("defaultWarehouseLocation")
+        .hiddenImpl(HiveCatalog.class, TableIdentifier.class)
+        .build()
+        .invoke(_hiveCatalog, tableIdentifier);
+      return new URI(location).getPath();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
Hive queries that spawn MR jobs will work after this change because:
      1) Table schema in RecordReader is now read from the inputsplit 
      2) HiveSerde on mappers would use input config

Also added a test class which simulates linkedin's way of storing metadata and tests testcases written upstream such as testScanEmptyTable(), testScanTable(), testJoinTables()

cc: @shardulm94 