### PR TITLE
Shading: Fix iceberg-runtime dependency after iceberg-hive was renamed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -765,7 +765,7 @@ project(':iceberg-runtime') {
   dependencies {
     compile project(':iceberg-core')
     compile project(':iceberg-orc')
-    compile project(':iceberg-hive')
+    compile project(':iceberg-hive-metastore')
   }
 
   shadowJar {

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,7 +34,6 @@ include 'spark3'
 include 'spark3-runtime'
 include 'pig'
 include 'runtime'
-include 'hive'
 include 'hive-metastore'
 
 project(':api').name = 'iceberg-api'
@@ -53,7 +52,6 @@ project(':spark3').name = 'iceberg-spark3'
 project(':spark3-runtime').name = 'iceberg-spark3-runtime'
 project(':pig').name = 'iceberg-pig'
 project(':runtime').name = 'iceberg-runtime'
-project(':hive').name = 'iceberg-hive'
 project(':hive-metastore').name = 'iceberg-hive-metastore'
 
 if (JavaVersion.current() == JavaVersion.VERSION_1_8) {


### PR DESCRIPTION
`iceberg-hive` was renamed upstream to `iceberg-hive-metastore` however our internal `iceberg-runtime` module was not updated to use the renamed module 