### PR TITLE
Accomodate for HiveConf overwriting defaults in copy constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
   repositories {
     jcenter()
     gradlePluginPortal()
-    maven { url "http://palantir.bintray.com/releases" }
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
@@ -64,7 +63,6 @@ allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
   repositories {
-    maven { url  "http://palantir.bintray.com/releases" }
     mavenCentral()
     mavenLocal()
   }
@@ -629,7 +627,7 @@ project(':iceberg-hive-runtime') {
       exclude group: 'com.github.stephenc.findbugs'
       exclude group: 'commons-pool'
       exclude group: 'javax.annotation'
-      exclude group: 'javax.xml.bind'      
+      exclude group: 'javax.xml.bind'
       exclude group: 'org.apache.commons'
       exclude group: 'org.slf4j'
       exclude group: 'org.xerial.snappy'
@@ -642,7 +640,7 @@ project(':iceberg-hive-runtime') {
       compile project(':iceberg-hive3')
     }
   }
-  
+
   shadowJar {
     configurations = [project.configurations.compile]
 
@@ -656,7 +654,7 @@ project(':iceberg-hive-runtime') {
 
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'  
+    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
     relocate 'com.google', 'org.apache.iceberg.shaded.com.google'
     relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
     relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -45,6 +45,11 @@ public class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> 
   public HiveClientPool(int poolSize, Configuration conf) {
     super(poolSize, TTransportException.class);
     this.hiveConf = new HiveConf(conf, HiveClientPool.class);
+    // hiveConf currently overwrites all things that are defaults in configuration so we need it again
+    // current codebase in hive doesn't run into this because they do Hive x = new Hive(); x.addResource() and
+    // don't use copy constructor
+    // there is value in using copying constructor because it keeps more debugging information in the reference
+    this.hiveConf.addResource(conf);
   }
 
   @Override


### PR DESCRIPTION
This unblocks an internal error: https://jira01.corp.linkedin.com:8443/browse/BDP-7063

Main thing here is that depending on the default HiveConfVars, HiveConf can overwrite your defaults. So, for example, if "hive.metastore.sasl.enabled" is true in configuration, when passed to HiveConf, it can return false (tested using debugger). 

Test Plan: wrote a unit test but turns out that it's dependent on the
HiveConf.ConfVars you have on the classpath so it was difficult to get
it right. So, ended up testing on the azkaban cluster manually