### PR TITLE
Support default value read for ORC format in spark

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.types;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -457,7 +456,7 @@ public class Types {
       }
       switch (type.typeId()) {
         case STRUCT:
-          Preconditions.checkArgument(Map.class.isInstance(defaultValue),
+          Preconditions.checkArgument(defaultValue instanceof Map,
               "defaultValue should be a Map from fields names to values, for StructType");
           Map<String, Object> defaultStruct = (Map<String, Object>) defaultValue;
           if (defaultStruct.isEmpty()) {
@@ -470,17 +469,17 @@ public class Types {
           break;
 
         case LIST:
-          Preconditions.checkArgument(defaultValue instanceof ArrayList,
-              "defaultValue should be an ArrayList of Objects, for ListType");
-          List<Object> defaultArrayList = (ArrayList<Object>) defaultValue;
-          if (defaultArrayList.size() == 0) {
+          Preconditions.checkArgument(defaultValue instanceof List,
+              "defaultValue should be an List of Objects, for ListType");
+          List<Object> defaultList = (List<Object>) defaultValue;
+          if (defaultList.size() == 0) {
             return;
           }
-          defaultArrayList.forEach(dv -> NestedField.validateDefaultValue(dv, type.asListType().elementField.type));
+          defaultList.forEach(dv -> NestedField.validateDefaultValue(dv, type.asListType().elementField.type));
           break;
 
         case MAP:
-          Preconditions.checkArgument(Map.class.isInstance(defaultValue),
+          Preconditions.checkArgument(defaultValue instanceof Map,
               "defaultValue should be an instance of Map for MapType");
           Map<Object, Object> defaultMap = (Map<Object, Object>) defaultValue;
           if (defaultMap.isEmpty()) {
@@ -494,7 +493,7 @@ public class Types {
 
         case FIXED:
         case BINARY:
-          Preconditions.checkArgument(byte[].class.isInstance(defaultValue),
+          Preconditions.checkArgument(defaultValue instanceof byte[],
               "defaultValue should be an instance of byte[] for TypeId.%s, but defaultValue.class = %s",
               type.typeId().name(), defaultValue.getClass().getCanonicalName());
           break;

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -270,6 +270,9 @@ public final class ORCSchemaUtil {
           // Using suffix _r to avoid potential underlying issues in ORC reader
           // with reused column names between ORC and Iceberg;
           // e.g. renaming column c -> d and adding new column d
+          if (mapping.get(nestedField.fieldId()) == null && nestedField.hasDefaultValue()) {
+            continue;
+          }
           String name = Optional.ofNullable(mapping.get(nestedField.fieldId()))
               .map(OrcField::name)
               .orElseGet(() -> nestedField.name() + "_r" + nestedField.fieldId());
@@ -387,7 +390,7 @@ public final class ORCSchemaUtil {
         .map(Integer::parseInt);
   }
 
-  static int fieldId(TypeDescription orcType) {
+  public static int fieldId(TypeDescription orcType) {
     String idStr = orcType.getAttributeValue(ICEBERG_ID_ATTRIBUTE);
     Preconditions.checkNotNull(idStr, "Missing expected '%s' property", ICEBERG_ID_ATTRIBUTE);
     return Integer.parseInt(idStr);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -35,7 +35,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
   public static <T> T visit(Type iType, TypeDescription schema, OrcSchemaWithTypeVisitor<T> visitor) {
     switch (schema.getCategory()) {
       case STRUCT:
-        return visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
+        return visitor.visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
 
       case UNION:
         throw new UnsupportedOperationException("Cannot handle " + schema);
@@ -58,7 +58,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     }
   }
 
-  private static <T> T visitRecord(
+  protected T visitRecord(
       Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
     List<TypeDescription> fields = record.getChildren();
     List<String> names = record.getFieldNames();

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -154,11 +154,7 @@ public class OrcValueReaders {
         } else if (field.equals(MetadataColumns.ROW_POSITION)) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = new RowPositionReader();
-        } else if (readers.get(readerIndex) instanceof ConstantReader) {
-          this.isConstantOrMetadataField[pos] = true;
-          this.readers[pos] = readers.get(readerIndex);
-        }
-        else {
+        } else {
           this.readers[pos] = readers.get(readerIndex);
           readerIndex++;
         }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -154,7 +154,11 @@ public class OrcValueReaders {
         } else if (field.equals(MetadataColumns.ROW_POSITION)) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = new RowPositionReader();
-        } else {
+        } else if (readers.get(readerIndex) instanceof ConstantReader) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = readers.get(readerIndex);
+        }
+        else {
           this.readers[pos] = readers.get(readerIndex);
           readerIndex++;
         }

--- a/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.apache.iceberg.orc.ORCSchemaUtil;
+import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class OrcSchemaWithTypeVisitorSpark<T> extends OrcSchemaWithTypeVisitor<T> {
+    protected final Map<Integer, Object> idToConstant;
+
+    protected OrcSchemaWithTypeVisitorSpark(Map<Integer, ?> idToConstant) {
+        this.idToConstant = new HashMap<>();
+        this.idToConstant.putAll(idToConstant);
+    }
+
+    @Override
+    protected T visitRecord(
+            Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
+        Preconditions.checkState(
+                checkIcebergAndOrcSchemaAlignment(struct, record),
+                "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
+                        "to get an aligned ORC schema first!"
+        );
+        List<Types.NestedField> iFields = struct.fields();
+        List<TypeDescription> fields = record.getChildren();
+        List<String> names = record.getFieldNames();
+        List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+
+        for (int i = 0, j = 0; i < iFields.size(); i++) {
+            Types.NestedField iField = iFields.get(i);
+            TypeDescription field = j < fields.size() ? fields.get(j) : null;
+            if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
+                idToConstant.put(iField.fieldId(), iField.getDefaultValue());
+            } else {
+                results.add(visit(iField.type(), field, visitor));
+                j++;
+            }
+        }
+        return visitor.record(struct, record, names, results);
+    }
+
+    private static boolean checkIcebergAndOrcSchemaAlignment(Types.StructType struct, TypeDescription record) {
+        List<Integer> icebergIDList = struct.fields().stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
+        List<Integer> orcIDList = record.getChildren().stream().map(ORCSchemaUtil::fieldId).collect(Collectors.toList());
+
+        // icebergIDList should be a superset of orcIDList, and the overlapping ids should appear
+        // in the same order in these 2 lists
+        return checkTwoListAlignmentHelper(icebergIDList, orcIDList);
+    }
+
+    private static boolean checkTwoListAlignmentHelper(List<Integer> list1, List<Integer> list2) {
+        if (list1.size() < list2.size()) {
+            return false;
+        }
+
+        for (int i = 0, j = 0; j < list2.size(); j++) {
+            if (i >= list1.size()) {
+                return false;
+            }
+            while (!list1.get(i).equals(list2.get(j))) {
+                i++;
+                if (i >= list1.size()) {
+                    return false;
+                }
+            }
+            i++;
+        }
+        return true;
+    }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
@@ -19,79 +19,82 @@
 
 package org.apache.iceberg.spark;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
-import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 public abstract class OrcSchemaWithTypeVisitorSpark<T> extends OrcSchemaWithTypeVisitor<T> {
-    protected final Map<Integer, Object> idToConstant;
 
-    protected OrcSchemaWithTypeVisitorSpark(Map<Integer, ?> idToConstant) {
-        this.idToConstant = new HashMap<>();
-        this.idToConstant.putAll(idToConstant);
+  private final Map<Integer, Object> idToConstant;
+
+  public Map<Integer, Object> getIdToConstant() {
+    return idToConstant;
+  }
+
+  protected OrcSchemaWithTypeVisitorSpark(Map<Integer, ?> idToConstant) {
+    this.idToConstant = new HashMap<>();
+    this.idToConstant.putAll(idToConstant);
+  }
+
+  @Override
+  protected T visitRecord(
+          Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
+    Preconditions.checkState(
+            checkIcebergAndOrcSchemaAlignment(struct, record),
+            "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
+                    "to get an aligned ORC schema first!"
+    );
+    List<Types.NestedField> iFields = struct.fields();
+    List<TypeDescription> fields = record.getChildren();
+    List<String> names = record.getFieldNames();
+    List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+
+    for (int i = 0, j = 0; i < iFields.size(); i++) {
+      Types.NestedField iField = iFields.get(i);
+      TypeDescription field = j < fields.size() ? fields.get(j) : null;
+      if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
+        idToConstant.put(iField.fieldId(), iField.getDefaultValue());
+      } else {
+        results.add(visit(iField.type(), field, visitor));
+        j++;
+      }
+    }
+    return visitor.record(struct, record, names, results);
+  }
+
+  private static boolean checkIcebergAndOrcSchemaAlignment(Types.StructType struct, TypeDescription record) {
+    List<Integer> icebergIDList = struct.fields().stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
+    List<Integer> orcIDList = record.getChildren().stream().map(ORCSchemaUtil::fieldId).collect(Collectors.toList());
+
+    // icebergIDList should be a superset of orcIDList, and the overlapping ids should appear
+    // in the same order in these 2 lists
+    return checkTwoListAlignmentHelper(icebergIDList, orcIDList);
+  }
+
+  private static boolean checkTwoListAlignmentHelper(List<Integer> list1, List<Integer> list2) {
+    if (list1.size() < list2.size()) {
+      return false;
     }
 
-    @Override
-    protected T visitRecord(
-            Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
-        Preconditions.checkState(
-                checkIcebergAndOrcSchemaAlignment(struct, record),
-                "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
-                        "to get an aligned ORC schema first!"
-        );
-        List<Types.NestedField> iFields = struct.fields();
-        List<TypeDescription> fields = record.getChildren();
-        List<String> names = record.getFieldNames();
-        List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
-
-        for (int i = 0, j = 0; i < iFields.size(); i++) {
-            Types.NestedField iField = iFields.get(i);
-            TypeDescription field = j < fields.size() ? fields.get(j) : null;
-            if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
-                idToConstant.put(iField.fieldId(), iField.getDefaultValue());
-            } else {
-                results.add(visit(iField.type(), field, visitor));
-                j++;
-            }
+    for (int i = 0, j = 0; j < list2.size(); j++) {
+      if (i >= list1.size()) {
+        return false;
+      }
+      while (!list1.get(i).equals(list2.get(j))) {
+        i++;
+        if (i >= list1.size()) {
+          return false;
         }
-        return visitor.record(struct, record, names, results);
+      }
+      i++;
     }
-
-    private static boolean checkIcebergAndOrcSchemaAlignment(Types.StructType struct, TypeDescription record) {
-        List<Integer> icebergIDList = struct.fields().stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
-        List<Integer> orcIDList = record.getChildren().stream().map(ORCSchemaUtil::fieldId).collect(Collectors.toList());
-
-        // icebergIDList should be a superset of orcIDList, and the overlapping ids should appear
-        // in the same order in these 2 lists
-        return checkTwoListAlignmentHelper(icebergIDList, orcIDList);
-    }
-
-    private static boolean checkTwoListAlignmentHelper(List<Integer> list1, List<Integer> list2) {
-        if (list1.size() < list2.size()) {
-            return false;
-        }
-
-        for (int i = 0, j = 0; j < list2.size(); j++) {
-            if (i >= list1.size()) {
-                return false;
-            }
-            while (!list1.get(i).equals(list2.get(j))) {
-                i++;
-                if (i >= list1.size()) {
-                    return false;
-                }
-            }
-            i++;
-        }
-        return true;
-    }
+    return true;
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/OrcSchemaWithTypeVisitorSpark.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -60,7 +61,9 @@ public abstract class OrcSchemaWithTypeVisitorSpark<T> extends OrcSchemaWithType
       Types.NestedField iField = iFields.get(i);
       TypeDescription field = j < fields.size() ? fields.get(j) : null;
       if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
-        idToConstant.put(iField.fieldId(), iField.getDefaultValue());
+        if (!iField.equals(MetadataColumns.ROW_POSITION)) {
+          idToConstant.put(iField.fieldId(), iField.getDefaultValue());
+        }
       } else {
         results.add(visit(iField.type(), field, visitor));
         j++;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.data;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ import org.apache.iceberg.orc.*;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.OrcSchemaWithTypeVisitorSpark;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
@@ -63,11 +65,10 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
     reader.setBatchContext(batchOffsetInFile);
   }
 
-  private static class ReadBuilder extends OrcSchemaWithTypeVisitor<OrcValueReader<?>> {
-    private final Map<Integer, ?> idToConstant;
+  public static class ReadBuilder extends OrcSchemaWithTypeVisitorSpark<OrcValueReader<?>> {
 
     private ReadBuilder(Map<Integer, ?> idToConstant) {
-      this.idToConstant = idToConstant;
+      super(idToConstant);
     }
 
     @Override
@@ -121,60 +122,31 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
       }
     }
 
-    @Override
-    protected OrcValueReader<?> visitRecord(
-            Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<OrcValueReader<?>> visitor) {
-      Preconditions.checkState(
-              checkIcebergAndOrcSchemaAlignment(struct, record),
-              "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
-                      "to get an aligned ORC schema first!"
-      );
-      List<Types.NestedField> iFields = struct.fields();
-      List<TypeDescription> fields = record.getChildren();
-      List<String> names = record.getFieldNames();
-      List<OrcValueReader<?>> results = Lists.newArrayListWithExpectedSize(fields.size());
-
-      for (int i = 0, j = 0; i < iFields.size(); i++) {
-        Types.NestedField iField = iFields.get(i);
-        TypeDescription field = j < fields.size() ? fields.get(j) : null;
-        if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
+//    @Override
+//    protected OrcValueReader<?> visitRecord(
+//            Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<OrcValueReader<?>> visitor) {
+//      Preconditions.checkState(
+//              checkIcebergAndOrcSchemaAlignment(struct, record),
+//              "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
+//                      "to get an aligned ORC schema first!"
+//      );
+//      List<Types.NestedField> iFields = struct.fields();
+//      List<TypeDescription> fields = record.getChildren();
+//      List<String> names = record.getFieldNames();
+//      List<OrcValueReader<?>> results = Lists.newArrayListWithExpectedSize(fields.size());
+//
+//      for (int i = 0, j = 0; i < iFields.size(); i++) {
+//        Types.NestedField iField = iFields.get(i);
+//        TypeDescription field = j < fields.size() ? fields.get(j) : null;
+//        if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
 //          idToConstant.put(iField.fieldId(), iField.getDefaultValue());
-          results.add(OrcValueReaders.constants(iField.getDefaultValue()));
-        } else {
-          results.add(visit(iField.type(), field, visitor));
-          j++;
-        }
-      }
-      return visitor.record(struct, record, names, results);
-    }
-
-    private static boolean checkIcebergAndOrcSchemaAlignment(Types.StructType struct, TypeDescription record) {
-      List<Integer> icebergIDList = struct.fields().stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
-      List<Integer> orcIDList = record.getChildren().stream().map(ORCSchemaUtil::fieldId).collect(Collectors.toList());
-
-      // icebergIDList should be a superset of orcIDList, and the overlapping ids should appear
-      // in the same order in these 2 lists
-      return checkTwoListAlignmentHelper(icebergIDList, orcIDList);
-    }
-
-    private static boolean checkTwoListAlignmentHelper(List<Integer> list1, List<Integer> list2) {
-      if (list1.size() < list2.size()) {
-        return false;
-      }
-
-      for (int i = 0, j = 0; j < list2.size(); j++) {
-        if (i >= list1.size()) {
-          return false;
-        }
-        while (!list1.get(i).equals(list2.get(j))) {
-          i++;
-          if (i >= list1.size()) {
-            return false;
-          }
-        }
-        i++;
-      }
-      return true;
-    }
+////          results.add(OrcValueReaders.constants(iField.getDefaultValue()));
+//        } else {
+//          results.add(visit(iField.type(), field, visitor));
+//          j++;
+//        }
+//      }
+//      return visitor.record(struct, record, names, results);
+//    }
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -19,15 +19,13 @@
 
 package org.apache.iceberg.spark.data;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.iceberg.orc.*;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.orc.OrcRowReader;
+import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.OrcSchemaWithTypeVisitorSpark;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -74,7 +72,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
     @Override
     public OrcValueReader<?> record(
         Types.StructType expected, TypeDescription record, List<String> names, List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(fields, expected, getIdToConstant());
     }
 
     @Override
@@ -121,32 +119,5 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
           throw new IllegalArgumentException("Unhandled type " + primitive);
       }
     }
-
-//    @Override
-//    protected OrcValueReader<?> visitRecord(
-//            Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<OrcValueReader<?>> visitor) {
-//      Preconditions.checkState(
-//              checkIcebergAndOrcSchemaAlignment(struct, record),
-//              "Iceberg schema and ORC schema doesn't align, please call ORCSchemaUtil.buildOrcProjection" +
-//                      "to get an aligned ORC schema first!"
-//      );
-//      List<Types.NestedField> iFields = struct.fields();
-//      List<TypeDescription> fields = record.getChildren();
-//      List<String> names = record.getFieldNames();
-//      List<OrcValueReader<?>> results = Lists.newArrayListWithExpectedSize(fields.size());
-//
-//      for (int i = 0, j = 0; i < iFields.size(); i++) {
-//        Types.NestedField iField = iFields.get(i);
-//        TypeDescription field = j < fields.size() ? fields.get(j) : null;
-//        if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
-//          idToConstant.put(iField.fieldId(), iField.getDefaultValue());
-////          results.add(OrcValueReaders.constants(iField.getDefaultValue()));
-//        } else {
-//          results.add(visit(iField.type(), field, visitor));
-//          j++;
-//        }
-//      }
-//      return visitor.record(struct, record, names, results);
-//    }
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantArrayColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantArrayColumnVector.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class ConstantArrayColumnVector extends ConstantColumnVector {
+
+  private final Object[] constantArray;
+
+  public ConstantArrayColumnVector(DataType type, int batchSize, Object[] constantArray) {
+    super(type, batchSize, constantArray);
+    this.constantArray = constantArray;
+  }
+
+  @Override
+  public boolean getBoolean(int rowId) {
+    return (boolean) constantArray[rowId];
+  }
+
+  @Override
+  public byte getByte(int rowId) {
+    return (byte) constantArray[rowId];
+  }
+
+  @Override
+  public short getShort(int rowId) {
+    return (short) constantArray[rowId];
+  }
+
+  @Override
+  public int getInt(int rowId) {
+    return (int) constantArray[rowId];
+  }
+
+  @Override
+  public long getLong(int rowId) {
+    return (long) constantArray[rowId];
+  }
+
+  @Override
+  public float getFloat(int rowId) {
+    return (float) constantArray[rowId];
+  }
+
+  @Override
+  public double getDouble(int rowId) {
+    return (double) constantArray[rowId];
+  }
+
+  @Override
+  public ColumnarArray getArray(int rowId) {
+    return null;
+  }
+
+  @Override
+  public ColumnarMap getMap(int ordinal) {
+    return null;
+  }
+
+  @Override
+  public Decimal getDecimal(int rowId, int precision, int scale) {
+    return (Decimal) constantArray[rowId];
+  }
+
+  @Override
+  public UTF8String getUTF8String(int rowId) {
+    return (UTF8String) constantArray[rowId];
+  }
+
+  @Override
+  public byte[] getBinary(int rowId) {
+    return (byte[]) constantArray[rowId];
+  }
+
+  @Override
+  protected ColumnVector getChild(int ordinal) {
+    return null;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -51,6 +51,10 @@ class ConstantColumnVector extends ColumnVector {
     this.batchSize = batchSize;
   }
 
+  protected int getBatchSize() {
+    return batchSize;
+  }
+
   @Override
   public void close() {
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -21,7 +21,14 @@ package org.apache.iceberg.spark.data.vectorized;
 
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
@@ -34,6 +41,12 @@ class ConstantColumnVector extends ColumnVector {
 
   ConstantColumnVector(Type type, int batchSize, Object constant) {
     super(SparkSchemaUtil.convert(type));
+    this.constant = constant;
+    this.batchSize = batchSize;
+  }
+
+  ConstantColumnVector(DataType type, int batchSize, Object constant) {
+    super(type);
     this.constant = constant;
     this.batchSize = batchSize;
   }
@@ -94,12 +107,20 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public ColumnarArray getArray(int rowId) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    return new ColumnarArray(
+        new ConstantArrayColumnVector(((ArrayType) type).elementType(), batchSize,
+            ((ArrayData) constant).array()),
+        0,
+        ((ArrayData) constant).numElements());
   }
 
   @Override
   public ColumnarMap getMap(int ordinal) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    ColumnVector keys = new ConstantArrayColumnVector(((MapType) type).keyType(), batchSize,
+        ((MapData) constant).keyArray().array());
+    ColumnVector values = new ConstantArrayColumnVector(((MapType) type).valueType(), batchSize,
+        ((MapData) constant).valueArray().array());
+    return new ColumnarMap(keys, values, 0, ((MapData) constant).numElements());
   }
 
   @Override
@@ -119,6 +140,8 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   protected ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    DataType fieldType = ((StructType) type).fields()[ordinal].dataType();
+    return new ConstantColumnVector(fieldType, batchSize,
+        ((InternalRow) constant).get(ordinal, fieldType));
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -109,9 +109,6 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public UTF8String getUTF8String(int rowId) {
-    if (constant instanceof String) {
-      return UTF8String.fromString((String) constant);
-    }
     return (UTF8String) constant;
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -109,6 +109,9 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public UTF8String getUTF8String(int rowId) {
+    if (constant instanceof String) {
+      return UTF8String.fromString((String) constant);
+    }
     return (UTF8String) constant;
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -19,16 +19,16 @@
 
 package org.apache.iceberg.spark.data.vectorized;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.orc.OrcBatchReader;
-import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
-import org.apache.iceberg.orc.OrcValueReader;
-import org.apache.iceberg.orc.OrcValueReaders;
+import org.apache.iceberg.orc.*;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.OrcSchemaWithTypeVisitorSpark;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.SparkOrcValueReaders;
 import org.apache.iceberg.types.Type;
@@ -80,11 +80,10 @@ public class VectorizedSparkOrcReaders {
                          long batchOffsetInFile);
   }
 
-  private static class ReadBuilder extends OrcSchemaWithTypeVisitor<Converter> {
-    private final Map<Integer, ?> idToConstant;
+  private static class ReadBuilder extends OrcSchemaWithTypeVisitorSpark<Converter> {
 
     private ReadBuilder(Map<Integer, ?> idToConstant) {
-      this.idToConstant = idToConstant;
+      super(idToConstant);
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -19,14 +19,15 @@
 
 package org.apache.iceberg.spark.data.vectorized;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.orc.*;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.orc.OrcBatchReader;
+import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.OrcSchemaWithTypeVisitorSpark;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -89,7 +90,7 @@ public class VectorizedSparkOrcReaders {
     @Override
     public Converter record(Types.StructType iStruct, TypeDescription record, List<String> names,
                             List<Converter> fields) {
-      return new StructConverter(iStruct, fields, idToConstant);
+      return new StructConverter(iStruct, fields, getIdToConstant());
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -23,9 +23,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
@@ -40,19 +44,26 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.rdd.InputFileBlockHolder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
 
 /**
  * Base class of Spark readers.
  *
  * @param <T> is the Java class returned by this reader whose objects contain one or more rows.
  */
-abstract class BaseDataReader<T> implements Closeable {
+public abstract class BaseDataReader<T> implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseDataReader.class);
 
   private final Iterator<FileScanTask> tasks;
@@ -132,12 +143,34 @@ abstract class BaseDataReader<T> implements Closeable {
     return inputFiles.get(location);
   }
 
-  protected static Object convertConstant(Type type, Object value) {
+  public static Object convertConstant(Type type, Object value) {
     if (value == null) {
       return null;
     }
 
     switch (type.typeId()) {
+      case STRUCT:
+        Types.StructType structType = type.asStructType();
+        InternalRow ret = new GenericInternalRow(structType.fields().size());
+        for (int i = 0; i < structType.fields().size(); i++) {
+          Types.NestedField nestedField = structType.fields().get(i);
+          ret.update(i, convertConstant(nestedField.type(), ((Map<?, ?>) value).get(nestedField.name())));
+        }
+        return ret;
+      case LIST:
+        List<?> javaList = ((Collection<?>) value).stream()
+            .map(e -> convertConstant(type.asListType().elementType(), e)).collect(Collectors.toList());
+        return ArrayData.toArrayData(JavaConverters.collectionAsScalaIterableConverter(javaList).asScala().toSeq());
+      case MAP:
+        List<Object> keyList = new ArrayList<>();
+        List<Object> valueList = new ArrayList<>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+          keyList.add(convertConstant(type.asMapType().keyType(), entry.getKey()));
+          valueList.add(convertConstant(type.asMapType().valueType(), entry.getValue()));
+        }
+        return new ArrayBasedMapData(
+            new GenericArrayData(keyList.toArray()),
+            new GenericArrayData(valueList.toArray()));
       case DECIMAL:
         return Decimal.apply((BigDecimal) value);
       case STRING:

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderForFieldsWithDefaultValue.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderForFieldsWithDefaultValue.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.spark.data;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
@@ -38,95 +41,90 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Iterator;
 
 import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
 
 
 public class TestSparkOrcReaderForFieldsWithDefaultValue {
 
-    @Rule
-    public TemporaryFolder temp = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
 
-    @Test
-    public void testOrcDefaultValues() throws IOException {
-        final int NUM_ROWS = 10;
+  @Test
+  public void testOrcDefaultValues() throws IOException {
+    final int numRows = 10;
 
-        final InternalRow expectedFirstRow = new GenericInternalRow(2);
-        expectedFirstRow.update(0, 0);
-        expectedFirstRow.update(1, "foo");
+    final InternalRow expectedFirstRow = new GenericInternalRow(2);
+    expectedFirstRow.update(0, 0);
+    expectedFirstRow.update(1, "foo");
 
-        final InternalRow expectedFirstRowFromBatch = expectedFirstRow.copy();
-        expectedFirstRowFromBatch.update(1, UTF8String.fromString("foo"));
+    final InternalRow expectedFirstRowFromBatch = expectedFirstRow.copy();
+    expectedFirstRowFromBatch.update(1, UTF8String.fromString("foo"));
 
-        TypeDescription orcSchema =
-                TypeDescription.fromString("struct<col1:int>");
+    TypeDescription orcSchema =
+            TypeDescription.fromString("struct<col1:int>");
 
-        Schema readSchema = new Schema(
-                Types.NestedField.required(1, "col1", Types.IntegerType.get()),
-                Types.NestedField.required(2, "col2", Types.StringType.get(), "foo", null)
-        );
+    Schema readSchema = new Schema(
+            Types.NestedField.required(1, "col1", Types.IntegerType.get()),
+            Types.NestedField.required(2, "col2", Types.StringType.get(), "foo", null)
+    );
 
-        Configuration conf = new Configuration();
+    Configuration conf = new Configuration();
 
-        File orcFile = temp.newFile();
-        Path orcFilePath = new Path(orcFile.getPath());
+    File orcFile = temp.newFile();
+    Path orcFilePath = new Path(orcFile.getPath());
 
-        Writer writer = OrcFile.createWriter(orcFilePath,
-                OrcFile.writerOptions(conf).setSchema(orcSchema).overwrite(true));
+    Writer writer = OrcFile.createWriter(orcFilePath,
+            OrcFile.writerOptions(conf).setSchema(orcSchema).overwrite(true));
 
-        VectorizedRowBatch batch = orcSchema.createRowBatch();
-        LongColumnVector firstCol =  (LongColumnVector) batch.cols[0];
-        for(int r=0; r < NUM_ROWS; ++r) {
-            int row = batch.size++;
-            firstCol.vector[row] = r;
-            // If the batch is full, write it out and start over.
-            if (batch.size == batch.getMaxSize()) {
-                writer.addRowBatch(batch);
-                batch.reset();
-            }
-        }
-        if (batch.size != 0) {
-            writer.addRowBatch(batch);
-            batch.reset();
-        }
-        writer.close();
+    VectorizedRowBatch batch = orcSchema.createRowBatch();
+    LongColumnVector firstCol = (LongColumnVector) batch.cols[0];
+    for (int r = 0; r < numRows; ++r) {
+      int row = batch.size++;
+      firstCol.vector[row] = r;
+      // If the batch is full, write it out and start over.
+      if (batch.size == batch.getMaxSize()) {
+        writer.addRowBatch(batch);
+        batch.reset();
+      }
+    }
+    if (batch.size != 0) {
+      writer.addRowBatch(batch);
+      batch.reset();
+    }
+    writer.close();
 
-        // try to read the data using the readSchema, which is an evolved
-        // schema that contains a new column with default value
+    // try to read the data using the readSchema, which is an evolved
+    // schema that contains a new column with default value
 
-        // non-vectorized read
-        try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
-                .project(readSchema)
-                .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
-                .build()) {
-            final Iterator<InternalRow> actualRows = reader.iterator();
-            final InternalRow actualFirstRow =  actualRows.next();
+    // non-vectorized read
+    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
+            .project(readSchema)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
+            .build()) {
+      final Iterator<InternalRow> actualRows = reader.iterator();
+      final InternalRow actualFirstRow = actualRows.next();
 
-            assertEquals(readSchema, expectedFirstRow, actualFirstRow);
-        }
-
-        // vectorized-read
-        try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
-                .project(readSchema)
-                .createBatchedReaderFunc(readOrcSchema ->
-                        VectorizedSparkOrcReaders.buildReader(readSchema, readOrcSchema, ImmutableMap.of()))
-                .build()) {
-            final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
-            final InternalRow actualFirstRow = actualRows.next();
-
-            assertEquals(readSchema, expectedFirstRowFromBatch, actualFirstRow);
-        }
+      assertEquals(readSchema, expectedFirstRow, actualFirstRow);
     }
 
-    private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
-        return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
+    // vectorized-read
+    try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+            .project(readSchema)
+            .createBatchedReaderFunc(readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(readSchema, readOrcSchema, ImmutableMap.of()))
+            .build()) {
+      final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
+      final InternalRow actualFirstRow = actualRows.next();
+
+      assertEquals(readSchema, expectedFirstRowFromBatch, actualFirstRow);
     }
+  }
+
+  private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
+    return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
+  }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderForFieldsWithDefaultValue.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderForFieldsWithDefaultValue.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+
+import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
+
+
+public class TestSparkOrcReaderForFieldsWithDefaultValue {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void testOrcDefaultValues() throws IOException {
+        final int NUM_ROWS = 10;
+
+        final InternalRow expectedFirstRow = new GenericInternalRow(2);
+        expectedFirstRow.update(0, 0);
+        expectedFirstRow.update(1, "foo");
+
+        TypeDescription orcSchema =
+                TypeDescription.fromString("struct<col1:int>");
+
+        Schema readSchema = new Schema(
+                Types.NestedField.required(1, "col1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "col2", Types.StringType.get(), "foo", null)
+        );
+
+        Configuration conf = new Configuration();
+
+        File orcFile = temp.newFile();
+        Path orcFilePath = new Path(orcFile.getPath());
+
+        Writer writer = OrcFile.createWriter(orcFilePath,
+                OrcFile.writerOptions(conf).setSchema(orcSchema).overwrite(true));
+
+        VectorizedRowBatch batch = orcSchema.createRowBatch();
+        LongColumnVector firstCol =  (LongColumnVector) batch.cols[0];
+        for(int r=0; r < NUM_ROWS; ++r) {
+            int row = batch.size++;
+            firstCol.vector[row] = r;
+            // If the batch is full, write it out and start over.
+            if (batch.size == batch.getMaxSize()) {
+                writer.addRowBatch(batch);
+                batch.reset();
+            }
+        }
+        if (batch.size != 0) {
+            writer.addRowBatch(batch);
+            batch.reset();
+        }
+        writer.close();
+
+        // try to read the data using the readSchema, which is an evolved
+        // schema that contains a new column with default value
+
+        // non-batch read
+        try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
+                .project(readSchema)
+                .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
+                .build()) {
+            final Iterator<InternalRow> actualRows = reader.iterator();
+            final InternalRow actualFirstRow =  actualRows.next();
+
+            assertEquals(readSchema, expectedFirstRow, actualFirstRow);
+        }
+
+        // batch-read
+//        try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+//                .project(readSchema)
+//                .createBatchedReaderFunc(readOrcSchema ->
+//                        VectorizedSparkOrcReaders.buildReader(readSchema, readOrcSchema, ImmutableMap.of()))
+//                .build()) {
+//            final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
+//            final InternalRow actualFirstRow = actualRows.next();
+//
+//            assertEquals(readSchema, expectedFirstRow, actualFirstRow);
+//        }
+    }
+
+    private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
+        return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
+    }
+}


### PR DESCRIPTION
This PR supports default value read for ORC format for Spark, based on the previous default value semantics support in #75.

During schema evolution, when there's an added field with the default value (regardless of required or optional field), the reader should return the default value for the field when reading the data files written with the previous schema (that doesn't contain this field).

When there's no schema evolution (i.e. when the field exists in the data file itself) and there's a default value for the field, the value written in the file should be read instead of the default value.