### PR TITLE
Support Date and Timestamp hive type partition columns in LegacyHiveT…

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
@@ -36,7 +36,6 @@ import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.or;
 import static org.apache.iceberg.hive.legacy.HiveExpressions.simplifyPartitionFilter;
-import static org.apache.iceberg.hive.legacy.HiveExpressions.toPartitionFilterString;
 
 
 public class TestHiveExpressions {
@@ -117,11 +116,5 @@ public class TestHiveExpressions {
     Expression input = not(and(equal("nonpcol", "1"), equal("pcol", "1")));
     Expression expected = alwaysTrue();
     Assert.assertEquals(expected.toString(), simplifyPartitionFilter(input, ImmutableSet.of("pcol")).toString());
-  }
-
-  @Test
-  public void testToPartitionFilterStringEscapeStringLiterals() {
-    Expression input = equal("pcol", "s'1");
-    Assert.assertEquals("( pcol = 's\\'1' )", toPartitionFilterString(input));
   }
 }


### PR DESCRIPTION
Previously, `LegacyHiveTableScan` only supports hive partition columns of string type, this patch leverage the `Binder` to augment the expressions (literals) with their corresponding types information and feed it to `ExpressionToPartitionFilterString`, thus has the power to handle different partition column types such as `Timestamp` and `Date`.

After this patch, iceberg can support reading partitioned tables in our existing hive metastore which has `date` and `timestamp` typed partition columns.