### PR TITLE
[#2039] Support Default Value Semantis: use default values reading AVRO files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -52,11 +52,11 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
       } else if (projectedType != null) {
         sameTypes = false; // signal that some types were altered
         if (field.isOptional()) {
-          selectedFields.add(
-              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
+          selectedFields.add(Types.NestedField.optional(
+              field.fieldId(), field.name(), projectedType, field.getDefaultValue(), field.doc()));
         } else {
-          selectedFields.add(
-              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
+          selectedFields.add(Types.NestedField.required(
+              field.fieldId(), field.name(), projectedType, field.getDefaultValue(), field.doc()));
         }
       }
     }

--- a/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
@@ -21,7 +21,9 @@ package org.apache.iceberg.types;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,9 +46,9 @@ public class TestDefaultValuesForContainerTypes {
 
   @Test
   public void testStructTypeDefault() {
-    List<Object> structDefaultvalue = new ArrayList<>();
-    structDefaultvalue.add(Integer.valueOf(1));
-    structDefaultvalue.add("two");
+    Map<String, Object> structDefaultvalue = new HashMap<>();
+    structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
+    structDefaultvalue.put(stringFieldType.name(), "two");
     NestedField structField = NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
     Assert.assertTrue(structField.hasDefaultValue());
     Assert.assertEquals(structDefaultvalue, structField.getDefaultValue());

--- a/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
@@ -50,6 +50,7 @@ public class TestNestedFieldDefaultValues {
     // required constructors
     Assert.assertFalse(required(id, fieldName, fieldType).hasDefaultValue());
     Assert.assertFalse(required(id, fieldName, fieldType, doc).hasDefaultValue());
+    Assert.assertFalse(required(id, fieldName, fieldType, null, doc).hasDefaultValue());
     nestedFieldWithDefault = required(id, fieldName, fieldType, defaultValue, doc);
     Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
     Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
@@ -65,22 +66,17 @@ public class TestNestedFieldDefaultValues {
     Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
   }
 
-  @Test (expected =  IllegalArgumentException.class)
-  public void testRequiredNullDefault() {
-    // illegal case (required with null defaultValue)
-    required(id, fieldName, fieldType, null, doc);
-  }
-
-  @Test (expected = IllegalArgumentException.class)
-  public void testRequiredWithDefaultNullDefault() {
-    // illegal case (required with null defaultValue)
-    required(id, fieldName, fieldType, null, null);
-  }
-
   @Test (expected = IllegalArgumentException.class)
   public void testOptionalWithInvalidDefaultValueClass() {
     // class of default value does not match class of type
     Long wrongClassDefaultValue = 100L;
     optional(id, fieldName, fieldType, wrongClassDefaultValue, doc);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testReqiredWithInvalidDefaultValueClass() {
+    // class of default value does not match class of type
+    Long wrongClassDefaultValue = 100L;
+    required(id, fieldName, fieldType, wrongClassDefaultValue, doc);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -19,20 +19,31 @@
 
 package org.apache.iceberg;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
+
 
 public class SchemaParser {
 
@@ -55,6 +66,26 @@ public class SchemaParser {
   private static final String REQUIRED = "required";
   private static final String ELEMENT_REQUIRED = "element-required";
   private static final String VALUE_REQUIRED = "value-required";
+  private static final String DEFAULT = "default";
+
+  private static final List<Class> primitiveClasses = Arrays.asList(Boolean.class, Integer.class, Long.class,
+      Float.class, Double.class, CharSequence.class, String.class, java.util.UUID.class, BigDecimal.class);
+
+  private static void writeDefaultValue(Object defaultValue, Type type, JsonGenerator generator) throws IOException {
+    if (defaultValue == null) {
+      return;
+    }
+    generator.writeFieldName(DEFAULT);
+    if (type.isListType()) {
+      generator.writeString(defaultValueToJsonString((List<Object>) defaultValue));
+    } else if (type.isStructType() || type.isMapType()) {
+      generator.writeString(defaultValueToJsonString((Map<String, Object>) defaultValue));
+    } else if (isFixedOrBinary(type)) {
+      generator.writeString(defaultValueToJsonString((byte[]) defaultValue));
+    } else {
+      generator.writeString(defaultValueToJsonString(defaultValue));
+    }
+  }
 
   static void toJson(Types.StructType struct, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
@@ -68,13 +99,14 @@ public class SchemaParser {
       generator.writeBooleanField(REQUIRED, field.isRequired());
       generator.writeFieldName(TYPE);
       toJson(field.type(), generator);
+      writeDefaultValue(field.getDefaultValue(), field.type(), generator);
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
       }
+
       generator.writeEndObject();
     }
     generator.writeEndArray();
-
     generator.writeEndObject();
   }
 
@@ -87,7 +119,6 @@ public class SchemaParser {
     generator.writeFieldName(ELEMENT);
     toJson(list.elementType(), generator);
     generator.writeBooleanField(ELEMENT_REQUIRED, !list.isElementOptional());
-
     generator.writeEndObject();
   }
 
@@ -175,6 +206,32 @@ public class SchemaParser {
     throw new IllegalArgumentException("Cannot parse type from json: " + json);
   }
 
+  private static boolean isFixedOrBinary(Type type) {
+    return type.typeId() == Type.TypeID.FIXED || type.typeId() == Type.TypeID.BINARY;
+  }
+
+  private static Object defaultValueFromJson(JsonNode field, Type type) {
+    if (!field.has(DEFAULT)) {
+      return null;
+    }
+
+    String defaultValueString = field.get(DEFAULT).asText();
+
+    if (isFixedOrBinary(type)) {
+      return defaultValueFromJsonBytesField(defaultValueString);
+    }
+
+    if (type.isPrimitiveType()) {
+      return primitiveDefaultValueFromJsonString(defaultValueString, type);
+    }
+
+    try {
+      return defaultValueFromJsonString(defaultValueString, type);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private static Types.StructType structFromJson(JsonNode json) {
     JsonNode fieldArray = json.get(FIELDS);
     Preconditions.checkArgument(fieldArray.isArray(),
@@ -190,13 +247,13 @@ public class SchemaParser {
       int id = JsonUtil.getInt(ID, field);
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(field.get(TYPE));
-
+      Object defaultValue = defaultValueFromJson(field, type);
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
       if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type, doc));
+        fields.add(Types.NestedField.required(id, name, type, defaultValue, doc));
       } else {
-        fields.add(Types.NestedField.optional(id, name, type, doc));
+        fields.add(Types.NestedField.optional(id, name, type, defaultValue, doc));
       }
     }
 
@@ -251,5 +308,135 @@ public class SchemaParser {
         throw new RuntimeIOException(e);
       }
     });
+  }
+
+  private static String defaultValueToJsonString(Map<String, Object> map) {
+    Map<String, String> jsonStringElementsMap = new LinkedHashMap<>();
+    map.entrySet().forEach(
+        entry -> jsonStringElementsMap.put(entry.getKey(), defaultValueToJsonString(entry.getValue())));
+    return defaultValueToJsonString(jsonStringElementsMap);
+  }
+
+  private static String defaultValueToJsonString(List<Object> list) {
+    List<String> jsonStringItemsList = new ArrayList<>();
+    list.forEach(item -> jsonStringItemsList.add(defaultValueToJsonString(item)));
+    return defaultValueToJsonString(jsonStringItemsList);
+  }
+
+  private static String defaultValueToJsonString(byte[] bytes) {
+    try {
+      return JsonUtil.mapper().writeValueAsString(ByteBuffer.wrap(bytes));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String defaultValueToJsonString(Object value) {
+    if (isPrimitiveClass(value)) {
+      return value.toString();
+    }
+
+    try {
+      return JsonUtil.mapper().writeValueAsString(new SerDeValue(value));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static boolean isPrimitiveClass(Object value) {
+    return primitiveClasses.contains(value.getClass());
+  }
+
+  private static Object defaultValueFromJsonBytesField(String value) {
+    try {
+      return JsonUtil.mapper().readValue(value, ByteBuffer.class).array();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Object defaultValueFromJsonString(String jsonString, Type type) throws IOException {
+    Preconditions.checkArgument(!type.isPrimitiveType(), "jsonString %s is for primitive type %s", jsonString, type);
+    Object jsonStringCollection = JsonUtil.mapper().readValue(jsonString, SerDeValue.class).getValue();
+
+    if (type.isListType()) {
+      Preconditions.checkArgument(jsonStringCollection instanceof List,
+          "deserialized Json object: (%s) is not List for List type", jsonStringCollection);
+      List<Object> list = new ArrayList<>();
+      Type elementType = type.asListType().elementType();
+      for (String item : (List<String>) jsonStringCollection) {
+        list.add(elementType.isPrimitiveType() ? primitiveDefaultValueFromJsonString(item, elementType) :
+            JsonUtil.mapper().readValue(item, SerDeValue.class).getValue());
+      }
+      return list;
+    }
+
+    Preconditions.checkArgument((type.isMapType() || type.isStructType()) && jsonStringCollection instanceof Map,
+        "deserialized Json object: (%s) is not Map for type: %s", jsonStringCollection, type);
+
+    // map (MapType or StructType) case
+    Map<String, Object> map = new HashMap<>();
+    Map<String, String> jsonStringMap = (HashMap<String, String>) jsonStringCollection;
+    for (Map.Entry entry : jsonStringMap.entrySet()) {
+      String key = entry.getKey().toString();
+      String valueString = entry.getValue().toString();
+      Type elementType = type.isMapType() ? type.asMapType().valueType() : type.asStructType().field(key).type();
+      Object value = elementType.isPrimitiveType() ? primitiveDefaultValueFromJsonString(valueString, elementType)
+            : JsonUtil.mapper().readValue(valueString, SerDeValue.class).getValue();
+      map.put(key, value);
+    }
+    return map;
+  }
+
+  private static Object primitiveDefaultValueFromJsonString(String jsonString, Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return Boolean.valueOf(jsonString);
+      case INTEGER:
+      case DATE:
+        return Integer.valueOf(jsonString);
+      case DECIMAL:
+        return BigDecimal.valueOf(Long.valueOf(jsonString));
+      case LONG:
+      case TIME:
+      case TIMESTAMP:
+        return Long.valueOf(jsonString);
+      case FLOAT:
+        return Float.valueOf(jsonString);
+      case DOUBLE:
+        return Double.valueOf(jsonString);
+      case STRING:
+        return jsonString;
+      case UUID:
+        return java.util.UUID.fromString(jsonString);
+      case FIXED:
+      case BINARY:
+        return defaultValueFromJsonBytesField(jsonString);
+      default:
+        throw new RuntimeException("non-primitive type: " + type);
+    }
+  }
+
+  /**
+   * SerDeValue class:
+   *   This is used so that the value to serialize is specified
+   *   as a property, so that the type information gets included in
+   *   the serialized String.
+   */
+  private static class SerDeValue {
+    // Name of the field used in the intermediate JSON representation
+    private static final String VALUE_FIELD = "__value__";
+
+    @JsonProperty(VALUE_FIELD)
+    private final Object value;
+
+    @JsonCreator
+    private SerDeValue(@JsonProperty(VALUE_FIELD) Object value) {
+      this.value = value;
+    }
+
+    private Object getValue() {
+      return value;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -82,28 +82,53 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     List<Schema.Field> updatedFields = Lists.newArrayListWithExpectedSize(struct.fields().size());
     List<Types.NestedField> expectedFields = struct.fields();
     for (int i = 0; i < expectedFields.size(); i += 1) {
-      Types.NestedField field = expectedFields.get(i);
-
+      Types.NestedField expectedField = expectedFields.get(i);
       // detect reordering
-      if (i < fields.size() && !field.name().equals(fields.get(i).name())) {
+      if (i < fields.size() && !expectedField.name().equals(fields.get(i).name())) {
         hasChange = true;
       }
 
-      Schema.Field avroField = updateMap.get(AvroSchemaUtil.makeCompatibleName(field.name()));
+      Schema.Field avroField = updateMap.get(AvroSchemaUtil.makeCompatibleName(expectedField.name()));
 
       if (avroField != null) {
-        updatedFields.add(avroField);
-
+        // if the expectedField has a defaultValue, but the avroField does not, we need to
+        // create a newField to copy over the non-null default value
+        if (expectedField.hasDefaultValue() && !AvroSchemaUtil.hasNonNullDefaultValue(avroField)) {
+          Schema newFiledSchema = (expectedField.isOptional()) ?
+              AvroSchemaUtil.toOption(AvroSchemaUtil.convert(expectedField.type()), true) :
+              AvroSchemaUtil.convert(expectedField.type());
+          Schema.Field newField =
+              new Schema.Field(avroField.name(), newFiledSchema, avroField.doc(), expectedField.getDefaultValue());
+          newField.addProp(AvroSchemaUtil.FIELD_ID_PROP, expectedField.fieldId());
+          updatedFields.add(newField);
+        } else {
+          // otherwise (i.e., expectedFiled has no default value, or it is null) we can use avroField as is
+          updatedFields.add(avroField);
+        }
       } else {
-        Preconditions.checkArgument(
-            field.isOptional() || field.fieldId() == MetadataColumns.ROW_POSITION.fieldId(),
-            "Missing required field: %s", field.name());
-        // Create a field that will be defaulted to null. We assign a unique suffix to the field
-        // to make sure that even if records in the file have the field it is not projected.
-        Schema.Field newField = new Schema.Field(
-            field.name() + "_r" + field.fieldId(),
-            AvroSchemaUtil.toOption(AvroSchemaUtil.convert(field.type())), null, JsonProperties.NULL_VALUE);
-        newField.addProp(AvroSchemaUtil.FIELD_ID_PROP, field.fieldId());
+        // here the expectedField is missing from the file schema, so we verify it is either
+        // an optional field, a metadata column or one that has default value
+        Preconditions.checkArgument(expectedField.isOptional() ||
+                expectedField.fieldId() == MetadataColumns.ROW_POSITION.fieldId() || expectedField.hasDefaultValue(),
+                "Missing required field that has no default value: expectedField: %s, avroField: null, record: %s",
+                expectedField, record);
+
+        // Create a field that will be defaulted to the expectedField's default value. If no default value,
+        // then default to null and assign a unique suffix to the field to make sure that even if records in the
+        // file have the field it is not projected.
+        String newFieldName = expectedField.name();
+        Schema newFiledSchema;
+        Object defaultValue;
+        if (expectedField.hasDefaultValue()) {
+          newFiledSchema = AvroSchemaUtil.convert(expectedField.type());
+          defaultValue = expectedField.getDefaultValue();
+        } else {
+          newFieldName = newFieldName + "_r" + expectedField.fieldId();
+          newFiledSchema = AvroSchemaUtil.toOption(AvroSchemaUtil.convert(expectedField.type()));
+          defaultValue = JsonProperties.NULL_VALUE;
+        }
+        Schema.Field newField = new Schema.Field(newFieldName, newFiledSchema, null, defaultValue);
+        newField.addProp(AvroSchemaUtil.FIELD_ID_PROP, expectedField.fieldId());
         updatedFields.add(newField);
         hasChange = true;
       }
@@ -153,10 +178,10 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       Schema nonNullResult = AvroSchemaUtil.fromOptions(Lists.newArrayList(options));
 
       if (nonNullOriginal != nonNullResult) {
-        return AvroSchemaUtil.toOption(nonNullResult);
+        boolean nullIsSecondOption = union.getTypes().get(1).getType() == Schema.Type.NULL;
+        return AvroSchemaUtil.toOption(nonNullResult, nullIsSecondOption);
       }
     }
-
     return union;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -260,16 +260,22 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
 
   private static Schema.Field copyField(Schema.Field field, Schema newSchema, Integer fieldId) {
     Schema newSchemaReordered;
-    // if the newSchema is an optional schema, make sure the NULL option is always the first
-    if (isOptionSchemaWithNonNullFirstOption(newSchema)) {
+    // if the newSchema is an optional schema with no, or null, default value, then make sure the
+    // NULL option is the first
+    boolean hasNonNullDefaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field);
+    if (isOptionSchemaWithNonNullFirstOption(newSchema) && !hasNonNullDefaultValue) {
       newSchemaReordered = AvroSchemaUtil.toOption(AvroSchemaUtil.fromOption(newSchema));
+    } else if (AvroSchemaUtil.isOptionSchema(newSchema) && hasNonNullDefaultValue) {
+      // o.w. if the newSchema is an optional that has a non-null default value, then make sure the
+      // NULL option is the second
+      newSchemaReordered = AvroSchemaUtil.toOption(AvroSchemaUtil.fromOption(newSchema), true);
     } else {
       newSchemaReordered = newSchema;
     }
-    // do not copy over default values as the file is expected to have values for fields already in the file schema
-    Schema.Field copy = new Schema.Field(field.name(),
-        newSchemaReordered, field.doc(),
-        AvroSchemaUtil.isOptionSchema(newSchemaReordered) ? JsonProperties.NULL_VALUE : null, field.order());
+    // copy over non-null default values
+    Object defaultValue = hasNonNullDefaultValue ? field.defaultVal() :
+        (AvroSchemaUtil.isOptionSchema(newSchemaReordered) ? JsonProperties.NULL_VALUE : null);
+    Schema.Field copy = new Schema.Field(field.name(), newSchemaReordered, field.doc(), defaultValue, field.order());
 
     for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
       copy.addProp(prop.getKey(), prop.getValue());

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.avro;
 
 import java.util.List;
-import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -93,15 +92,12 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       Type fieldType = fieldTypes.get(i);
       int fieldId = getId(field);
 
-      Object defaultValue = field.hasDefaultValue() && !(field.defaultVal() instanceof JsonProperties.Null) ?
-          field.defaultVal() : null;
+      Object defaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field) ? field.defaultVal() : null;
 
       if (AvroSchemaUtil.isOptionSchema(field.schema()) || AvroSchemaUtil.isOptionalComplexUnion(field.schema())) {
         newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, defaultValue, null));
-      } else if (defaultValue != null) {
-        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, defaultValue, null));
       } else {
-        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType));
+        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, defaultValue, null));
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -121,7 +121,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   @Override
   public Schema field(Types.NestedField field, Schema fieldSchema) {
     if (field.isOptional()) {
-      return AvroSchemaUtil.toOption(fieldSchema);
+      return AvroSchemaUtil.toOption(fieldSchema, field.hasDefaultValue());
     } else {
       return fieldSchema;
     }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.avro.Schema.Type.BOOLEAN;
+import static org.apache.avro.Schema.Type.BYTES;
+import static org.apache.avro.Schema.Type.DOUBLE;
+import static org.apache.avro.Schema.Type.FLOAT;
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.avro.Schema.Type.STRING;
+
+
+public class TestSchemaParserForDefaultValues {
+
+  private void assertEqualStructs(org.apache.iceberg.Schema expected, org.apache.iceberg.Schema actual) {
+    if (expected == null) {
+      Assert.assertNull(actual);
+      return;
+    }
+    Assert.assertNotNull(actual);
+    List<NestedField> expectedFields = expected.asStruct().fields();
+    List<NestedField> actualFields = actual.asStruct().fields();
+
+    Assert.assertEquals(expectedFields.size(), actualFields.size());
+
+    for (int i = 0; i < expectedFields.size(); i++) {
+      NestedField expectedField = expectedFields.get(i);
+      NestedField actualField = actualFields.get(i);
+      Assert.assertEquals(expectedField.fieldId(), actualField.fieldId());
+      Assert.assertEquals(expectedField.name(), actualField.name());
+      Assert.assertEquals(expectedField.type(), actualField.type());
+      Assert.assertEquals(expectedField.doc(), actualField.doc());
+      if (expectedField.hasDefaultValue()) {
+        Assert.assertTrue(actualField.hasDefaultValue());
+        switch (expectedField.type().typeId()) {
+          case BINARY:
+          case FIXED:
+            Assert.assertTrue(
+                Arrays.equals((byte[]) expectedField.getDefaultValue(), (byte[]) actualField.getDefaultValue()));
+            break;
+          default:
+            Assert.assertEquals(expectedField.getDefaultValue(), actualField.getDefaultValue());
+        }
+      } else {
+        Assert.assertFalse(actualField.hasDefaultValue());
+      }
+    }
+  }
+
+  private void testToFromJsonPreservingDefaultValues(String[] fieldNames, Schema[] fieldsSchemas, Object[] defaults) {
+    List<Field> fields = new ArrayList<>();
+    IntStream.range(0, defaults.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], fieldsSchemas[i], null, defaults[i])));
+
+    Schema schema = Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema icebergSchemaFromJson = SchemaParser.fromJson(jsonString);
+
+    assertEqualStructs(icebergSchema, icebergSchemaFromJson);
+  }
+
+  @Test
+  public void testPrimitiveTypes() {
+    Boolean defaultBoolean = true;
+    Integer defaultInt = 1;
+    Long defaultLong = -1L;
+    Double defaultDouble = 0.1;
+    Float defaultFloat = 0.1f;
+    String defaultString = "default string";
+    String defaultBytes = "1111";
+    int fixedSize = defaultBytes.getBytes().length;
+
+    String[] fieldNames = {
+        "booleanField",
+        "intField",
+        "longField",
+        "doubleField",
+        "floatField",
+        "stringField",
+        "binaryField",
+        "fixedField"};
+
+    Object[] defaults = {
+        defaultBoolean,
+        defaultInt,
+        defaultLong,
+        defaultDouble,
+        defaultFloat,
+        defaultString,
+        defaultBytes,
+        defaultBytes};
+
+    Schema[] primitives = {
+        Schema.create(BOOLEAN),
+        Schema.create(INT),
+        Schema.create(LONG),
+        Schema.create(DOUBLE),
+        Schema.create(FLOAT),
+        Schema.create(STRING),
+        Schema.create(BYTES),
+        Schema.createFixed("md5", null, "namespace", fixedSize)};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, primitives, defaults);
+  }
+
+  @Test
+  public void testLogicalTypes() {
+    Long longDefault = Long.valueOf(1234556789);
+    String[] fieldNames = {
+        "dateField",
+        "timeField",
+        "timestampField",
+        "uuidField",
+        "decimalField"};
+
+    Object[] defaults = {
+        Integer.valueOf(123446),
+        longDefault,
+        "randomUUID",
+        longDefault};
+
+    Schema dateSchema = Schema.create(INT);
+    dateSchema.addProp("logicaltype", "date");
+    Schema timestampSchema = Schema.create(LONG);
+    timestampSchema.addProp("logicaltype", "timestamp");
+    Schema uuidSchema = Schema.create(STRING);
+    uuidSchema.addProp("logicaltype", "UUID");
+    Schema bigDecimalSchema = Schema.create(LONG);
+    bigDecimalSchema.addProp("logicaltype", "decimal");
+
+    Schema[] logicals = {
+        dateSchema,
+        timestampSchema,
+        uuidSchema,
+        bigDecimalSchema};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, logicals, defaults);
+  }
+
+  @Test
+  public void testNestedTypes() {
+    String structStringFieldName = "stringFieldOfStruct";
+    String structBooleanFieldName = "booleanFieldOfStruct";
+    Map<String, Object> defaultStruct = ImmutableMap.of(structStringFieldName, "default string",
+        structBooleanFieldName, Boolean.TRUE);
+    List<Integer> defaultList = Arrays.asList(1, 2);
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structStringFieldName, Schema.create(STRING), null),
+        new Schema.Field(structBooleanFieldName, Schema.create(BOOLEAN), null));
+
+    String[] fieldNames = {"structField", "listField", "mapField"};
+    Object[] defaults = {defaultStruct, defaultList, defaultMap};
+    Schema[] nested = {
+        Schema.createRecord("name", null, "namespace", false, structFields),
+        Schema.createArray(Schema.create(INT)),
+        Schema.createMap(Schema.create(LONG))};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, nested, defaults);
+  }
+
+  @Test
+  public void testOptionalWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String[] fieldNames = {"optionalPrimitive", "optionalNested"};
+    Schema[] optionals = {
+        Schema.createUnion(Schema.create(INT), Schema.create(NULL)),
+        Schema.createUnion(Schema.createMap(Schema.create(LONG)), Schema.create(NULL))};
+    Object[] defaults = {defaultInt, defaultMap};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, optionals, defaults);
+  }
+
+  @Test
+  public void testNestedOfNestedWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String structIntField = "intFieldOfStruct";
+    String structMapFieldName = "mapFieldOfStruct";
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structIntField, Schema.create(INT), null, defaultInt),
+        new Schema.Field(structMapFieldName, Schema.createMap(Schema.create(LONG)), null, defaultMap));
+
+    String[] fieldNames = {"intFieldNoDefault", "structFieldNoDefault"};
+    Schema[] topLevelFields = {
+        Schema.create(INT),
+        Schema.createRecord("name", null, "namespace", false, structFields)};
+
+    List<Schema.Field> fields = new ArrayList<>();
+    IntStream.range(0, fieldNames.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], topLevelFields[i], null)));
+
+    Schema schema = org.apache.avro.Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema fromJsonIcebergSchema = SchemaParser.fromJson(jsonString);
+    Assert.assertEquals(icebergSchema.toString(), fromJsonIcebergSchema.toString());
+  }
+
+  @Test
+  public void testDeepNestedWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String structIntField = "intFieldOfStruct";
+    String structMapFieldName = "mapFieldOfStruct";
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structIntField, Schema.create(INT), null, defaultInt),
+        new Schema.Field(structMapFieldName, Schema.createMap(Schema.create(LONG)), null, defaultMap));
+
+    Schema downLevelStruct = Schema.createRecord("name", null, "namespace0", false, structFields);
+
+    List<Schema.Field> intermediateStructFields = ImmutableList.of(
+        new Schema.Field("intermediateIntField", Schema.create(INT), null),
+        new Schema.Field("intermediateStructField", downLevelStruct, null));
+
+    Schema intermediateStruct = Schema.createRecord("name", null, "namespace1", false, intermediateStructFields);
+    String[] fieldNames = {"topLevelLong", "topLevelString", "topLevelStruct"};
+    Schema[] topLevelFields = {
+        Schema.create(LONG),
+        Schema.create(STRING),
+        intermediateStruct};
+
+    List<Schema.Field> fields = new ArrayList<>();
+    IntStream.range(0, fieldNames.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], topLevelFields[i], null)));
+
+    Schema schema = org.apache.avro.Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema fromJsonIcebergSchema = SchemaParser.fromJson(jsonString);
+    Assert.assertEquals(icebergSchema.toString(), fromJsonIcebergSchema.toString());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -173,7 +173,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
 
     Schema readSchema = writeSchema;
     AssertHelpers.assertThrows("Missing required field in nameMapping",
-        IllegalArgumentException.class, "Missing required field: x",
+        IllegalArgumentException.class,
         // In this case, pruneColumns result is an empty record
         () -> writeAndRead(writeSchema, readSchema, record, nameMapping));
   }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
@@ -39,6 +40,9 @@ import static org.apache.avro.Schema.Type.LONG;
 import static org.apache.avro.Schema.Type.NULL;
 
 public class TestAvroOptionsWithNonNullDefaults {
+
+  private static final String fieldWithDefaultName = "fieldWithDefault";
+  private static final String noDefaultFiledName = "noDefaultField";
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -123,6 +127,118 @@ public class TestAvroOptionsWithNonNullDefaults {
 
     for (int i = 0; i < expected.size(); i += 1) {
       AvroTestHelpers.assertEquals(readIcebergSchema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+
+  @Test
+  public void testDefaultValueUsedPrimitiveType() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null)));
+    // evolved schema
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, -1)));
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put(noDefaultFiledName, 1);
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put(noDefaultFiledName, 2);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+
+    List<GenericData.Record> expected = ImmutableList.of(record1, record2);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default should be used for records missing the field
+      Assert.assertEquals(-1, rows.get(i).get(fieldWithDefaultName));
+    }
+  }
+
+  @Test
+  public void testDefaultValueNotUsedWhenFiledHasValue() throws IOException {
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, -1)));
+
+    GenericData.Record record1 = new GenericData.Record(readSchema);
+    record1.put(noDefaultFiledName, 3);
+    record1.put(fieldWithDefaultName, 3);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(readSchema, testFile);
+      writer.append(record1);
+    }
+
+    List<GenericData.Record> expected = ImmutableList.of(record1);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default value should NOT be used if field is populated
+      Assert.assertEquals(expected.get(i).get(fieldWithDefaultName), rows.get(i).get(fieldWithDefaultName));
+    }
+  }
+
+  @Test
+  public void testDefaultValueUsedComplexType() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null)));
+    // evolved schema
+    List<Integer> defaultArray = Arrays.asList(-1, -2);
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.createArray(Schema.create(INT)), null, defaultArray)));
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put(noDefaultFiledName, 1);
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put(noDefaultFiledName, 2);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+
+    List<GenericData.Record> expected = ImmutableList.of(record1, record2);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default should be used for records missing the field
+      Assert.assertEquals(defaultArray, rows.get(i).get(fieldWithDefaultName));
     }
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+
+public class TestSparkAvroReaderForFieldsWithDefaultValue {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testAvroDefaultValues() throws IOException {
+    String indexFiledName = "index";
+    String nullableFiledName = "optionalFieldWithDefault";
+    String requiredFiledName = "requiredFieldWithDefault";
+    int defaultValue = -1;
+
+    // write records with initial writeSchema
+    org.apache.avro.Schema writeSchema = org.apache.avro.Schema.createRecord("root", null, null, false,
+        ImmutableList.of(new org.apache.avro.Schema.Field(indexFiledName, org.apache.avro.Schema.create(INT),
+            null, null), new org.apache.avro.Schema.Field(nullableFiledName,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(INT),
+                org.apache.avro.Schema.create(NULL)), null, defaultValue)));
+
+    Schema icebergWriteSchema = AvroSchemaUtil.toIceberg(writeSchema);
+    List<GenericData.Record> expected = RandomData.generateList(icebergWriteSchema, 2, 0L);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<GenericData.Record> writer = Avro.write(Files.localOutput(testFile))
+        .schema(icebergWriteSchema)
+        .named("test")
+        .build()) {
+      for (GenericData.Record rec : expected) {
+        writer.add(rec);
+      }
+    }
+
+    // evolve schema by adding a required field with default value
+    org.apache.avro.Schema evolvedSchema = org.apache.avro.Schema.createRecord("root", null, null, false,
+        ImmutableList.of(new org.apache.avro.Schema.Field(indexFiledName, org.apache.avro.Schema.create(INT),
+                null, null),
+            new org.apache.avro.Schema.Field(nullableFiledName,
+                org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(INT),
+                    org.apache.avro.Schema.create(NULL)), null, defaultValue),
+            new org.apache.avro.Schema.Field(requiredFiledName, org.apache.avro.Schema.create(INT), null, defaultValue)
+        ));
+
+    // read written rows with evolved schema
+    List<InternalRow> rows;
+    Schema icebergReadSchema = AvroSchemaUtil.toIceberg(evolvedSchema);
+    try (AvroIterable<InternalRow> reader = Avro.read(Files.localInput(testFile))
+        .createReaderFunc(SparkAvroReader::new)
+        .project(icebergReadSchema)
+        .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    // validate all rows, and all fields are read properly
+    Assert.assertNotNull(rows);
+    Assert.assertEquals(expected.size(), rows.size());
+    for (int row = 0; row < expected.size(); row++) {
+      GenericData.Record expectedRow = expected.get(row);
+      InternalRow actualRow = rows.get(row);
+      List<Types.NestedField> fields = icebergReadSchema.asStruct().fields();
+
+      for (int i = 0; i < fields.size(); i += 1) {
+        Object expectedValue = null;
+        if (i >= writeSchema.getFields().size() && fields.get(i).hasDefaultValue()) {
+          expectedValue = fields.get(i).getDefaultValue();
+        } else if (i < writeSchema.getFields().size()) {
+          expectedValue = expectedRow.get(i);
+        }
+        Type fieldType = fields.get(i).type();
+        Object actualValue = actualRow.isNullAt(i) ? null : actualRow.get(i, convert(fieldType));
+        Assert.assertEquals(expectedValue, actualValue);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Last change of 3 (see description: https://github.com/apache/iceberg/pull/2496#issue-618854752)
The main changes here are in BuildAvroProjection.java and PruneColumns.java which makes sure that default value is copied over and used while reading projected columns with default values.
Other changes are utils, and testing changes.

There will be a followup PR to handle default values in serialization/deserializaiton, but this can go on parallel with ORC and Parquet changes.

[Update: during integration testing, I had to implement the default value serialization/deserialization. It works now on spark shell to select missing columns with default values and return the default value:
```
// required with non-null default
scala> spark.sql(s"select * from u_sguirgui.testi6").show
+---------+-----------------+                                                    
|firstname |     lastname          |
+---------+-----------------+
|        f        |               l.             |
|     Adam  | default lastname | <-- omitting the required col altogether
+---------+-----------------+
// optional with default value
scala> DaliSpark.createDataFrame("dalids:///u_sguirgui.test5", Map(DaliSpark.PROJECT_COLS -> "firstname, lastname")).show
+---------+----------------+
| firstname|        lastname      |
+---------+----------------+
|     Abel     |            Adam       |
|     Adam   |            null           | <-- using the null option
|     Adam|default lastname   |  <-- omitting the col altogether
+---------+----------------+
```
Also, during integration testing, it turns out that Avro default values for records are Maps, not Lists, so had to change that in the NestedField class.