### PR TITLE
Fix empty struct type in selectNot call

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
@@ -34,6 +34,11 @@ class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
 
   @Override
   public Set<Integer> struct(Types.StructType struct, List<Set<Integer>> fieldResults) {
+    // if the struct is an empty struct, we should consider itself as 'internal', thus including its id.
+    if (struct.fields().size() == 0) {
+      // since returning null is signaling the call to field() to add the field ID.
+      return null;
+    }
     return fieldIds;
   }
 

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -21,9 +21,13 @@
 package org.apache.iceberg.types;
 
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 
@@ -54,6 +58,27 @@ public class TestTypeUtil {
         );
 
     TypeUtil.indexByName(Types.StructType.of(nestedType));
+  }
+
+  @Test
+  public void testSelectNot(){
+    // iceberg schema which has an empty struct column.
+    Schema schema = new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            optional(2, "b", Types.StructType.of(
+                    required(3, "c", Types.StringType.get()),
+                    optional(4, "d", Types.StructType.of(Collections.emptyList()))))
+    );
+    Schema filteredSchema = TypeUtil.selectNot(schema, ImmutableSet.of());
+    Assert.assertEquals(schema.toString(), filteredSchema.toString());
+
+    filteredSchema = TypeUtil.selectNot(schema, ImmutableSet.of(4));
+    Schema expected = new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            optional(2, "b", Types.StructType.of(
+                    required(3, "c", Types.StringType.get())))
+    );
+    Assert.assertEquals(expected.toString(), filteredSchema.toString());
   }
 }
 


### PR DESCRIPTION
Tested the table with the empty struct schema using spark-shell, the table could now be read without exception.