### PR TITLE
[#2039] Support default value semantics: Schema Mapping changes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.avro;
 
 import java.util.List;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -92,8 +93,13 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       Type fieldType = fieldTypes.get(i);
       int fieldId = getId(field);
 
+      Object defaultValue = field.hasDefaultValue() && !(field.defaultVal() instanceof JsonProperties.Null) ?
+          field.defaultVal() : null;
+
       if (AvroSchemaUtil.isOptionSchema(field.schema())) {
-        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType));
+        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, defaultValue, null));
+      } else if (defaultValue != null) {
+        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, defaultValue, null));
       } else {
         newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType));
       }

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -101,9 +101,9 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       String origFieldName = structField.name();
       boolean isValidFieldName = AvroSchemaUtil.validAvroName(origFieldName);
       String fieldName =  isValidFieldName ? origFieldName : AvroSchemaUtil.sanitize(origFieldName);
-      Schema.Field field = new Schema.Field(
-          fieldName, fieldSchemas.get(i), null,
-          structField.isOptional() ? JsonProperties.NULL_VALUE : null);
+      Object defaultValue = structField.hasDefaultValue() ? structField.getDefaultValue() :
+          (structField.isOptional() ? JsonProperties.NULL_VALUE : null);
+      Schema.Field field = new Schema.Field(fieldName, fieldSchemas.get(i), null, defaultValue);
       if (!isValidFieldName) {
         field.addProp(AvroSchemaUtil.ICEBERG_FIELD_NAME_PROP, origFieldName);
       }

--- a/core/src/test/java/org/apache/iceberg/avro/TestDefaultValuePreserving.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestDefaultValuePreserving.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.avro.Schema.Type.INT;
+
+
+/**
+ * Testing the preserving of fields; default values in {@link SchemaToType} and {@link TypeToSchema}
+ */
+public class TestDefaultValuePreserving {
+
+  String noDefaultFiledName = "fieldWithNoDefaultValue";
+  String fieldWithDefaultName = "fieldWithDefaultValue";
+  Integer defaultValue = -1;
+
+  @Test
+  public void testSchemaToTypeRecord() {
+    Schema recordSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, defaultValue)));
+    SchemaToType schemaToType = new SchemaToType(recordSchema);
+    List<String> names = recordSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
+    List<Type> types = ImmutableList.of(Types.IntegerType.get(), Types.IntegerType.get());
+
+    Type record = schemaToType.record(recordSchema, names, types);
+
+    Assert.assertNotNull(record);
+    Assert.assertTrue(record.isStructType());
+    Assert.assertEquals(names.size(), record.asStructType().fields().size());
+    Assert.assertFalse(record.asStructType().field(noDefaultFiledName).hasDefaultValue());
+    Assert.assertTrue(record.asStructType().field(fieldWithDefaultName).hasDefaultValue());
+    Assert.assertEquals(defaultValue, record.asStructType().field(fieldWithDefaultName).getDefaultValue());
+  }
+
+  @Test
+  public void testTypeToSchemaStruct() {
+    List<Types.NestedField> nestedFields = ImmutableList.of(
+        Types.NestedField.required(0, noDefaultFiledName, Types.IntegerType.get()),
+        Types.NestedField.required(1, fieldWithDefaultName, Types.IntegerType.get(), defaultValue, null));
+    Types.StructType structType = Types.StructType.of(nestedFields);
+    Map<Types.StructType, String> names = ImmutableMap.of(structType, "tableName");
+    TypeToSchema typeToSchema = new TypeToSchema(names);
+    List<Schema> fieldSchemas = ImmutableList.of(Schema.create(INT), Schema.create(INT));
+
+    Schema structSchema = typeToSchema.struct(structType, fieldSchemas);
+
+    Assert.assertNotNull(structSchema);
+    Assert.assertEquals(nestedFields.size(), structSchema.getFields().size());
+    for (int i = 0; i < nestedFields.size(); i++) {
+      if (nestedFields.get(i).hasDefaultValue()) {
+        Assert.assertTrue(structSchema.getFields().get(i).hasDefaultValue());
+        Assert.assertEquals(nestedFields.get(i).getDefaultValue(), structSchema.getFields().get(i).defaultVal());
+      } else {
+        Assert.assertFalse(structSchema.getFields().get(i).hasDefaultValue());
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the 2nd PR out of 3 to support default values for AVRO. In this change, the mappings between Iceberg schema and Avro schema preserves the defaultValue of the fields. Tested via unit tests, and a prototype

In next PR, we will check the default values while building projection/read schema, and make sure this default value is used when the field is not materialized.

@wmoustafa @shardulm94 @funcheetah @HotSushi 