### PR TITLE
Avro: Change union read schema from hive to trino

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -61,7 +61,7 @@ public abstract class AvroSchemaVisitor<T> {
           int idx = 0;
           for (Schema type : types) {
             if (type.getType() != Schema.Type.NULL) {
-              options.add(visitWithName("tag_" + idx, type, visitor));
+              options.add(visitWithName("field" + idx, type, visitor));
               idx += 1;
             } else {
               options.add(visit(type, visitor));

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -80,17 +80,24 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
     List<Schema> types = union.getTypes();
     List<T> options = Lists.newArrayListWithExpectedSize(types.size());
 
-    int index = 0;
-    for (Schema branch : types) {
-      if (branch.getType() == Schema.Type.NULL) {
-        options.add(visit((Type) null, branch, visitor));
-      } else {
-        if (AvroSchemaUtil.isOptionSchema(union)) {
+    // simple union case
+    if (AvroSchemaUtil.isOptionSchema(union)) {
+      for (Schema branch : types) {
+        if (branch.getType() == Schema.Type.NULL) {
+          options.add(visit((Type) null, branch, visitor));
+        } else {
           options.add(visit(type, branch, visitor));
+        }
+      }
+    } else { // complex union case
+      int index = 1;
+      for (Schema branch : types) {
+        if (branch.getType() == Schema.Type.NULL) {
+          options.add(visit((Type) null, branch, visitor));
         } else {
           options.add(visit(type.asStructType().fields().get(index).type(), branch, visitor));
+          index += 1;
         }
-        index++;
       }
     }
     return visitor.union(type, union, options);

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.avro;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
@@ -116,12 +117,13 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       }
     } else {
       // Complex union
-      List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(options.size());
+      List<Types.NestedField> newFields = new ArrayList<>();
+      newFields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
 
       int tagIndex = 0;
       for (Type type : options) {
         if (type != null) {
-          newFields.add(Types.NestedField.optional(allocateId(), "tag_" + tagIndex++, type));
+          newFields.add(Types.NestedField.optional(allocateId(), "field" + tagIndex++, type));
         }
       }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestUnionSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestUnionSchemaConversions.java
@@ -25,7 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 
-public class TestAvroComplexUnion {
+public class TestUnionSchemaConversions {
 
   @Test
   public void testRequiredComplexUnion() {
@@ -43,7 +43,8 @@ public class TestAvroComplexUnion {
 
     org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
     String expectedIcebergSchema = "table {\n" +
-        "  0: unionCol: required struct<1: tag_0: optional int, 2: tag_1: optional string>\n" + "}";
+        "  0: unionCol: required struct<1: tag: required int, 2: field0: optional int, 3: field1: optional string>\n" +
+        "}";
 
     Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
   }
@@ -65,32 +66,15 @@ public class TestAvroComplexUnion {
         .endRecord();
 
     org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
-    String expectedIcebergSchema =
-        "table {\n" + "  0: unionCol: optional struct<1: tag_0: optional int, 2: tag_1: optional string>\n" + "}";
+    String expectedIcebergSchema = "table {\n" +
+        "  0: unionCol: optional struct<1: tag: required int, 2: field0: optional int, 3: field1: optional string>\n" +
+        "}";
 
     Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
   }
 
   @Test
-  public void testSingleComponentUnion() {
-    Schema avroSchema = SchemaBuilder.record("root")
-        .fields()
-        .name("unionCol")
-        .type()
-        .unionOf()
-        .intType()
-        .endUnion()
-        .noDefault()
-        .endRecord();
-
-    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
-    String expectedIcebergSchema = "table {\n" + "  0: unionCol: required struct<1: tag_0: optional int>\n" + "}";
-
-    Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
-  }
-
-  @Test
-  public void testOptionSchema() {
+  public void testSimpleUnionSchema() {
     Schema avroSchema = SchemaBuilder.record("root")
         .fields()
         .name("optionCol")
@@ -105,24 +89,6 @@ public class TestAvroComplexUnion {
 
     org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
     String expectedIcebergSchema = "table {\n" + "  0: optionCol: optional int\n" + "}";
-
-    Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
-  }
-
-  @Test
-  public void testNullUnionSchema() {
-    Schema avroSchema = SchemaBuilder.record("root")
-        .fields()
-        .name("nullUnionCol")
-        .type()
-        .unionOf()
-        .nullType()
-        .endUnion()
-        .noDefault()
-        .endRecord();
-
-    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
-    String expectedIcebergSchema = "table {\n" + "  0: nullUnionCol: optional struct<>\n" + "}";
 
     Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -83,7 +83,7 @@ public class SparkValueReaders {
     return new StructReader(readers, struct, idToConstant);
   }
 
-  static ValueReader<Object> union(Schema schema, List<ValueReader<?>> readers) {
+  static ValueReader<InternalRow> union(Schema schema, List<ValueReader<?>> readers) {
     return new UnionReader(schema, readers);
   }
 
@@ -292,7 +292,7 @@ public class SparkValueReaders {
     }
   }
 
-  private static class UnionReader implements ValueReader<Object> {
+  private static class UnionReader implements ValueReader<InternalRow> {
     private final Schema schema;
     private final ValueReader[] readers;
 
@@ -305,7 +305,7 @@ public class SparkValueReaders {
     }
 
     @Override
-    public Object read(Decoder decoder, Object reuse) throws IOException {
+    public InternalRow read(Decoder decoder, Object reuse) throws IOException {
       // first we need to filter out NULL alternative if it exists in the union schema
       int nullIndex = -1;
       List<Schema> alts = schema.getTypes();
@@ -320,7 +320,7 @@ public class SparkValueReaders {
       int index = decoder.readIndex();
       if (index == nullIndex) {
         // if it is a null data, directly return null as the whole union result
-        return readers[index].read(decoder, reuse);
+        return null;
       }
 
       // otherwise, we need to return an InternalRow as a struct data

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
@@ -65,8 +65,6 @@ public class TestSparkAvroUnions {
     unionRecord2.put("unionCol", 1);
 
     File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
     try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
       writer.append(unionRecord1);
@@ -82,13 +80,15 @@ public class TestSparkAvroUnions {
         .build()) {
       rows = Lists.newArrayList(reader);
 
-      Assert.assertEquals(2, rows.get(0).getStruct(0, 2).numFields());
-      Assert.assertTrue(rows.get(0).getStruct(0, 2).isNullAt(0));
-      Assert.assertEquals("foo", rows.get(0).getStruct(0, 2).getString(1));
+      Assert.assertEquals(3, rows.get(0).getStruct(0, 3).numFields());
+      Assert.assertEquals(1, rows.get(0).getStruct(0, 3).getInt(0));
+      Assert.assertTrue(rows.get(0).getStruct(0, 3).isNullAt(1));
+      Assert.assertEquals("foo", rows.get(0).getStruct(0, 3).getString(2));
 
-      Assert.assertEquals(2, rows.get(1).getStruct(0, 2).numFields());
-      Assert.assertEquals(1, rows.get(1).getStruct(0, 2).getInt(0));
-      Assert.assertTrue(rows.get(1).getStruct(0, 2).isNullAt(1));
+      Assert.assertEquals(3, rows.get(1).getStruct(0, 3).numFields());
+      Assert.assertEquals(0, rows.get(1).getStruct(0, 3).getInt(0));
+      Assert.assertEquals(1, rows.get(1).getStruct(0, 3).getInt(1));
+      Assert.assertTrue(rows.get(1).getStruct(0, 3).isNullAt(2));
     }
   }
 
@@ -116,8 +116,6 @@ public class TestSparkAvroUnions {
     unionRecord3.put("unionCol", null);
 
     File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
     try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
       writer.append(unionRecord1);
@@ -134,10 +132,9 @@ public class TestSparkAvroUnions {
         .build()) {
       rows = Lists.newArrayList(reader);
 
-      Assert.assertEquals("foo", rows.get(0).getStruct(0, 2).getString(1));
-      Assert.assertEquals(1, rows.get(1).getStruct(0, 2).getInt(0));
-      Assert.assertTrue(rows.get(2).getStruct(0, 2).isNullAt(0));
-      Assert.assertTrue(rows.get(2).getStruct(0, 2).isNullAt(1));
+      Assert.assertEquals("foo", rows.get(0).getStruct(0, 3).getString(2));
+      Assert.assertEquals(1, rows.get(1).getStruct(0, 3).getInt(1));
+      Assert.assertTrue(rows.get(2).isNullAt(0));
     }
   }
 
@@ -161,8 +158,6 @@ public class TestSparkAvroUnions {
     unionRecord2.put("unionCol", 1);
 
     File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
     try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
       writer.append(unionRecord1);
@@ -207,8 +202,6 @@ public class TestSparkAvroUnions {
     unionRecord2.put("col1", Arrays.asList(2, "bar"));
 
     File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
     try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
       writer.append(unionRecord1);
@@ -225,7 +218,7 @@ public class TestSparkAvroUnions {
       rows = Lists.newArrayList(reader);
 
       // making sure it reads the correctly nested structured data, based on the transformation from union to struct
-      Assert.assertEquals("foo", rows.get(0).getArray(0).getStruct(0, 2).getString(1));
+      Assert.assertEquals("foo", rows.get(0).getArray(0).getStruct(0, 3).getString(2));
     }
   }
 
@@ -265,8 +258,6 @@ public class TestSparkAvroUnions {
     outer.put("col1", Arrays.asList(inner));
 
     File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
-
     try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
       writer.create(avroSchema, testFile);
       writer.append(outer);
@@ -281,7 +272,7 @@ public class TestSparkAvroUnions {
       rows = Lists.newArrayList(reader);
 
       // making sure it reads the correctly nested structured data, based on the transformation from union to struct
-      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 2).getStruct(0, 1).getInt(0));
+      Assert.assertEquals(1, rows.get(0).getArray(0).getStruct(0, 3).getStruct(1, 1).getInt(0));
     }
   }
 }


### PR DESCRIPTION
This rb changes the avro spark reader code path to read a union data type of `[int, string]` to a spark schema/data of `[tag, field0, field1]` instead of the previous `[tag_0, tag_1]`.
it also fixed an issue that when the avro union is a null, the reader should return a plain `null` instead of `[0, null, null]` or `[null, null]` (as the previous schema did).