### PR TITLE
Fix pushdown of non-partition predicates within NOT

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveExpressions.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveExpressions.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.UnboundTerm;
 class HiveExpressions {
 
   private static final Expression REMOVED = (Expression) () -> null;
+
   private HiveExpressions() {}
 
   /**
@@ -50,7 +51,8 @@ class HiveExpressions {
   static Expression simplifyPartitionFilter(Expression expr, Set<String> partitionColumnNames) {
     try {
       // Pushing down NOTs is critical for the correctness of RemoveNonPartitionPredicates
-      // Without pushdown NOT(P and NP) will be written to NOT(P)
+      // e.g. consider a predicate on a partition field (P) and a predicate on a non-partition field (NP)
+      // With simply ignoring NP, NOT(P and NP) will be written to NOT(P)
       // However the correct behaviour is NOT(P and NP) => NOT(P) OR NOT(NP) => True
       Expression notPushedDown = Expressions.rewriteNot(expr);
       Expression partitionPredicatesOnly = ExpressionVisitors.visit(notPushedDown,

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
@@ -106,6 +106,20 @@ public class TestHiveExpressions {
   }
 
   @Test
+  public void testSimplifyRemoveNonPartitionColumnsWithinNot1() {
+    Expression input = and(not(equal("nonpcol", "1")), equal("pcol", "1"));
+    Expression expected = equal("pcol", "1");
+    Assert.assertEquals(expected.toString(), simplifyPartitionFilter(input, ImmutableSet.of("pcol")).toString());
+  }
+
+  @Test
+  public void testSimplifyRemoveNonPartitionColumnsWithinNot2() {
+    Expression input = not(and(equal("nonpcol", "1"), equal("pcol", "1")));
+    Expression expected = alwaysTrue();
+    Assert.assertEquals(expected.toString(), simplifyPartitionFilter(input, ImmutableSet.of("pcol")).toString());
+  }
+
+  @Test
   public void testToPartitionFilterStringEscapeStringLiterals() {
     Expression input = equal("pcol", "s'1");
     Assert.assertEquals("( pcol = 's\\'1' )", toPartitionFilterString(input));


### PR DESCRIPTION
`partitionCol = 1 AND NOT(nonpartitionCol = 2)` was getting simplified to `partitionCol = 1 AND NOT(TRUE)` and consequently `FALSE` when removing partition predicates.
Now the flow looks like `partitionCol = 1 AND NOT(nonpartitionCol = 2)` => `partitionCol = 1 AND nonpartitionCol != 2)` => `partitionCol = 1 AND REMOVED` => `partitionCol = 1`

Other expressions like  `NOT(partitionCol = 1 AND nonpartitionCol = 2)` will now translate to `NOT(partitionCol = 1) OR NOT(nonpartitionCol = 2)` => `partitionCol != 1 AND nonpartitionCol != 2` => `partitionCol != 1 AND REMOVED` => `partitionCol != 1`