### PR TITLE
Support reading ORC complex union types

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ApplyNameMapping.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ApplyNameMapping.java
@@ -71,6 +71,21 @@ class ApplyNameMapping extends OrcSchemaVisitor<TypeDescription> {
   }
 
   @Override
+  public TypeDescription union(TypeDescription union, List<TypeDescription> options) {
+    Preconditions.checkArgument(options.size() >= 1, "Union type must have options");
+    MappedField field = nameMapping.find(currentPath());
+    TypeDescription unionType = TypeDescription.createUnion();
+
+    for (TypeDescription option : options) {
+      if (option != null) {
+        unionType.addUnionChild(option);
+      }
+    }
+
+    return setId(unionType, field);
+  }
+
+  @Override
   public TypeDescription list(TypeDescription array, TypeDescription element) {
     Preconditions.checkArgument(element != null, "List type must have element type");
 

--- a/orc/src/main/java/org/apache/iceberg/orc/HasIds.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/HasIds.java
@@ -31,6 +31,11 @@ class HasIds extends OrcSchemaVisitor<Boolean> {
   }
 
   @Override
+  public Boolean union(TypeDescription union, List<Boolean> options) {
+    return ORCSchemaUtil.icebergID(union).isPresent() || options.stream().anyMatch(Predicate.isEqual(true));
+  }
+
+  @Override
   public Boolean list(TypeDescription array, Boolean element) {
     return ORCSchemaUtil.icebergID(array).isPresent() || element;
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -265,20 +265,25 @@ public final class ORCSchemaUtil {
 
     switch (type.typeId()) {
       case STRUCT:
-        orcType = TypeDescription.createStruct();
-        for (Types.NestedField nestedField : type.asStructType().fields()) {
-          // Using suffix _r to avoid potential underlying issues in ORC reader
-          // with reused column names between ORC and Iceberg;
-          // e.g. renaming column c -> d and adding new column d
-          if (mapping.get(nestedField.fieldId()) == null && nestedField.hasDefaultValue()) {
-            continue;
+        OrcField orcField = mapping.getOrDefault(fieldId, null);
+        if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
+          orcType = orcField.type;
+        } else {
+          orcType = TypeDescription.createStruct();
+          for (Types.NestedField nestedField : type.asStructType().fields()) {
+            // Using suffix _r to avoid potential underlying issues in ORC reader
+            // with reused column names between ORC and Iceberg;
+            // e.g. renaming column c -> d and adding new column d
+            if (mapping.get(nestedField.fieldId()) == null && nestedField.hasDefaultValue()) {
+              continue;
+            }
+            String name = Optional.ofNullable(mapping.get(nestedField.fieldId()))
+                .map(OrcField::name)
+                .orElseGet(() -> nestedField.name() + "_r" + nestedField.fieldId());
+            TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),
+                isRequired && nestedField.isRequired(), mapping);
+            orcType.addField(name, childType);
           }
-          String name = Optional.ofNullable(mapping.get(nestedField.fieldId()))
-              .map(OrcField::name)
-              .orElseGet(() -> nestedField.name() + "_r" + nestedField.fieldId());
-          TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),
-              isRequired && nestedField.isRequired(), mapping);
-          orcType.addField(name, childType);
         }
         break;
       case LIST:
@@ -328,6 +333,12 @@ public final class ORCSchemaUtil {
         List<TypeDescription> children = orcType.getChildren();
         for (int i = 0; i < children.size(); i++) {
           icebergToOrc.putAll(icebergToOrcMapping(childrenNames.get(i), children.get(i)));
+        }
+        break;
+      case UNION:
+        List<TypeDescription> options = orcType.getChildren();
+        for (int i = 0; i < options.size(); i++) {
+          icebergToOrc.putAll(icebergToOrcMapping("option" + i, options.get(i)));
         }
         break;
       case LIST:

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 
+
 /**
  * Utilities for mapping Iceberg to ORC schemas.
  */
@@ -265,26 +266,7 @@ public final class ORCSchemaUtil {
 
     switch (type.typeId()) {
       case STRUCT:
-        OrcField orcField = mapping.getOrDefault(fieldId, null);
-        if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
-          orcType = orcField.type;
-        } else {
-          orcType = TypeDescription.createStruct();
-          for (Types.NestedField nestedField : type.asStructType().fields()) {
-            // Using suffix _r to avoid potential underlying issues in ORC reader
-            // with reused column names between ORC and Iceberg;
-            // e.g. renaming column c -> d and adding new column d
-            if (mapping.get(nestedField.fieldId()) == null && nestedField.hasDefaultValue()) {
-              continue;
-            }
-            String name = Optional.ofNullable(mapping.get(nestedField.fieldId()))
-                .map(OrcField::name)
-                .orElseGet(() -> nestedField.name() + "_r" + nestedField.fieldId());
-            TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),
-                isRequired && nestedField.isRequired(), mapping);
-            orcType.addField(name, childType);
-          }
-        }
+        orcType = buildOrcProjectForStructType(fieldId, type, isRequired, mapping);
         break;
       case LIST:
         Types.ListType list = (Types.ListType) type;
@@ -325,6 +307,32 @@ public final class ORCSchemaUtil {
     return orcType;
   }
 
+  private static TypeDescription buildOrcProjectForStructType(Integer fieldId, Type type, boolean isRequired,
+      Map<Integer, OrcField> mapping) {
+    TypeDescription orcType;
+    OrcField orcField = mapping.getOrDefault(fieldId, null);
+    if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
+      orcType = orcField.type;
+    } else {
+      orcType = TypeDescription.createStruct();
+      for (Types.NestedField nestedField : type.asStructType().fields()) {
+        // Using suffix _r to avoid potential underlying issues in ORC reader
+        // with reused column names between ORC and Iceberg;
+        // e.g. renaming column c -> d and adding new column d
+        if (mapping.get(nestedField.fieldId()) == null && nestedField.hasDefaultValue()) {
+          continue;
+        }
+        String name = Optional.ofNullable(mapping.get(nestedField.fieldId()))
+            .map(OrcField::name)
+            .orElseGet(() -> nestedField.name() + "_r" + nestedField.fieldId());
+        TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),
+            isRequired && nestedField.isRequired(), mapping);
+        orcType.addField(name, childType);
+      }
+    }
+    return orcType;
+  }
+
   private static Map<Integer, OrcField> icebergToOrcMapping(String name, TypeDescription orcType) {
     Map<Integer, OrcField> icebergToOrc = Maps.newHashMap();
     switch (orcType.getCategory()) {
@@ -336,6 +344,7 @@ public final class ORCSchemaUtil {
         }
         break;
       case UNION:
+        // This is part of building orc read schema in file level. orcType has union type inside it.
         List<TypeDescription> options = orcType.getChildren();
         for (int i = 0; i < options.size(); i++) {
           icebergToOrc.putAll(icebergToOrcMapping("option" + i, options.get(i)));

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
@@ -47,7 +47,18 @@ public abstract class OrcSchemaVisitor<T> {
         return visitRecord(schema, visitor);
 
       case UNION:
-        throw new UnsupportedOperationException("Cannot handle " + schema);
+        List<TypeDescription> types = schema.getChildren();
+        List<T> options = Lists.newArrayListWithExpectedSize(types.size());
+        for (TypeDescription type : types) {
+          visitor.beforeUnionOption(type);
+          try {
+            options.add(visit(type, visitor));
+          } finally {
+            visitor.afterUnionOption(type);
+          }
+        }
+
+        return visitor.union(schema, options);
 
       case LIST:
         final T elementResult;
@@ -112,6 +123,10 @@ public abstract class OrcSchemaVisitor<T> {
     return visitor.record(record, names, visitFields(fields, names, visitor));
   }
 
+  public String optionName() {
+    return "_option";
+  }
+
   public String elementName() {
     return "_elem";
   }
@@ -134,6 +149,14 @@ public abstract class OrcSchemaVisitor<T> {
 
   public void afterField(String name, TypeDescription type) {
     fieldNames.pop();
+  }
+
+  public void beforeUnionOption(TypeDescription option) {
+    beforeField(optionName(), option);
+  }
+
+  public void afterUnionOption(TypeDescription option) {
+    afterField(optionName(), option);
   }
 
   public void beforeElementField(TypeDescription element) {
@@ -161,6 +184,10 @@ public abstract class OrcSchemaVisitor<T> {
   }
 
   public T record(TypeDescription record, List<String> names, List<T> fields) {
+    return null;
+  }
+
+  public T union(TypeDescription union, List<T> options) {
     return null;
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -38,7 +38,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
         return visitor.visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
 
       case UNION:
-        throw new UnsupportedOperationException("Cannot handle " + schema);
+        return visitUnion(iType, schema, visitor);
 
       case LIST:
         Types.ListType list = iType != null ? iType.asListType() : null;
@@ -71,7 +71,22 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     return visitor.record(struct, record, names, results);
   }
 
+  private static <T> T visitUnion(Type type, TypeDescription union, OrcSchemaWithTypeVisitor<T> visitor) {
+    List<TypeDescription> types = union.getChildren();
+    List<T> options = Lists.newArrayListWithCapacity(types.size());
+
+    for (int i = 0; i < types.size(); i += 1) {
+      options.add(visit(type.asStructType().fields().get(i).type(), types.get(i), visitor));
+    }
+
+    return visitor.union(type, union, options);
+  }
+
   public T record(Types.StructType iStruct, TypeDescription record, List<String> names, List<T> fields) {
+    return null;
+  }
+
+  public T union(Type iUnion, TypeDescription union, List<T> options) {
     return null;
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -76,6 +76,11 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
     }
 
     @Override
+    public OrcValueReader<?> union(Type expected, TypeDescription union, List<OrcValueReader<?>> options) {
+      return SparkOrcValueReaders.union(options);
+    }
+
+    @Override
     public OrcValueReader<?> list(Types.ListType iList, TypeDescription array, OrcValueReader<?> elementReader) {
       return SparkOrcValueReaders.array(elementReader);
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -33,6 +33,7 @@ import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ListColumnVector;
 import org.apache.orc.storage.ql.exec.vector.MapColumnVector;
 import org.apache.orc.storage.ql.exec.vector.TimestampColumnVector;
+import org.apache.orc.storage.ql.exec.vector.UnionColumnVector;
 import org.apache.orc.storage.serde2.io.HiveDecimalWritable;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
@@ -68,6 +69,10 @@ public class SparkOrcValueReaders {
   static OrcValueReader<?> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
     return new StructReader(readers, struct, idToConstant);
+  }
+
+  static OrcValueReader<?> union(List<OrcValueReader<?>> readers) {
+    return new UnionReader(readers);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -156,6 +161,33 @@ public class SparkOrcValueReaders {
       } else {
         struct.setNullAt(pos);
       }
+    }
+  }
+
+  static class UnionReader implements OrcValueReader<InternalRow> {
+    private final OrcValueReader[] readers;
+
+    private UnionReader(List<OrcValueReader<?>> readers) {
+      this.readers = new OrcValueReader[readers.size()];
+      for (int i = 0; i < this.readers.length; i += 1) {
+        this.readers[i] = readers.get(i);
+      }
+    }
+
+    @Override
+    public InternalRow nonNullRead(ColumnVector vector, int row) {
+      InternalRow struct = new GenericInternalRow(readers.length);
+      UnionColumnVector unionColumnVector = (UnionColumnVector) vector;
+
+      int fieldIndex = unionColumnVector.tags[row];
+      Object value = this.readers[fieldIndex].read(unionColumnVector.fields[fieldIndex], row);
+
+      for (int i = 0; i < readers.length; i += 1) {
+        struct.setNullAt(i);
+      }
+      struct.update(fieldIndex, value);
+
+      return struct;
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -94,6 +94,11 @@ public class VectorizedSparkOrcReaders {
     }
 
     @Override
+    public Converter union(Type iType, TypeDescription union, List<Converter> options) {
+      return new UnionConverter(iType, options);
+    }
+
+    @Override
     public Converter list(Types.ListType iList, TypeDescription array, Converter element) {
       return new ArrayConverter(iList, element);
     }
@@ -420,6 +425,23 @@ public class VectorizedSparkOrcReaders {
           return fieldVectors.get(ordinal);
         }
       };
+    }
+  }
+
+  private static class UnionConverter implements Converter {
+    private final Type unionType;
+    private final List<Converter> optionConverters;
+
+    private UnionConverter(Type type, List<Converter> optionConverters) {
+      this.unionType = type;
+      this.optionConverters = optionConverters;
+    }
+
+    @Override
+    public ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector columnVector, int batchSize,
+        long batchOffsetInFile) {
+      // TODO: implementation this method
+      return null;
     }
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.data;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +30,7 @@ import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
 import org.apache.iceberg.types.Types;

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.UnionColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+public class TestSparkOrcUnions {
+  private static final int BATCH_SIZE = 50;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testComplexUnion() throws IOException {
+    TypeDescription orcSchema =
+        TypeDescription.fromString("struct<unionCol:uniontype<int,string>>");
+
+    Schema expectedSchema = new Schema(
+        Types.NestedField.optional(0, "unionCol", Types.StructType.of(
+            Types.NestedField.optional(1, "tag_0", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "tag_1", Types.StringType.get())))
+    );
+
+    Configuration conf = new Configuration();
+
+    temp.delete();
+    String basePath = temp.getRoot().getAbsolutePath();
+    Path path = new Path(basePath + "/test.orc");
+
+    Writer writer = OrcFile.createWriter(path,
+        OrcFile.writerOptions(conf)
+            .setSchema(orcSchema));
+
+    VectorizedRowBatch batch = orcSchema.createRowBatch();
+    LongColumnVector longColumnVector = new LongColumnVector(BATCH_SIZE);
+    BytesColumnVector bytesColumnVector = new BytesColumnVector(BATCH_SIZE);
+    UnionColumnVector complexUnion = new UnionColumnVector(BATCH_SIZE, longColumnVector, bytesColumnVector);
+    complexUnion.init();
+
+    for (int i = 0; i < BATCH_SIZE; i += 1) {
+      complexUnion.tags[i] = i % 2;
+      longColumnVector.vector[i] = i;
+      String stringValue = "stringtype" + i;
+      bytesColumnVector.setVal(i, stringValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    batch.size = BATCH_SIZE;
+    batch.cols[0] = complexUnion;
+
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    List<InternalRow> internalRows = Lists.newArrayList();
+    try (CloseableIterable<InternalRow> reader = ORC
+        .read(Files.localInput(new File(path.getParent() + "/" + path.getName())))
+        .project(expectedSchema)
+        .createReaderFunc(readOrcSchema -> new SparkOrcReader(expectedSchema, readOrcSchema))
+        .build()) {
+      reader.forEach(internalRows::add);
+
+      Assert.assertEquals(internalRows.size(), BATCH_SIZE);
+    } finally {
+      temp.delete();
+    }
+  }
+}


### PR DESCRIPTION
This PR supports reading ORC complex union types as Iceberg Struct type via SparkOrcReader. It is a followup up PR for reading Avro complex union types https://github.com/linkedin/iceberg/pull/65 and https://github.com/linkedin/iceberg/pull/73.