### PR TITLE
Support hive non string partition cols

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/And.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/And.java
@@ -60,7 +60,7 @@ public class And implements Expression, Bound<Boolean> {
     Preconditions.checkNotNull(left, "Left expression cannot be null.");
     Preconditions.checkNotNull(right, "Right expression cannot be null.");
     if (!(left instanceof Bound) || !(right instanceof Bound)) {
-      throw new IllegalStateException("Bound predicate not expected");
+      throw new IllegalStateException("Unbound predicate not expected");
     }
     return ((Bound<Boolean>) left).eval(struct) && ((Bound<Boolean>) right).eval(struct);
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/And.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/And.java
@@ -19,7 +19,10 @@
 
 package org.apache.iceberg.expressions;
 
-public class And implements Expression {
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class And implements Expression, Bound<Boolean> {
   private final Expression left;
   private final Expression right;
 
@@ -45,6 +48,21 @@ public class And implements Expression {
   public Expression negate() {
     // not(and(a, b)) => or(not(a), not(b))
     return Expressions.or(left.negate(), right.negate());
+  }
+
+  @Override
+  public BoundReference<?> ref() {
+    return null;
+  }
+
+  @Override
+  public Boolean eval(StructLike struct) {
+    Preconditions.checkNotNull(left, "Left expression cannot be null.");
+    Preconditions.checkNotNull(right, "Right expression cannot be null.");
+    if (!(left instanceof Bound) || !(right instanceof Bound)) {
+      throw new IllegalStateException("Bound predicate not expected");
+    }
+    return ((Bound<Boolean>) left).eval(struct) && ((Bound<Boolean>) right).eval(struct);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Or.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Or.java
@@ -19,7 +19,10 @@
 
 package org.apache.iceberg.expressions;
 
-public class Or implements Expression {
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class Or implements Expression, Bound<Boolean> {
   private final Expression left;
   private final Expression right;
 
@@ -45,6 +48,21 @@ public class Or implements Expression {
   public Expression negate() {
     // not(or(a, b)) => and(not(a), not(b))
     return Expressions.and(left.negate(), right.negate());
+  }
+
+  @Override
+  public BoundReference<?> ref() {
+    return null;
+  }
+
+  @Override
+  public Boolean eval(StructLike struct) {
+    Preconditions.checkNotNull(left, "Left expression cannot be null.");
+    Preconditions.checkNotNull(right, "Right expression cannot be null.");
+    if (!(left instanceof Bound) || !(right instanceof Bound)) {
+      throw new IllegalStateException("Bound predicate not expected");
+    }
+    return ((Bound<Boolean>) left).eval(struct) || ((Bound<Boolean>) right).eval(struct);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Or.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Or.java
@@ -60,7 +60,7 @@ public class Or implements Expression, Bound<Boolean> {
     Preconditions.checkNotNull(left, "Left expression cannot be null.");
     Preconditions.checkNotNull(right, "Right expression cannot be null.");
     if (!(left instanceof Bound) || !(right instanceof Bound)) {
-      throw new IllegalStateException("Bound predicate not expected");
+      throw new IllegalStateException("Unbound predicate not expected");
     }
     return ((Bound<Boolean>) left).eval(struct) || ((Bound<Boolean>) right).eval(struct);
   }

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -71,6 +71,8 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveExpressions.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveExpressions.java
@@ -326,14 +326,8 @@ class HiveExpressions {
 
     private <T> String getLiteralValue(Literal<T> lit, Type type) {
       Object value = lit.value();
-      switch (type.typeId()) {
-        case DATE:
-          value = EPOCH.plus((Integer) value, ChronoUnit.DAYS).toLocalDate().toString();
-          break;
-        case TIMESTAMP:
-          // This format seems to be matching the hive timestamp column partition string literal value
-          value = EPOCH.plus((Long) value, ChronoUnit.MICROS).toLocalDateTime().toString().replace('T', ' ');
-          break;
+      if (type.typeId() == Type.TypeID.DATE) {
+        value = EPOCH.plus((Integer) value, ChronoUnit.DAYS).toLocalDate().toString();
       }
       if (value instanceof String) {
         String escapedString = ((String) value).replace("'", "\\'");

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveExpressions.java
@@ -36,7 +36,6 @@ import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.or;
 import static org.apache.iceberg.hive.legacy.HiveExpressions.simplifyPartitionFilter;
-import static org.apache.iceberg.hive.legacy.HiveExpressions.toPartitionFilterString;
 
 
 public class TestHiveExpressions {
@@ -117,11 +116,5 @@ public class TestHiveExpressions {
     Expression input = not(and(equal("nonpcol", "1"), equal("pcol", "1")));
     Expression expected = alwaysTrue();
     Assert.assertEquals(expected.toString(), simplifyPartitionFilter(input, ImmutableSet.of("pcol")).toString());
-  }
-
-  @Test
-  public void testToPartitionFilterStringEscapeStringLiterals() {
-    Expression input = equal("pcol", "s'1");
-    Assert.assertEquals("( pcol = 's\\'1' )", toPartitionFilterString(input));
   }
 }


### PR DESCRIPTION
Previously, `LegacyHiveTableScan` only supports hive partition columns of string type.
This patch leverages the `Binder` to augment the expressions (literals) with their corresponding types of information and feed it to `ExpressionToPartitionFilterString`, thus handling different partition column types such as `Timestamp` and `Date`.
It also adds a fall-back filtering strategy when the HMS `listPartitionsByFilter` call failed because of non-string type partition columns, by first listing all partitions from HMS, and then do the filtering ourselves by evaluating each partition against the partitions filter `BoundExpression`.

After this patch, Iceberg can support reading partitioned tables in our existing hive metastore which has `date`, `timestamp`, `int`, `varchar(n)`, `char(n)` typed partition columns.

This PR covers all the features introduced in #77, so will close #77 now.