### PR TITLE
ORC: Support NameMapping with row-level filtering

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -255,11 +255,6 @@ public final class ORCSchemaUtil {
   public static TypeDescription buildOrcProjection(Schema schema,
                                                    TypeDescription originalOrcSchema) {
     Map<Integer, OrcField> icebergToOrc = icebergToOrcMapping("root", originalOrcSchema);
-    if (icebergToOrc.isEmpty()) {
-      // if no field ids are present in original schema then build mapping from expected schema
-      // this should ideally be handled at a higher layer with NameMapping
-      icebergToOrc = icebergToOrcMapping("root", convert(schema));
-    }
     return buildOrcProjection(Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc);
   }
 


### PR DESCRIPTION
- Add support for `NameMapping` in scan's using row level filters
- Remove an old workaround in ORC needed before upstream had implemented `NameMapping` support