### PR TITLE
Stop using serdeToFileFormat to unblock formats other than Avro or Orc

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/LegacyHiveTableUtils.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/LegacyHiveTableUtils.java
@@ -61,7 +61,8 @@ class LegacyHiveTableUtils {
     if (avroSchema != null) {
       String serde = table.getSd().getSerdeInfo().getSerializationLib();
       org.apache.avro.Schema finalAvroSchema;
-      if (serde.equals("org.apache.hadoop.hive.serde2.avro.AvroSerDe") || HasDuplicateLowercaseColumnNames.visit(avroSchema)) {
+      if (serde.equals("org.apache.hadoop.hive.serde2.avro.AvroSerDe") ||
+          HasDuplicateLowercaseColumnNames.visit(avroSchema)) {
         // Case 1: If serde == AVRO, early escape; Hive column info is not reliable and can be empty for these tables
         //         Hive itself uses avro.schema.literal as source of truth for these tables, so this should be fine
         // Case 2: If avro.schema.literal has duplicate column names when lowercased, that means we cannot do reliable

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/LegacyHiveTableUtils.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/LegacyHiveTableUtils.java
@@ -59,9 +59,9 @@ class LegacyHiveTableUtils {
     org.apache.avro.Schema avroSchema = schemaStr != null ? new org.apache.avro.Schema.Parser().parse(schemaStr) : null;
     Schema schema;
     if (avroSchema != null) {
-      FileFormat format = serdeToFileFormat(table.getSd().getSerdeInfo().getSerializationLib());
+      String serde = table.getSd().getSerdeInfo().getSerializationLib();
       org.apache.avro.Schema finalAvroSchema;
-      if (format.equals(FileFormat.AVRO) || HasDuplicateLowercaseColumnNames.visit(avroSchema)) {
+      if (serde.equals("org.apache.hadoop.hive.serde2.avro.AvroSerDe") || HasDuplicateLowercaseColumnNames.visit(avroSchema)) {
         // Case 1: If serde == AVRO, early escape; Hive column info is not reliable and can be empty for these tables
         //         Hive itself uses avro.schema.literal as source of truth for these tables, so this should be fine
         // Case 2: If avro.schema.literal has duplicate column names when lowercased, that means we cannot do reliable


### PR DESCRIPTION
At LinkedIn, we have internally custom format that is non Avro nor Orc, but the previous code used function `serdeToFileFormat` which when called will block non Avro or Orc format being read. This is a simple fix to unblock.