### PR TITLE
 [#2039] Support default value semantic for AVRO

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -54,11 +54,11 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
       } else if (projectedType != null) {
         sameTypes = false; // signal that some types were altered
         if (field.isOptional()) {
-          selectedFields.add(
-              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
+          selectedFields.add(Types.NestedField.optional(
+              field.fieldId(), field.name(), projectedType, field.getDefaultValue(), field.doc()));
         } else {
-          selectedFields.add(
-              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
+          selectedFields.add(Types.NestedField.required(
+              field.fieldId(), field.name(), projectedType, field.getDefaultValue(), field.doc()));
         }
       }
     }

--- a/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField;
+import static org.apache.iceberg.types.Types.StructType;
+
+public class TestDefaultValuesForContainerTypes {
+
+  static NestedField intFieldType;
+  static NestedField stringFieldType;
+  static StructType structType;
+
+  @BeforeClass
+  public static void beforeClass() {
+    intFieldType = NestedField.optional(0, "optionalIntField", Types.IntegerType.get());
+    stringFieldType = NestedField.required(1, "requiredStringField", Types.StringType.get());
+    structType = StructType.of(Arrays.asList(intFieldType, stringFieldType));
+  }
+
+  @Test
+  public void testStructTypeDefault() {
+    Map<String, Object> structDefaultvalue = new HashMap<>();
+    structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
+    structDefaultvalue.put(stringFieldType.name(), "two");
+    NestedField structField = NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+    Assert.assertTrue(structField.hasDefaultValue());
+    Assert.assertEquals(structDefaultvalue, structField.getDefaultValue());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testStructTypeDefaultInvalidFieldsTypes() {
+    List<Object> structDefaultvalue = new ArrayList<>();
+    structDefaultvalue.add("one");
+    structDefaultvalue.add("two");
+    NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testStructTypeDefaultInvalidNumberFields() {
+    List<Object> structDefaultvalue = new ArrayList<>();
+    structDefaultvalue.add(Integer.valueOf(1));
+    structDefaultvalue.add("two");
+    structDefaultvalue.add("three");
+    NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+
+public class TestNestedFieldDefaultValues {
+
+  private final int id = 1;
+  private final String fieldName = "fieldName";
+  private final Type fieldType = Types.IntegerType.get();
+  private final String doc = "field doc";
+  private final Integer defaultValue = 100;
+
+  @Test
+  public void testConstructorsValidCases() {
+    // optional constructors
+    Assert.assertFalse(optional(id, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(optional(id, fieldName, fieldType, doc).hasDefaultValue());
+    NestedField nestedFieldWithDefault = optional(id, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+    nestedFieldWithDefault = optional(id, fieldName, fieldType, defaultValue, null);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+
+    // required constructors
+    Assert.assertFalse(required(id, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(required(id, fieldName, fieldType, doc).hasDefaultValue());
+    Assert.assertFalse(required(id, fieldName, fieldType, null, doc).hasDefaultValue());
+    nestedFieldWithDefault = required(id, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+    nestedFieldWithDefault = required(id, fieldName, fieldType, defaultValue, null);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+
+    // of constructors
+    Assert.assertFalse(NestedField.of(id, true, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(NestedField.of(id, true, fieldName, fieldType, doc).hasDefaultValue());
+    nestedFieldWithDefault = NestedField.of(id, true, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testOptionalWithInvalidDefaultValueClass() {
+    // class of default value does not match class of type
+    Long wrongClassDefaultValue = 100L;
+    optional(id, fieldName, fieldType, wrongClassDefaultValue, doc);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testReqiredWithInvalidDefaultValueClass() {
+    // class of default value does not match class of type
+    Long wrongClassDefaultValue = 100L;
+    required(id, fieldName, fieldType, wrongClassDefaultValue, doc);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -19,20 +19,31 @@
 
 package org.apache.iceberg;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
+
 
 public class SchemaParser {
 
@@ -56,6 +67,26 @@ public class SchemaParser {
   private static final String REQUIRED = "required";
   private static final String ELEMENT_REQUIRED = "element-required";
   private static final String VALUE_REQUIRED = "value-required";
+  private static final String DEFAULT = "default";
+
+  private static final List<Class> primitiveClasses = Arrays.asList(Boolean.class, Integer.class, Long.class,
+      Float.class, Double.class, CharSequence.class, String.class, java.util.UUID.class, BigDecimal.class);
+
+  private static void writeDefaultValue(Object defaultValue, Type type, JsonGenerator generator) throws IOException {
+    if (defaultValue == null) {
+      return;
+    }
+    generator.writeFieldName(DEFAULT);
+    if (type.isListType()) {
+      generator.writeString(defaultValueToJsonString((List<Object>) defaultValue));
+    } else if (type.isStructType() || type.isMapType()) {
+      generator.writeString(defaultValueToJsonString((Map<String, Object>) defaultValue));
+    } else if (isFixedOrBinary(type)) {
+      generator.writeString(defaultValueToJsonString((byte[]) defaultValue));
+    } else {
+      generator.writeString(defaultValueToJsonString(defaultValue));
+    }
+  }
 
   static void toJson(Types.StructType struct, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
@@ -69,13 +100,14 @@ public class SchemaParser {
       generator.writeBooleanField(REQUIRED, field.isRequired());
       generator.writeFieldName(TYPE);
       toJson(field.type(), generator);
+      writeDefaultValue(field.getDefaultValue(), field.type(), generator);
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
       }
+
       generator.writeEndObject();
     }
     generator.writeEndArray();
-
     generator.writeEndObject();
   }
 
@@ -88,7 +120,6 @@ public class SchemaParser {
     generator.writeFieldName(ELEMENT);
     toJson(list.elementType(), generator);
     generator.writeBooleanField(ELEMENT_REQUIRED, !list.isElementOptional());
-
     generator.writeEndObject();
   }
 
@@ -176,6 +207,32 @@ public class SchemaParser {
     throw new IllegalArgumentException("Cannot parse type from json: " + json);
   }
 
+  private static boolean isFixedOrBinary(Type type) {
+    return type.typeId() == Type.TypeID.FIXED || type.typeId() == Type.TypeID.BINARY;
+  }
+
+  private static Object defaultValueFromJson(JsonNode field, Type type) {
+    if (!field.has(DEFAULT)) {
+      return null;
+    }
+
+    String defaultValueString = field.get(DEFAULT).asText();
+
+    if (isFixedOrBinary(type)) {
+      return defaultValueFromJsonBytesField(defaultValueString);
+    }
+
+    if (type.isPrimitiveType()) {
+      return primitiveDefaultValueFromJsonString(defaultValueString, type);
+    }
+
+    try {
+      return defaultValueFromJsonString(defaultValueString, type);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private static Types.StructType structFromJson(JsonNode json) {
     JsonNode fieldArray = json.get(FIELDS);
     Preconditions.checkArgument(fieldArray.isArray(),
@@ -191,13 +248,13 @@ public class SchemaParser {
       int id = JsonUtil.getInt(ID, field);
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(field.get(TYPE));
-
+      Object defaultValue = defaultValueFromJson(field, type);
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
       if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type, doc));
+        fields.add(Types.NestedField.required(id, name, type, defaultValue, doc));
       } else {
-        fields.add(Types.NestedField.optional(id, name, type, doc));
+        fields.add(Types.NestedField.optional(id, name, type, defaultValue, doc));
       }
     }
 
@@ -252,5 +309,135 @@ public class SchemaParser {
         throw new RuntimeIOException(e);
       }
     });
+  }
+
+  private static String defaultValueToJsonString(Map<String, Object> map) {
+    Map<String, String> jsonStringElementsMap = new LinkedHashMap<>();
+    map.entrySet().forEach(
+        entry -> jsonStringElementsMap.put(entry.getKey(), defaultValueToJsonString(entry.getValue())));
+    return defaultValueToJsonString(jsonStringElementsMap);
+  }
+
+  private static String defaultValueToJsonString(List<Object> list) {
+    List<String> jsonStringItemsList = new ArrayList<>();
+    list.forEach(item -> jsonStringItemsList.add(defaultValueToJsonString(item)));
+    return defaultValueToJsonString(jsonStringItemsList);
+  }
+
+  private static String defaultValueToJsonString(byte[] bytes) {
+    try {
+      return JsonUtil.mapper().writeValueAsString(ByteBuffer.wrap(bytes));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String defaultValueToJsonString(Object value) {
+    if (isPrimitiveClass(value)) {
+      return value.toString();
+    }
+
+    try {
+      return JsonUtil.mapper().writeValueAsString(new SerDeValue(value));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static boolean isPrimitiveClass(Object value) {
+    return primitiveClasses.contains(value.getClass());
+  }
+
+  private static Object defaultValueFromJsonBytesField(String value) {
+    try {
+      return JsonUtil.mapper().readValue(value, ByteBuffer.class).array();
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Object defaultValueFromJsonString(String jsonString, Type type) throws IOException {
+    Preconditions.checkArgument(!type.isPrimitiveType(), "jsonString %s is for primitive type %s", jsonString, type);
+    Object jsonStringCollection = JsonUtil.mapper().readValue(jsonString, SerDeValue.class).getValue();
+
+    if (type.isListType()) {
+      Preconditions.checkArgument(jsonStringCollection instanceof List,
+          "deserialized Json object: (%s) is not List for List type", jsonStringCollection);
+      List<Object> list = new ArrayList<>();
+      Type elementType = type.asListType().elementType();
+      for (String item : (List<String>) jsonStringCollection) {
+        list.add(elementType.isPrimitiveType() ? primitiveDefaultValueFromJsonString(item, elementType) :
+            JsonUtil.mapper().readValue(item, SerDeValue.class).getValue());
+      }
+      return list;
+    }
+
+    Preconditions.checkArgument((type.isMapType() || type.isStructType()) && jsonStringCollection instanceof Map,
+        "deserialized Json object: (%s) is not Map for type: %s", jsonStringCollection, type);
+
+    // map (MapType or StructType) case
+    Map<String, Object> map = new HashMap<>();
+    Map<String, String> jsonStringMap = (HashMap<String, String>) jsonStringCollection;
+    for (Map.Entry entry : jsonStringMap.entrySet()) {
+      String key = entry.getKey().toString();
+      String valueString = entry.getValue().toString();
+      Type elementType = type.isMapType() ? type.asMapType().valueType() : type.asStructType().field(key).type();
+      Object value = elementType.isPrimitiveType() ? primitiveDefaultValueFromJsonString(valueString, elementType)
+            : JsonUtil.mapper().readValue(valueString, SerDeValue.class).getValue();
+      map.put(key, value);
+    }
+    return map;
+  }
+
+  private static Object primitiveDefaultValueFromJsonString(String jsonString, Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return Boolean.valueOf(jsonString);
+      case INTEGER:
+      case DATE:
+        return Integer.valueOf(jsonString);
+      case DECIMAL:
+        return BigDecimal.valueOf(Long.valueOf(jsonString));
+      case LONG:
+      case TIME:
+      case TIMESTAMP:
+        return Long.valueOf(jsonString);
+      case FLOAT:
+        return Float.valueOf(jsonString);
+      case DOUBLE:
+        return Double.valueOf(jsonString);
+      case STRING:
+        return jsonString;
+      case UUID:
+        return java.util.UUID.fromString(jsonString);
+      case FIXED:
+      case BINARY:
+        return defaultValueFromJsonBytesField(jsonString);
+      default:
+        throw new RuntimeException("non-primitive type: " + type);
+    }
+  }
+
+  /**
+   * SerDeValue class:
+   *   This is used so that the value to serialize is specified
+   *   as a property, so that the type information gets included in
+   *   the serialized String.
+   */
+  private static class SerDeValue {
+    // Name of the field used in the intermediate JSON representation
+    private static final String VALUE_FIELD = "__value__";
+
+    @JsonProperty(VALUE_FIELD)
+    private final Object value;
+
+    @JsonCreator
+    private SerDeValue(@JsonProperty(VALUE_FIELD) Object value) {
+      this.value = value;
+    }
+
+    private Object getValue() {
+      return value;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -157,10 +157,15 @@ public class AvroSchemaUtil {
   }
 
   public static Schema toOption(Schema schema) {
+    return toOption(schema, false);
+  }
+
+  public static Schema toOption(Schema schema, boolean nullIsSecondElement) {
     if (schema.getType() == UNION) {
-      Preconditions.checkArgument(isOptionSchema(schema),
-          "Union schemas are not supported: %s", schema);
+      Preconditions.checkArgument(isOptionSchema(schema), "Union schemas are not supported: %s", schema);
       return schema;
+    } else if (nullIsSecondElement) {
+      return Schema.createUnion(schema, NULL);
     } else {
       return Schema.createUnion(NULL, schema);
     }
@@ -428,5 +433,13 @@ public class AvroSchemaUtil {
       return "_" + character;
     }
     return "_x" + Integer.toHexString(character).toUpperCase();
+  }
+
+  static boolean hasNonNullDefaultValue(Schema.Field field) {
+    // the schema should use JsonProperties.NULL_VALUE (i.e., null) as the null default
+    // value, but a user might also use "null" to indicate null while it is actually a String, so
+    // need to account for it.
+    return field.hasDefaultValue() && field.defaultVal() != JsonProperties.NULL_VALUE &&
+        !(field.defaultVal() instanceof String && ((String) field.defaultVal()).equalsIgnoreCase("null"));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -92,10 +92,12 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       Type fieldType = fieldTypes.get(i);
       int fieldId = getId(field);
 
+      Object defaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field) ? field.defaultVal() : null;
+
       if (AvroSchemaUtil.isOptionSchema(field.schema()) || AvroSchemaUtil.isOptionalComplexUnion(field.schema())) {
-        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, field.doc()));
+        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, defaultValue, field.doc()));
       } else {
-        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, field.doc()));
+        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, defaultValue, field.doc()));
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -101,9 +101,9 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       String origFieldName = structField.name();
       boolean isValidFieldName = AvroSchemaUtil.validAvroName(origFieldName);
       String fieldName =  isValidFieldName ? origFieldName : AvroSchemaUtil.sanitize(origFieldName);
-      Schema.Field field = new Schema.Field(
-          fieldName, fieldSchemas.get(i), structField.doc(),
-          structField.isOptional() ? JsonProperties.NULL_VALUE : null);
+      Object defaultValue = structField.hasDefaultValue() ? structField.getDefaultValue() :
+          (structField.isOptional() ? JsonProperties.NULL_VALUE : null);
+      Schema.Field field = new Schema.Field(fieldName, fieldSchemas.get(i), structField.doc(), defaultValue);
       if (!isValidFieldName) {
         field.addProp(AvroSchemaUtil.ICEBERG_FIELD_NAME_PROP, origFieldName);
       }
@@ -121,7 +121,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   @Override
   public Schema field(Types.NestedField field, Schema fieldSchema) {
     if (field.isOptional()) {
-      return AvroSchemaUtil.toOption(fieldSchema);
+      return AvroSchemaUtil.toOption(fieldSchema, field.hasDefaultValue());
     } else {
       return fieldSchema;
     }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.avro.Schema.Type.BOOLEAN;
+import static org.apache.avro.Schema.Type.BYTES;
+import static org.apache.avro.Schema.Type.DOUBLE;
+import static org.apache.avro.Schema.Type.FLOAT;
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.avro.Schema.Type.STRING;
+
+
+public class TestSchemaParserForDefaultValues {
+
+  private void assertEqualStructs(org.apache.iceberg.Schema expected, org.apache.iceberg.Schema actual) {
+    if (expected == null) {
+      Assert.assertNull(actual);
+      return;
+    }
+    Assert.assertNotNull(actual);
+    List<NestedField> expectedFields = expected.asStruct().fields();
+    List<NestedField> actualFields = actual.asStruct().fields();
+
+    Assert.assertEquals(expectedFields.size(), actualFields.size());
+
+    for (int i = 0; i < expectedFields.size(); i++) {
+      NestedField expectedField = expectedFields.get(i);
+      NestedField actualField = actualFields.get(i);
+      Assert.assertEquals(expectedField.fieldId(), actualField.fieldId());
+      Assert.assertEquals(expectedField.name(), actualField.name());
+      Assert.assertEquals(expectedField.type(), actualField.type());
+      Assert.assertEquals(expectedField.doc(), actualField.doc());
+      if (expectedField.hasDefaultValue()) {
+        Assert.assertTrue(actualField.hasDefaultValue());
+        switch (expectedField.type().typeId()) {
+          case BINARY:
+          case FIXED:
+            Assert.assertTrue(
+                Arrays.equals((byte[]) expectedField.getDefaultValue(), (byte[]) actualField.getDefaultValue()));
+            break;
+          default:
+            Assert.assertEquals(expectedField.getDefaultValue(), actualField.getDefaultValue());
+        }
+      } else {
+        Assert.assertFalse(actualField.hasDefaultValue());
+      }
+    }
+  }
+
+  private void testToFromJsonPreservingDefaultValues(String[] fieldNames, Schema[] fieldsSchemas, Object[] defaults) {
+    List<Field> fields = new ArrayList<>();
+    IntStream.range(0, defaults.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], fieldsSchemas[i], null, defaults[i])));
+
+    Schema schema = Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema icebergSchemaFromJson = SchemaParser.fromJson(jsonString);
+
+    assertEqualStructs(icebergSchema, icebergSchemaFromJson);
+  }
+
+  @Test
+  public void testPrimitiveTypes() {
+    Boolean defaultBoolean = true;
+    Integer defaultInt = 1;
+    Long defaultLong = -1L;
+    Double defaultDouble = 0.1;
+    Float defaultFloat = 0.1f;
+    String defaultString = "default string";
+    String defaultBytes = "1111";
+    int fixedSize = defaultBytes.getBytes().length;
+
+    String[] fieldNames = {
+        "booleanField",
+        "intField",
+        "longField",
+        "doubleField",
+        "floatField",
+        "stringField",
+        "binaryField",
+        "fixedField"};
+
+    Object[] defaults = {
+        defaultBoolean,
+        defaultInt,
+        defaultLong,
+        defaultDouble,
+        defaultFloat,
+        defaultString,
+        defaultBytes,
+        defaultBytes};
+
+    Schema[] primitives = {
+        Schema.create(BOOLEAN),
+        Schema.create(INT),
+        Schema.create(LONG),
+        Schema.create(DOUBLE),
+        Schema.create(FLOAT),
+        Schema.create(STRING),
+        Schema.create(BYTES),
+        Schema.createFixed("md5", null, "namespace", fixedSize)};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, primitives, defaults);
+  }
+
+  @Test
+  public void testLogicalTypes() {
+    Long longDefault = Long.valueOf(1234556789);
+    String[] fieldNames = {
+        "dateField",
+        "timeField",
+        "timestampField",
+        "uuidField",
+        "decimalField"};
+
+    Object[] defaults = {
+        Integer.valueOf(123446),
+        longDefault,
+        "randomUUID",
+        longDefault};
+
+    Schema dateSchema = Schema.create(INT);
+    dateSchema.addProp("logicaltype", "date");
+    Schema timestampSchema = Schema.create(LONG);
+    timestampSchema.addProp("logicaltype", "timestamp");
+    Schema uuidSchema = Schema.create(STRING);
+    uuidSchema.addProp("logicaltype", "UUID");
+    Schema bigDecimalSchema = Schema.create(LONG);
+    bigDecimalSchema.addProp("logicaltype", "decimal");
+
+    Schema[] logicals = {
+        dateSchema,
+        timestampSchema,
+        uuidSchema,
+        bigDecimalSchema};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, logicals, defaults);
+  }
+
+  @Test
+  public void testNestedTypes() {
+    String structStringFieldName = "stringFieldOfStruct";
+    String structBooleanFieldName = "booleanFieldOfStruct";
+    Map<String, Object> defaultStruct = ImmutableMap.of(structStringFieldName, "default string",
+        structBooleanFieldName, Boolean.TRUE);
+    List<Integer> defaultList = Arrays.asList(1, 2);
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structStringFieldName, Schema.create(STRING), null),
+        new Schema.Field(structBooleanFieldName, Schema.create(BOOLEAN), null));
+
+    String[] fieldNames = {"structField", "listField", "mapField"};
+    Object[] defaults = {defaultStruct, defaultList, defaultMap};
+    Schema[] nested = {
+        Schema.createRecord("name", null, "namespace", false, structFields),
+        Schema.createArray(Schema.create(INT)),
+        Schema.createMap(Schema.create(LONG))};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, nested, defaults);
+  }
+
+  @Test
+  public void testOptionalWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String[] fieldNames = {"optionalPrimitive", "optionalNested"};
+    Schema[] optionals = {
+        Schema.createUnion(Schema.create(INT), Schema.create(NULL)),
+        Schema.createUnion(Schema.createMap(Schema.create(LONG)), Schema.create(NULL))};
+    Object[] defaults = {defaultInt, defaultMap};
+
+    testToFromJsonPreservingDefaultValues(fieldNames, optionals, defaults);
+  }
+
+  @Test
+  public void testNestedOfNestedWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String structIntField = "intFieldOfStruct";
+    String structMapFieldName = "mapFieldOfStruct";
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structIntField, Schema.create(INT), null, defaultInt),
+        new Schema.Field(structMapFieldName, Schema.createMap(Schema.create(LONG)), null, defaultMap));
+
+    String[] fieldNames = {"intFieldNoDefault", "structFieldNoDefault"};
+    Schema[] topLevelFields = {
+        Schema.create(INT),
+        Schema.createRecord("name", null, "namespace", false, structFields)};
+
+    List<Schema.Field> fields = new ArrayList<>();
+    IntStream.range(0, fieldNames.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], topLevelFields[i], null)));
+
+    Schema schema = org.apache.avro.Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema fromJsonIcebergSchema = SchemaParser.fromJson(jsonString);
+    Assert.assertEquals(icebergSchema.toString(), fromJsonIcebergSchema.toString());
+  }
+
+  @Test
+  public void testDeepNestedWithDefault() {
+    Integer defaultInt = 1;
+    Map<String, Long> defaultMap = ImmutableMap.of("key1", Long.valueOf(1L), "key2", Long.valueOf(2L));
+
+    String structIntField = "intFieldOfStruct";
+    String structMapFieldName = "mapFieldOfStruct";
+    List<Schema.Field> structFields = ImmutableList.of(
+        new Schema.Field(structIntField, Schema.create(INT), null, defaultInt),
+        new Schema.Field(structMapFieldName, Schema.createMap(Schema.create(LONG)), null, defaultMap));
+
+    Schema downLevelStruct = Schema.createRecord("name", null, "namespace0", false, structFields);
+
+    List<Schema.Field> intermediateStructFields = ImmutableList.of(
+        new Schema.Field("intermediateIntField", Schema.create(INT), null),
+        new Schema.Field("intermediateStructField", downLevelStruct, null));
+
+    Schema intermediateStruct = Schema.createRecord("name", null, "namespace1", false, intermediateStructFields);
+    String[] fieldNames = {"topLevelLong", "topLevelString", "topLevelStruct"};
+    Schema[] topLevelFields = {
+        Schema.create(LONG),
+        Schema.create(STRING),
+        intermediateStruct};
+
+    List<Schema.Field> fields = new ArrayList<>();
+    IntStream.range(0, fieldNames.length).forEach(
+        i -> fields.add(new Schema.Field(fieldNames[i], topLevelFields[i], null)));
+
+    Schema schema = org.apache.avro.Schema.createRecord("root", null, null, false, fields);
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    String jsonString = SchemaParser.toJson(icebergSchema);
+
+    Assert.assertTrue(jsonString.contains("default"));
+
+    org.apache.iceberg.Schema fromJsonIcebergSchema = SchemaParser.fromJson(jsonString);
+    Assert.assertEquals(icebergSchema.toString(), fromJsonIcebergSchema.toString());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -173,7 +173,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
 
     Schema readSchema = writeSchema;
     AssertHelpers.assertThrows("Missing required field in nameMapping",
-        IllegalArgumentException.class, "Missing required field: x",
+        IllegalArgumentException.class,
         // In this case, pruneColumns result is an empty record
         () -> writeAndRead(writeSchema, readSchema, record, nameMapping));
   }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
@@ -39,6 +40,9 @@ import static org.apache.avro.Schema.Type.LONG;
 import static org.apache.avro.Schema.Type.NULL;
 
 public class TestAvroOptionsWithNonNullDefaults {
+
+  private static final String fieldWithDefaultName = "fieldWithDefault";
+  private static final String noDefaultFiledName = "noDefaultField";
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -123,6 +127,118 @@ public class TestAvroOptionsWithNonNullDefaults {
 
     for (int i = 0; i < expected.size(); i += 1) {
       AvroTestHelpers.assertEquals(readIcebergSchema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+
+  @Test
+  public void testDefaultValueUsedPrimitiveType() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null)));
+    // evolved schema
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, -1)));
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put(noDefaultFiledName, 1);
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put(noDefaultFiledName, 2);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+
+    List<GenericData.Record> expected = ImmutableList.of(record1, record2);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default should be used for records missing the field
+      Assert.assertEquals(-1, rows.get(i).get(fieldWithDefaultName));
+    }
+  }
+
+  @Test
+  public void testDefaultValueNotUsedWhenFiledHasValue() throws IOException {
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, -1)));
+
+    GenericData.Record record1 = new GenericData.Record(readSchema);
+    record1.put(noDefaultFiledName, 3);
+    record1.put(fieldWithDefaultName, 3);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(readSchema, testFile);
+      writer.append(record1);
+    }
+
+    List<GenericData.Record> expected = ImmutableList.of(record1);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default value should NOT be used if field is populated
+      Assert.assertEquals(expected.get(i).get(fieldWithDefaultName), rows.get(i).get(fieldWithDefaultName));
+    }
+  }
+
+  @Test
+  public void testDefaultValueUsedComplexType() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null)));
+    // evolved schema
+    List<Integer> defaultArray = Arrays.asList(-1, -2);
+    Schema readSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.createArray(Schema.create(INT)), null, defaultArray)));
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put(noDefaultFiledName, 1);
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put(noDefaultFiledName, 2);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+
+    List<GenericData.Record> expected = ImmutableList.of(record1, record2);
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader =
+        Avro.read(Files.localInput(testFile)).project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals(expected.get(i).get(noDefaultFiledName), rows.get(i).get(noDefaultFiledName));
+      // default should be used for records missing the field
+      Assert.assertEquals(defaultArray, rows.get(i).get(fieldWithDefaultName));
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestDefaultValuePreserving.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestDefaultValuePreserving.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.avro.Schema.Type.INT;
+
+
+/**
+ * Testing the preserving of fields; default values in {@link SchemaToType} and {@link TypeToSchema}
+ */
+public class TestDefaultValuePreserving {
+
+  String noDefaultFiledName = "fieldWithNoDefaultValue";
+  String fieldWithDefaultName = "fieldWithDefaultValue";
+  Integer defaultValue = -1;
+
+  @Test
+  public void testSchemaToTypeRecord() {
+    Schema recordSchema = Schema.createRecord("root", null, null, false, ImmutableList.of(
+        new Schema.Field(noDefaultFiledName, Schema.create(INT), null, null),
+        new Schema.Field(fieldWithDefaultName, Schema.create(INT), null, defaultValue)));
+    SchemaToType schemaToType = new SchemaToType(recordSchema);
+    List<String> names = recordSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
+    List<Type> types = ImmutableList.of(Types.IntegerType.get(), Types.IntegerType.get());
+
+    Type record = schemaToType.record(recordSchema, names, types);
+
+    Assert.assertNotNull(record);
+    Assert.assertTrue(record.isStructType());
+    Assert.assertEquals(names.size(), record.asStructType().fields().size());
+    Assert.assertFalse(record.asStructType().field(noDefaultFiledName).hasDefaultValue());
+    Assert.assertTrue(record.asStructType().field(fieldWithDefaultName).hasDefaultValue());
+    Assert.assertEquals(defaultValue, record.asStructType().field(fieldWithDefaultName).getDefaultValue());
+  }
+
+  @Test
+  public void testTypeToSchemaStruct() {
+    List<Types.NestedField> nestedFields = ImmutableList.of(
+        Types.NestedField.required(0, noDefaultFiledName, Types.IntegerType.get()),
+        Types.NestedField.required(1, fieldWithDefaultName, Types.IntegerType.get(), defaultValue, null));
+    Types.StructType structType = Types.StructType.of(nestedFields);
+    Map<Types.StructType, String> names = ImmutableMap.of(structType, "tableName");
+    TypeToSchema typeToSchema = new TypeToSchema(names);
+    List<Schema> fieldSchemas = ImmutableList.of(Schema.create(INT), Schema.create(INT));
+
+    Schema structSchema = typeToSchema.struct(structType, fieldSchemas);
+
+    Assert.assertNotNull(structSchema);
+    Assert.assertEquals(nestedFields.size(), structSchema.getFields().size());
+    for (int i = 0; i < nestedFields.size(); i++) {
+      if (nestedFields.get(i).hasDefaultValue()) {
+        Assert.assertTrue(structSchema.getFields().get(i).hasDefaultValue());
+        Assert.assertEquals(nestedFields.get(i).getDefaultValue(), structSchema.getFields().get(i).defaultVal());
+      } else {
+        Assert.assertFalse(structSchema.getFields().get(i).hasDefaultValue());
+      }
+    }
+  }
+}

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -116,6 +116,8 @@ A table's **schema** is a list of named columns. All data types are either primi
 
 For the representations of these types in Avro, ORC, and Parquet file formats, see Appendix A.
 
+Default values for fields are supported, see Neted Types below.
+
 #### Nested Types
 
 A **`struct`** is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema. Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type. Fields may have an optional comment or doc string.
@@ -123,6 +125,13 @@ A **`struct`** is a tuple of typed values. Each field in the tuple is named and 
 A **`list`** is a collection of values with some element type. The element field has an integer id that is unique in the table schema. Elements can be either optional or required. Element types may be any type.
 
 A **`map`** is a collection of key-value pairs with a key type and a value type. Both the key field and value field each have an integer id that is unique in the table schema. Map keys are required and map values can be either optional or required. Both map keys and map values may be any type, including nested types.
+
+Iceberg supports default-value semantics for fields of nested types (i.e., struct, list and map). Specifically, a field 
+of a nested type field can have a default value that will be returned upon reading this field, if it is not manifested. 
+The default value can be defined with both required and optional fields. Null default values are allowed with optional
+fields only, and it's behavior is identical to optional fields with no default value, that is a Null is returned upon
+reading this field when it is not manifested.
+
 
 #### Primitive Types
 
@@ -924,7 +933,6 @@ This serialization scheme is for storing single values as individual binary valu
 | **`struct`**                 | Not supported                                                                                                |
 | **`list`**                   | Not supported                                                                                                |
 | **`map`**                    | Not supported                                                                                                |
-
 
 ## Format version changes
 

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
+
+public class TestSparkAvroReaderForFieldsWithDefaultValue {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testAvroDefaultValues() throws IOException {
+    String indexFiledName = "index";
+    String nullableFiledName = "optionalFieldWithDefault";
+    String requiredFiledName = "requiredFieldWithDefault";
+    int defaultValue = -1;
+
+    // write records with initial writeSchema
+    org.apache.avro.Schema writeSchema = org.apache.avro.Schema.createRecord("root", null, null, false,
+        ImmutableList.of(new org.apache.avro.Schema.Field(indexFiledName, org.apache.avro.Schema.create(INT),
+            null, null), new org.apache.avro.Schema.Field(nullableFiledName,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(INT),
+                org.apache.avro.Schema.create(NULL)), null, defaultValue)));
+
+    Schema icebergWriteSchema = AvroSchemaUtil.toIceberg(writeSchema);
+    List<GenericData.Record> expected = RandomData.generateList(icebergWriteSchema, 2, 0L);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<GenericData.Record> writer = Avro.write(Files.localOutput(testFile))
+        .schema(icebergWriteSchema)
+        .named("test")
+        .build()) {
+      for (GenericData.Record rec : expected) {
+        writer.add(rec);
+      }
+    }
+
+    // evolve schema by adding a required field with default value
+    org.apache.avro.Schema evolvedSchema = org.apache.avro.Schema.createRecord("root", null, null, false,
+        ImmutableList.of(new org.apache.avro.Schema.Field(indexFiledName, org.apache.avro.Schema.create(INT),
+                null, null),
+            new org.apache.avro.Schema.Field(nullableFiledName,
+                org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(INT),
+                    org.apache.avro.Schema.create(NULL)), null, defaultValue),
+            new org.apache.avro.Schema.Field(requiredFiledName, org.apache.avro.Schema.create(INT), null, defaultValue)
+        ));
+
+    // read written rows with evolved schema
+    List<InternalRow> rows;
+    Schema icebergReadSchema = AvroSchemaUtil.toIceberg(evolvedSchema);
+    try (AvroIterable<InternalRow> reader = Avro.read(Files.localInput(testFile))
+        .createReaderFunc(SparkAvroReader::new)
+        .project(icebergReadSchema)
+        .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    // validate all rows, and all fields are read properly
+    Assert.assertNotNull(rows);
+    Assert.assertEquals(expected.size(), rows.size());
+    for (int row = 0; row < expected.size(); row++) {
+      GenericData.Record expectedRow = expected.get(row);
+      InternalRow actualRow = rows.get(row);
+      List<Types.NestedField> fields = icebergReadSchema.asStruct().fields();
+
+      for (int i = 0; i < fields.size(); i += 1) {
+        Object expectedValue = null;
+        if (i >= writeSchema.getFields().size() && fields.get(i).hasDefaultValue()) {
+          expectedValue = fields.get(i).getDefaultValue();
+        } else if (i < writeSchema.getFields().size()) {
+          expectedValue = expectedRow.get(i);
+        }
+        Type fieldType = fields.get(i).type();
+        Object actualValue = actualRow.isNullAt(i) ? null : actualRow.get(i, convert(fieldType));
+        Assert.assertEquals(expectedValue, actualValue);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Supporting default value semantics for AVRO tables/datasets.
cherry picked from master branch commits:

[[#2039] Support Default Value Semantis: use default values reading AV…](https://github.com/linkedin/iceberg/commit/b81ab9ed0c83cc20a29850a180ee7e56530a961b)

[[#2039] Support default value semantics: Schema Mapping changes](https://github.com/linkedin/iceberg/commit/c88ec3f2352789a213f3d409cec3ec36238d0ef0)
and 
[[#2039] Support default value semantics: API changes](https://github.com/linkedin/iceberg/commit/c18f4c4858deeb0e3b2a2831d18bc8dc163e22dd)

With these commits, on spark-shell one can select missing columns with non-null default values and get the default value in the results:

```
// required with non-null default
scala> spark.sql(s"select * from u_sguirgui.testi6").show
+----------+------------------+
| firstname |      lastname  |
+----------+------------------+
| Sam       |        Adam      |
| Adam      | default lastname |  <-- omitting the required col altogether
+----------+------------------+

// optional with default value
scala> DaliSpark.createDataFrame("dalids:///u_sguirgui.test5", Map(DaliSpark.PROJECT_COLS -> "firstname, lastname")).show
+----------+------------------+
| firstname|        lastname |
+----------+------------------+
| Sam      |    Adam         |
| Adam     | null.           |  <-- using the null option
| Adam.    | default lastname|  <-- omitting the col altogether
+----------+------------------+
```