### PR TITLE
Change error handling to not delete data from HDFS when hive metaStore has been updated

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveMetadataPreservingTableOperations.java
@@ -215,11 +215,30 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       throw new RuntimeException("Interrupted during commit", e);
 
     } finally {
-      if (threw) {
-        // if anything went wrong, clean up the uncommitted metadata file
+      if (threw && !metadataUpdatedSuccessfully(newMetadataLocation)) {
+        // if anything went wrong and meta store hasn't been updated, clean up the uncommitted metadata file
         io().deleteFile(newMetadataLocation);
       }
       unlock(lockId);
     }
+  }
+
+  private boolean metadataUpdatedSuccessfully(String newMetadataLocation) {
+    boolean metadataUpdatedSuccessfully = false;
+    try {
+      Table tbl;
+      boolean tableExists = metaClients.run(client -> client.tableExists(database, tableName));
+      if (tableExists) {
+        tbl = metaClients.run(client -> client.getTable(database, tableName));
+        if (tbl.getParameters().get(METADATA_LOCATION_PROP).equals(newMetadataLocation)) {
+          metadataUpdatedSuccessfully = true;
+        }
+      }
+    } catch (Exception e) {
+      // This indicate the client might be closed and we cannout make sure whether the table has been updated, so
+      //assume it succeeds to avoid table pointing to non-exist location
+      metadataUpdatedSuccessfully = true;
+    }
+    return metadataUpdatedSuccessfully;
   }
 }


### PR DESCRIPTION
Issue: we encounter the issue that when shutdown happens during commit process, it leaves table in a dirty state (int the following commit/query, it ends up with table pointing to a non exist location). 
Solution: Change the error handling logic, when meet issue, will first check whether metadata store has been updated then decide whether to clean metadata file. If client closed or meta store unavailable, then not delete metadata file to avoid this situation and rely on the  process of "[Remove orphan files](https://iceberg.apache.org/maintenance/)" to remove untracked metadata file