### PR TITLE
Hive Table Operations: Do not throw an exception on dangling partitions; log warning message

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/FileSystemUtils.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/FileSystemUtils.java
@@ -50,6 +50,16 @@ class FileSystemUtils {
     return Arrays.asList(files);
   }
 
+  static boolean exists(String file, Configuration conf) {
+    final Path filePath = new Path(file);
+    try {
+      FileSystem fs = filePath.getFileSystem(conf);
+      return fs.exists(filePath);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Error determining if file or directory exists: " + file);
+    }
+  }
+
   private enum HiddenPathFilter implements PathFilter {
     INSTANCE;
 


### PR DESCRIPTION
Prior to this patch, during planning of Hive tables, if partition points to a non-existent file location, the table scan throws an exception. This patch returns an empty list of files instead.

Added unit test.