### PR TITLE
fix hive primitive typeinfo to avro logical type conversion.

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
@@ -23,10 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Map;
-
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
 import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;


### PR DESCRIPTION
fix hive primitive to avro logical type conversion, making sure the merged avro schema can be converted to iceberg schema correctly by AvroSchemaUtil.convert(Schema schema) .

This is the root cause of the type promotion (date/timestamp -> int/long) error we've seen so far.