### PR TITLE
Fix spark avro reader reading union schema data

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -52,8 +52,21 @@ public abstract class AvroSchemaVisitor<T> {
       case UNION:
         List<Schema> types = schema.getTypes();
         List<T> options = Lists.newArrayListWithExpectedSize(types.size());
-        for (Schema type : types) {
-          options.add(visit(type, visitor));
+        if (AvroSchemaUtil.isOptionSchema(schema)) {
+          for (Schema type : types) {
+            options.add(visit(type, visitor));
+          }
+        } else {
+          int i = 0;
+          // complex union case
+          for (Schema type : types) {
+            if (type.getType() != Schema.Type.NULL) {
+              options.add(visitWithName("tag_"+i, type, visitor));
+              i += 1;
+            } else {
+              options.add(visit(type, visitor));
+            }
+          }
         }
         return visitor.union(schema, options);
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -57,12 +57,12 @@ public abstract class AvroSchemaVisitor<T> {
             options.add(visit(type, visitor));
           }
         } else {
-          int i = 0;
           // complex union case
+          int idx = 0;
           for (Schema type : types) {
             if (type.getType() != Schema.Type.NULL) {
-              options.add(visitWithName("tag_"+i, type, visitor));
-              i += 1;
+              options.add(visitWithName("tag_" + idx, type, visitor));
+              idx += 1;
             } else {
               options.add(visit(type, visitor));
             }

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -125,7 +125,6 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       return null;
     } else {
       // Complex union case
-//      return Schema.createUnion(options);
       return copyUnion(union, options);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -299,10 +299,13 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     return AvroSchemaUtil.isOptionSchema(schema) && schema.getTypes().get(0).getType() != Schema.Type.NULL;
   }
 
+  // for primitive types, the visitResult will be null, we want to reuse the primitive types from the original
+  // schema, while for nested types, we want to use the visitResult because they have content from the previous
+  // recursive calls.
   private static Schema copyUnion(Schema record, List<Schema> visitResults) {
     List<Schema> alts = Lists.newArrayListWithExpectedSize(visitResults.size());
     for (int i = 0; i < visitResults.size(); i++) {
-      if (visitResults.get(0) == null) {
+      if (visitResults.get(i) == null) {
         alts.add(record.getTypes().get(i));
       } else {
         alts.add(visitResults.get(i));

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -125,9 +125,11 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       return null;
     } else {
       // Complex union case
-      return union;
+//      return Schema.createUnion(options);
+      return copyUnion(union, options);
     }
   }
+
 
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
@@ -296,5 +298,17 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
 
   private static boolean isOptionSchemaWithNonNullFirstOption(Schema schema) {
     return AvroSchemaUtil.isOptionSchema(schema) && schema.getTypes().get(0).getType() != Schema.Type.NULL;
+  }
+
+  private static Schema copyUnion(Schema record, List<Schema> visitResults) {
+    List<Schema> alts = Lists.newArrayListWithExpectedSize(visitResults.size());
+    for (int i = 0; i < visitResults.size(); i++) {
+      if (visitResults.get(0) == null) {
+        alts.add(record.getTypes().get(i));
+      } else {
+        alts.add(visitResults.get(i));
+      }
+    }
+    return Schema.createUnion(alts);
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -83,7 +83,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
       if (AvroSchemaUtil.isOptionSchema(union)) {
         return ValueReaders.union(options);
       } else {
-        return SparkValueReaders.union(options);
+        return SparkValueReaders.union(union, options);
       }
     }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -323,11 +323,15 @@ public class SparkValueReaders {
 
       int index = decoder.readIndex();
       Object value = this.readers[index].read(decoder, reuse);
-      if (nullIndex >= 0 && index > nullIndex) {
-        struct.update(index - 1, value);
-      } else {
+
+      if (nullIndex < 0) {
         struct.update(index, value);
+      } else if (index < nullIndex) {
+        struct.update(index, value);
+      } else if (index > nullIndex) {
+        struct.update(index - 1, value);
       }
+
       return struct;
     }
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.data;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.avro.SchemaBuilder;
@@ -108,7 +107,6 @@ public class TestSparkAvroUnions {
     unionRecord1.put("unionCol", "foo");
     GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
     unionRecord2.put("unionCol", 1);
-    List<GenericData.Record> expectedRows = new ArrayList<>();
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -196,7 +194,7 @@ public class TestSparkAvroUnions {
     GenericData.Record unionRecord1 = new GenericData.Record(avroSchema);
     unionRecord1.put("col1", Arrays.asList("foo", 1));
     GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
-    unionRecord2.put("col1",  Arrays.asList(2, "bar"));
+    unionRecord2.put("col1", Arrays.asList(2, "bar"));
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -250,10 +248,11 @@ public class TestSparkAvroUnions {
         .endRecord();
 
     GenericData.Record outer = new GenericData.Record(avroSchema);
-    GenericData.Record inner = new GenericData.Record(avroSchema.getFields().get(0).schema().getElementType().getTypes().get(0));
+    GenericData.Record inner = new GenericData.Record(avroSchema.getFields().get(0).schema()
+        .getElementType().getTypes().get(0));
 
     inner.put("id", 1);
-    outer.put("col1",  Arrays.asList(inner));
+    outer.put("col1", Arrays.asList(inner));
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -272,7 +271,7 @@ public class TestSparkAvroUnions {
       rows = Lists.newArrayList(reader);
 
       // making sure it reads the correctly nested structured data, based on the transformation from union to struct
-      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 2).getStruct(0,1).getInt(0));
+      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 2).getStruct(0, 1).getInt(0));
     }
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
@@ -82,8 +82,13 @@ public class TestSparkAvroUnions {
         .build()) {
       rows = Lists.newArrayList(reader);
 
+      Assert.assertEquals(2, rows.get(0).getStruct(0, 2).numFields());
+      Assert.assertTrue(rows.get(0).getStruct(0, 2).isNullAt(0));
       Assert.assertEquals("foo", rows.get(0).getStruct(0, 2).getString(1));
+
+      Assert.assertEquals(2, rows.get(1).getStruct(0, 2).numFields());
       Assert.assertEquals(1, rows.get(1).getStruct(0, 2).getInt(0));
+      Assert.assertTrue(rows.get(1).getStruct(0, 2).isNullAt(1));
     }
   }
 
@@ -107,6 +112,8 @@ public class TestSparkAvroUnions {
     unionRecord1.put("unionCol", "foo");
     GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
     unionRecord2.put("unionCol", 1);
+    GenericData.Record unionRecord3 = new GenericData.Record(avroSchema);
+    unionRecord3.put("unionCol", null);
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -115,6 +122,7 @@ public class TestSparkAvroUnions {
       writer.create(avroSchema, testFile);
       writer.append(unionRecord1);
       writer.append(unionRecord2);
+      writer.append(unionRecord3);
     }
 
     Schema expectedSchema = AvroSchemaUtil.toIceberg(avroSchema);
@@ -128,6 +136,8 @@ public class TestSparkAvroUnions {
 
       Assert.assertEquals("foo", rows.get(0).getStruct(0, 2).getString(1));
       Assert.assertEquals(1, rows.get(1).getStruct(0, 2).getInt(0));
+      Assert.assertTrue(rows.get(2).getStruct(0, 2).isNullAt(0));
+      Assert.assertTrue(rows.get(2).getStruct(0, 2).isNullAt(1));
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
@@ -108,7 +108,6 @@ public class TestSparkAvroUnions {
     unionRecord1.put("unionCol", "foo");
     GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
     unionRecord2.put("unionCol", 1);
-    List<GenericData.Record> expectedRows = new ArrayList<>();
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -196,7 +195,7 @@ public class TestSparkAvroUnions {
     GenericData.Record unionRecord1 = new GenericData.Record(avroSchema);
     unionRecord1.put("col1", Arrays.asList("foo", 1));
     GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
-    unionRecord2.put("col1",  Arrays.asList(2, "bar"));
+    unionRecord2.put("col1", Arrays.asList(2, "bar"));
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -250,10 +249,11 @@ public class TestSparkAvroUnions {
         .endRecord();
 
     GenericData.Record outer = new GenericData.Record(avroSchema);
-    GenericData.Record inner = new GenericData.Record(avroSchema.getFields().get(0).schema().getElementType().getTypes().get(0));
+    GenericData.Record inner = new GenericData.Record(avroSchema.getFields().get(0).schema()
+        .getElementType().getTypes().get(0));
 
     inner.put("id", 1);
-    outer.put("col1",  Arrays.asList(inner));
+    outer.put("col1", Arrays.asList(inner));
 
     File testFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", testFile.delete());
@@ -272,7 +272,7 @@ public class TestSparkAvroUnions {
       rows = Lists.newArrayList(reader);
 
       // making sure it reads the correctly nested structured data, based on the transformation from union to struct
-      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 2).getStruct(0,1).getInt(0));
+      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 2).getStruct(0, 1).getInt(0));
     }
   }
 }


### PR DESCRIPTION
This PR fixes 2 implementation issues in #73 

1. The previous implementation doesn't handle return values correctly when there is a `null` element in the union, like `[null, int, string]`, it returned a struct data of `[null, 1, null` instead of just `[1, null]`, this PR fixes it.
2. The previous implementation doesn't decorate the internal Avro schema with correct mapped field-ids, when there's nested complex data types inside the union, because the union to struct conversion create another layer of a struct that contains several fields, each of which has a new field name and brings in a new namespace, this PR is fixing that.