### PR TITLE
ORC: Change union read schema from hive to trino

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveTypeToIcebergType.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/legacy/HiveTypeToIcebergType.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.types.Types;
 
 
 public class HiveTypeToIcebergType extends HiveTypeUtil.HiveSchemaVisitor<Type> {
-  private static final String UNION_TO_STRUCT_CONVERSION_PREFIX = "tag_";
+  private static final String UNION_TO_STRUCT_CONVERSION_PREFIX = "field";
   private int nextId = 1;
 
   @Override
@@ -57,7 +57,8 @@ public class HiveTypeToIcebergType extends HiveTypeUtil.HiveSchemaVisitor<Type> 
   // Mimic the struct call behavior to construct a union converted struct type
   @Override
   public Type union(UnionTypeInfo union, List<Type> unionResults) {
-    List<Types.NestedField> fields = Lists.newArrayListWithExpectedSize(unionResults.size());
+    List<Types.NestedField> fields = Lists.newArrayListWithExpectedSize(unionResults.size() + 1);
+    fields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
     for (int i = 0; i < unionResults.size(); i++) {
       fields.add(Types.NestedField.optional(allocateId(), UNION_TO_STRUCT_CONVERSION_PREFIX + i, unionResults.get(i)));
     }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveSchemaConversions.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/legacy/TestHiveSchemaConversions.java
@@ -80,7 +80,7 @@ public class TestHiveSchemaConversions {
           "struct<" +
               "length:int,count:int,list:array<struct<lastword:string,lastwordlength:int>>," +
               "wordcounts:map<string,int>>");
-    check("struct<1: tag_0: optional int, 2: tag_1: optional string>", "uniontype<int,string>");
+    check("struct<1: tag: required int, 2: field0: optional int, 3: field1: optional string>", "uniontype<int,string>");
   }
 
   private static void check(String icebergTypeStr, String hiveTypeStr) {

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -311,9 +311,11 @@ public final class ORCSchemaUtil {
       Map<Integer, OrcField> mapping) {
     TypeDescription orcType;
     OrcField orcField = mapping.getOrDefault(fieldId, null);
+    // this branch means the iceberg struct schema actually correspond to an underlying union
     if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
       orcType = TypeDescription.createUnion();
-      for (Types.NestedField nestedField : type.asStructType().fields()) {
+      List<Types.NestedField> nestedFields = type.asStructType().fields();
+      for (Types.NestedField nestedField : nestedFields.subList(1, nestedFields.size())) {
         TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),
             isRequired && nestedField.isRequired(), mapping);
         orcType.addUnionChild(childType);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
@@ -123,7 +123,7 @@ public abstract class OrcSchemaVisitor<T> {
   }
 
   public String optionName(int ordinal) {
-    return "tag_" + ordinal;
+    return "field" + ordinal;
   }
 
   public String elementName() {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -38,7 +38,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
         return visitor.visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
 
       case UNION:
-        return visitUnion(iType, schema, visitor);
+        return visitor.visitUnion(iType, schema, visitor);
 
       case LIST:
         Types.ListType list = iType != null ? iType.asListType() : null;
@@ -71,12 +71,12 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     return visitor.record(struct, record, names, results);
   }
 
-  private static <T> T visitUnion(Type type, TypeDescription union, OrcSchemaWithTypeVisitor<T> visitor) {
+  protected T visitUnion(Type type, TypeDescription union, OrcSchemaWithTypeVisitor<T> visitor) {
     List<TypeDescription> types = union.getChildren();
     List<T> options = Lists.newArrayListWithCapacity(types.size());
 
     for (int i = 0; i < types.size(); i += 1) {
-      options.add(visit(type.asStructType().fields().get(i).type(), types.get(i), visitor));
+      options.add(visit(type.asStructType().fields().get(i + 1).type(), types.get(i), visitor));
     }
 
     return visitor.union(type, union, options);

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -176,16 +176,17 @@ public class SparkOrcValueReaders {
 
     @Override
     public InternalRow nonNullRead(ColumnVector vector, int row) {
-      InternalRow struct = new GenericInternalRow(readers.length);
+      InternalRow struct = new GenericInternalRow(readers.length + 1);
       UnionColumnVector unionColumnVector = (UnionColumnVector) vector;
 
       int fieldIndex = unionColumnVector.tags[row];
       Object value = this.readers[fieldIndex].read(unionColumnVector.fields[fieldIndex], row);
 
       for (int i = 0; i < readers.length; i += 1) {
-        struct.setNullAt(i);
+        struct.setNullAt(i + 1);
       }
-      struct.update(fieldIndex, value);
+      struct.update(0, fieldIndex);
+      struct.update(fieldIndex + 1, value);
 
       return struct;
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.data.vectorized;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -36,6 +37,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.ListColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
 import org.apache.orc.storage.ql.exec.vector.MapColumnVector;
 import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
 import org.apache.orc.storage.ql.exec.vector.UnionColumnVector;
@@ -443,11 +445,14 @@ public class VectorizedSparkOrcReaders {
         long batchOffsetInFile) {
       UnionColumnVector unionColumnVector = (UnionColumnVector) vector;
       List<Types.NestedField> fields = structType.fields();
-      assert fields.size() == unionColumnVector.fields.length;
-      assert fields.size() == optionConverters.size();
-
       List<ColumnVector> fieldVectors = Lists.newArrayListWithExpectedSize(fields.size());
-      for (int i = 0; i < fields.size(); i += 1) {
+
+      LongColumnVector longColumnVector = new LongColumnVector();
+      longColumnVector.vector = Arrays.stream(unionColumnVector.tags).asLongStream().toArray();
+
+      fieldVectors.add(new PrimitiveOrcColumnVector(Types.IntegerType.get(), batchSize, longColumnVector,
+          OrcValueReaders.ints(), batchOffsetInFile));
+      for (int i = 0; i < fields.size() - 1; i += 1) {
         fieldVectors.add(optionConverters.get(i).convert(unionColumnVector.fields[i], batchSize, batchOffsetInFile));
       }
 


### PR DESCRIPTION
This rb changes the OC  spark reader  and vectorized reader code path to read a union data type of `[int, string]` to a spark schema/data of `[tag, field0, field1]` instead of the previous `[tag_0, tag_1]`.