### PR TITLE
Fix support for Hive timestamp type

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/MergeHiveSchemaWithAvro.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/MergeHiveSchemaWithAvro.java
@@ -236,7 +236,9 @@ class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema, Schem
         return LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
 
       case TIMESTAMP:
-        return LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+        Schema schema = Schema.create(Schema.Type.LONG);
+        schema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+        return LogicalTypes.timestampMillis().addToSchema(schema);
 
       case DECIMAL:
         DecimalTypeInfo dti = (DecimalTypeInfo) primitive;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
@@ -288,8 +288,8 @@ public class TestMergeHiveSchemaWithAvro {
     assertSchema(expected, merged);
     Assert.assertEquals("date",
             AvroSchemaUtil.fromOption(merged.getField("fa").schema()).getLogicalType().getName());
+    // This last line should not throw any exception.
     org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(merged);
-    System.out.println(iSchema);
   }
 
   // TODO: tests to retain schema props

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
@@ -289,7 +289,7 @@ public class TestMergeHiveSchemaWithAvro {
     Assert.assertEquals("date",
             AvroSchemaUtil.fromOption(merged.getField("fa").schema()).getLogicalType().getName());
     // This last line should not throw any exception.
-    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(merged);
+    AvroSchemaUtil.toIceberg(merged);
   }
 
   // TODO: tests to retain schema props

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestMergeHiveSchemaWithAvro.java
@@ -278,14 +278,18 @@ public class TestMergeHiveSchemaWithAvro {
             optional("fc", Schema.Type.BYTES));
     Schema merged = merge(hive, avro);
 
+    Schema expectedTimestampSchema = Schema.create(Schema.Type.LONG);
+    expectedTimestampSchema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     Schema expected = struct("r1",
             optional("fa", LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT))),
-            optional("fb", LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG))),
+            optional("fb", LogicalTypes.timestampMillis().addToSchema(expectedTimestampSchema)),
             optional("fc", LogicalTypes.decimal(4, 2).addToSchema(Schema.create(Schema.Type.BYTES))));
 
     assertSchema(expected, merged);
     Assert.assertEquals("date",
             AvroSchemaUtil.fromOption(merged.getField("fa").schema()).getLogicalType().getName());
+    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(merged);
+    System.out.println(iSchema);
   }
 
   // TODO: tests to retain schema props


### PR DESCRIPTION
This PR fix support for hive timestamp type to be correctly converted to timestamp (Timestamp without timezone) type in iceberg, this will make PR #60 able to read Hive tables with timestamp type.