### PR TITLE
Hive: Fix schema not forwarded to SerDe on MR jobs

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergConfigUtil.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergConfigUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.mr.SerializationUtil;
+
+
+class HiveIcebergConfigUtil {
+
+  private static final String NAME = "name";
+  private static final String TABLE_SCHEMA_MAP = "iceberg.mr.table.schema.map";
+
+
+  private HiveIcebergConfigUtil() {
+  }
+
+  /**
+   * Copies schema provided by schemaSupplier into the configuration.
+   *
+   * While copying, the schema is added into a map(tablename -> schema). This map is serialized and set as the
+   * value for the key TABLE_SCHEMA_MAP.
+   */
+  static void copySchemaToConf(Supplier<Schema> schemaSupplier, Configuration configuration, Properties tblProperties) {
+    String tableName = tblProperties.getProperty(NAME);
+    Map<String, String> tableToSchema =
+        Optional.ofNullable(configuration.get(TABLE_SCHEMA_MAP))
+            .map(x -> (HashMap<String, String>) SerializationUtil.deserializeFromBase64(x))
+            .orElse(new HashMap<>());
+    if (!tableToSchema.containsKey(tableName)) {
+      tableToSchema.put(tableName, SchemaParser.toJson(schemaSupplier.get()));
+    }
+    configuration.set(TABLE_SCHEMA_MAP, SerializationUtil.serializeToBase64(tableToSchema));
+  }
+
+  /**
+   * Gets schema from the configuration.
+   *
+   * tblProperties is consulted to get the tablename. This tablename is looked up in the serialized map present in
+   * TABLE_SCHEMA_MAP configuration. The returned json schema is then parsed and returned.
+   */
+  static Optional<Schema> getSchemaFromConf(@Nullable Configuration configuration, Properties tblProperties) {
+    String tableName = tblProperties.getProperty(NAME);
+    return Optional.ofNullable(configuration)
+        .map(c -> c.get(TABLE_SCHEMA_MAP))
+        .map(x -> (HashMap<String, String>) SerializationUtil.deserializeFromBase64(x))
+        .map(map -> map.get(tableName))
+        .map(SchemaParser::fromJson);
+  }
+
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -56,6 +56,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
           Configuration.class, ExprNodeGenericFuncDesc.class)
       .orNoop()
       .buildStatic();
+  static final String SPLIT_LOCATION = "iceberg.hive.split.location";
 
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
@@ -72,7 +73,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
       }
     }
 
-    String location = job.get(InputFormatConfig.TABLE_LOCATION);
+    String location = job.get(SPLIT_LOCATION);
     return Arrays.stream(super.getSplits(job, numSplits))
                  .map(split -> new HiveIcebergSplit((IcebergSplit) split, location))
                  .toArray(InputSplit[]::new);

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -95,7 +95,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-
+    HiveIcebergConfigUtil.copySchemaToConf(
+        () -> Catalogs.loadTable(conf, tableDesc.getProperties()).schema(),
+        jobConf,
+        tableDesc.getProperties()
+    );
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.mr.InputFormatConfig;
 public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, HiveStorageHandler {
 
   private static final String NAME = "name";
+  private static final String LOCATION = "location";
 
   private Configuration conf;
 
@@ -79,6 +80,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     map.put(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(NAME));
     map.put(InputFormatConfig.TABLE_LOCATION, table.location());
     map.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+    map.put(HiveIcebergInputFormat.SPLIT_LOCATION, props.getProperty(LOCATION));
   }
 
   @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.mr.hive;
@@ -33,16 +38,17 @@ import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.rules.TemporaryFolder;
 
-public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata extends TestHiveIcebergStorageHandlerWithHiveCatalog {
+public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata
+    extends TestHiveIcebergStorageHandlerWithHiveCatalog {
 
-  private HiveCatalog _hiveCatalog;
-  private TemporaryFolder _temporaryFolder;
-  private final FileFormat _fileFormat = FileFormat.PARQUET;
+  private HiveCatalog hiveCatalog;
+  private TemporaryFolder temporaryFolder;
+  private final FileFormat fileFormat = FileFormat.PARQUET;
 
   @Override
   public TestTables testTables(Configuration conf, TemporaryFolder temp) {
-    _hiveCatalog = HiveCatalogs.loadCatalog(conf);
-    _temporaryFolder = temp;
+    hiveCatalog = HiveCatalogs.loadCatalog(conf);
+    temporaryFolder = temp;
     return super.testTables(conf, temp);
   }
 
@@ -51,17 +57,17 @@ public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata ext
     // This code is derived from TestTables. There was no easy way to alter table location without changing
     // bunch of interfaces. With this code the same outcome is achieved.
     TableIdentifier tableIdentifier = TableIdentifier.parse("default." + tableName);
-    Table table = _hiveCatalog.createTable(
+    Table table = hiveCatalog.createTable(
         tableIdentifier,
         schema,
         PartitionSpec.unpartitioned(),
         getLocationWithoutURI(tableIdentifier),
-        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, _fileFormat.name()));
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, fileFormat.name()));
 
     if (!records.isEmpty()) {
       table
           .newAppend()
-          .appendFile(TestHelper.writeFile(table, null, records, _fileFormat, _temporaryFolder.newFile()))
+          .appendFile(TestHelper.writeFile(table, null, records, fileFormat, temporaryFolder.newFile()))
           .commit();
     }
     return table;
@@ -72,7 +78,7 @@ public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata ext
       String location =  DynMethods.builder("defaultWarehouseLocation")
           .hiddenImpl(HiveCatalog.class, TableIdentifier.class)
           .build()
-          .invoke(_hiveCatalog, tableIdentifier);
+          .invoke(hiveCatalog, tableIdentifier);
       return new URI(location).getPath();
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.hive.HiveCatalogs;
+import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.rules.TemporaryFolder;
+
+public class TestHiveIcebergStorageHandlerWithHiveCatalogAndLinkedinMetadata extends TestHiveIcebergStorageHandlerWithHiveCatalog {
+
+  private HiveCatalog _hiveCatalog;
+  private TemporaryFolder _temporaryFolder;
+  private final FileFormat _fileFormat = FileFormat.PARQUET;
+
+  @Override
+  public TestTables testTables(Configuration conf, TemporaryFolder temp) {
+    _hiveCatalog = HiveCatalogs.loadCatalog(conf);
+    _temporaryFolder = temp;
+    return super.testTables(conf, temp);
+  }
+
+  @Override
+  protected Table createIcebergTable(String tableName, Schema schema, List<Record> records) throws IOException {
+    // This code is derived from TestTables. There was no easy way to alter table location without changing
+    // bunch of interfaces. With this code the same outcome is achieved.
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default." + tableName);
+    Table table = _hiveCatalog.createTable(
+        tableIdentifier,
+        schema,
+        PartitionSpec.unpartitioned(),
+        getLocationWithoutURI(tableIdentifier),
+        ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, _fileFormat.name()));
+
+    if (!records.isEmpty()) {
+      table
+          .newAppend()
+          .appendFile(TestHelper.writeFile(table, null, records, _fileFormat, _temporaryFolder.newFile()))
+          .commit();
+    }
+    return table;
+  }
+
+  private String getLocationWithoutURI(TableIdentifier tableIdentifier) {
+    try {
+      String location =  DynMethods.builder("defaultWarehouseLocation")
+          .hiddenImpl(HiveCatalog.class, TableIdentifier.class)
+          .build()
+          .invoke(_hiveCatalog, tableIdentifier);
+      return new URI(location).getPath();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
Hive queries that spawn MR jobs fail with linkedin hive, the reason being, `HiveIcebergSerDe` doesn't get access to serialized schema.

This failure is caused because LinkedIn hive deep copies conf objects before calling `HiveIcebergStorageHandler::configureInputJobProperties`. Because of this, even though `IcebergInputFormat::IcebergRecordReader` gets access to the serialized schema, `HiveIcebergSerDe::initialize` doesn't (as serialized schema is set on the copy and not the original conf). The linkedin specific code in Hive can be found here: https://rb.corp.linkedin.com/r/895799/

This PR introduces a fix to workaround this issue by propagating the schema to `HiveIcebergSerDe::initialize` through another route, i.e.  `HiveIcebergStorageHandler::configureJobConf`. `configureJobConf()` is called for altering config just before handing them over to mappers. And `configureJobConf()` gets called for each table being read...
..Hence in this patch a map is kept between "tablename -> schema" as one of the JobConf property ("iceberg.mr.table.schema.map"). While initializing SerDe for a particular table, this map from config is looked up and schema is fetched.

With this change SerDe is properly initialized on Mappers.

--------------------------------------------------------------------
I tried to use same map(tablename -> schema) for instantiating `IcebergInputFormat::IcebergRecordReader` but this is not always possible.`configureJobConf()` is not called if Hive can run the query entirely on client side, (for ex: simple "select * from" queries). Because of this we could not entirely get rid of the property TABLE_SCHEMA being set in `HiveIcebergStorageHandler::configureInputJobProperties`

---------------------------------------------------------------------

Also brings in location change that @shardulm94 proposed here: https://github.com/linkedin/iceberg/pull/43