### PR TITLE
MR: Fix NPE when InputSplit.getLocations is called on mappers

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -65,9 +65,11 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
 
   @Override
   public String[] getLocations() {
-    if (locations == null) {
+    if (locations == null && conf != null) {
       boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
       locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE;
+    } else {
+      locations = ANYWHERE;
     }
 
     return locations;


### PR DESCRIPTION
Same as https://github.com/apache/iceberg/pull/1582 but pulling in early to create a new release