### PR TITLE
Backport https://github.com/apache/iceberg/pull/2328 and its prerequisites 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.exceptions;
+
+/**
+ * Exception for a failure to confirm either affirmatively or negatively that a commit was applied. The client
+ * cannot take any further action without possibly corrupting the table.
+ */
+public class CommitStateUnknownException extends RuntimeException {
+
+  private static final String COMMON_INFO =
+      "Cannot determine whether the commit was successful or not, the underlying data files may or " +
+      "may not be needed. Manual intervention via the Remove Orphan Files Action can remove these " +
+      "files when a connection to the Catalog can be re-established if the commit was actually unsuccessful.\n" +
+      "Please check to see whether or not your commit was successful before retrying this commit. Retrying " +
+      "an already successful operation will result in duplicate records or unintentional modifications.\n" +
+      "At this time no files will be deleted including possibly unused manifest lists.";
+
+  public CommitStateUnknownException(Throwable cause) {
+    super(cause.getMessage() + "\n" + COMMON_INFO, cause);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -218,12 +218,15 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       }
     } else {
       // if there was no previous snapshot, default the summary to start totals at 0
-      previousSummary = ImmutableMap.of(
-          SnapshotSummary.TOTAL_RECORDS_PROP, "0",
-          SnapshotSummary.TOTAL_DATA_FILES_PROP, "0",
-          SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0",
-          SnapshotSummary.TOTAL_POS_DELETES_PROP, "0",
-          SnapshotSummary.TOTAL_EQ_DELETES_PROP, "0");
+      ImmutableMap.Builder<String, String> summaryBuilder = ImmutableMap.builder();
+      summaryBuilder
+          .put(SnapshotSummary.TOTAL_RECORDS_PROP, "0")
+          .put(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "0")
+          .put(SnapshotSummary.TOTAL_DATA_FILES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_POS_DELETES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_EQ_DELETES_PROP, "0");
+      previousSummary = summaryBuilder.build();
     }
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
@@ -234,6 +237,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     updateTotal(
         builder, previousSummary, SnapshotSummary.TOTAL_RECORDS_PROP,
         summary, SnapshotSummary.ADDED_RECORDS_PROP, SnapshotSummary.DELETED_RECORDS_PROP);
+    updateTotal(
+        builder, previousSummary, SnapshotSummary.TOTAL_FILE_SIZE_PROP,
+        summary, SnapshotSummary.ADDED_FILE_SIZE_PROP, SnapshotSummary.REMOVED_FILE_SIZE_PROP);
     updateTotal(
         builder, previousSummary, SnapshotSummary.TOTAL_DATA_FILES_PROP,
         summary, SnapshotSummary.ADDED_FILES_PROP, SnapshotSummary.DELETED_FILES_PROP);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -299,6 +300,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             taskOps.commit(base, updated.withUUID());
           });
 
+    } catch (CommitStateUnknownException commitStateUnknownException) {
+      throw commitStateUnknownException;
     } catch (RuntimeException e) {
       Exceptions.suppressAndThrow(e, this::cleanAll);
     }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -38,6 +38,7 @@ public class SnapshotSummary {
   public static final String TOTAL_RECORDS_PROP = "total-records";
   public static final String ADDED_FILE_SIZE_PROP = "added-files-size";
   public static final String REMOVED_FILE_SIZE_PROP = "removed-files-size";
+  public static final String TOTAL_FILE_SIZE_PROP = "total-files-size";
   public static final String ADDED_POS_DELETES_PROP = "added-position-deletes";
   public static final String REMOVED_POS_DELETES_PROP = "removed-position-deletes";
   public static final String TOTAL_POS_DELETES_PROP = "total-position-deletes";

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -52,6 +52,13 @@ public interface TableOperations {
    * Implementations must check that the base metadata is current to avoid overwriting updates.
    * Once the atomic commit operation succeeds, implementations must not perform any operations that
    * may fail because failure in this method cannot be distinguished from commit failure.
+   * <p>
+   * Implementations must throw a {@link org.apache.iceberg.exceptions.CommitStateUnknownException}
+   * in cases where it cannot be determined if the commit succeeded or failed.
+   * For example if a network partition causes the confirmation of the commit to be lost,
+   * the implementation should throw a CommitStateUnknownException. This is important because downstream users of
+   * this API need to know whether they can clean up the commit or not, if the state is unknown then it is not safe
+   * to remove any files. All other exceptions will be treated as if the commit has failed.
    *
    * @param base     table metadata on which changes were based
    * @param metadata new table metadata with updates

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -36,6 +36,9 @@ public class TableProperties {
   public static final String COMMIT_TOTAL_RETRY_TIME_MS = "commit.retry.total-timeout-ms";
   public static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 1800000; // 30 minutes
 
+  public static final String COMMIT_NUM_STATUS_CHECKS = "commit.num-status-checks";
+  public static final int COMMIT_NUM_STATUS_CHECKS_DEFAULT = 3;
+
   public static final String MANIFEST_TARGET_SIZE_BYTES = "commit.manifest.target-size-bytes";
   public static final long MANIFEST_TARGET_SIZE_BYTES_DEFAULT = 8388608; // 8 MB
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestSnapshotSummary extends TableTestBase {
+  public TestSnapshotSummary(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Parameterized.Parameters(name = "formatVersion = {0}")
+  public static Object[] parameters() {
+    return new Object[] { 1, 2 };
+  }
+
+  @Test
+  public void testFileSizeSummary() {
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    // fast append
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .commit();
+    Map<String, String> summary = table.currentSnapshot().summary();
+    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    // merge append
+    table.newAppend()
+        .appendFile(FILE_B)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    table.newOverwrite()
+        .deleteFile(FILE_A)
+        .deleteFile(FILE_B)
+        .addFile(FILE_C)
+        .addFile(FILE_D)
+        .addFile(FILE_D)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertEquals("30", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("30", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    table.newDelete()
+        .deleteFile(FILE_C)
+        .deleteFile(FILE_D)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertNull(summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+  }
+}

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -191,7 +191,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             baseMetadataLocation, metadataLocation, database, tableName);
       }
 
-      setParameters(newMetadataLocation, tbl, hiveEngineEnabled);
+      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), hiveEngineEnabled);
 
       persistTable(tbl, updateHiveTable);
       threw = false;
@@ -262,12 +262,16 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return newTable;
   }
 
-  void setParameters(String newMetadataLocation, Table tbl, boolean hiveEngineEnabled) {
+  private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
+      boolean hiveEngineEnabled) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
       parameters = new HashMap<>();
     }
+
+    // push all Iceberg table properties into HMS
+    icebergTableProps.forEach(parameters::put);
 
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -47,6 +47,8 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynMethods;
@@ -201,7 +203,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             .collect(Collectors.toSet());
       }
 
-      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled);
+      Map<String, String> summary = Optional.ofNullable(metadata.currentSnapshot())
+          .map(Snapshot::summary)
+          .orElseGet(ImmutableMap::of);
+      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary);
 
       persistTable(tbl, updateHiveTable);
       threw = false;
@@ -273,7 +278,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   }
 
   private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
-                                     Set<String> obsoleteProps, boolean hiveEngineEnabled) {
+                                     Set<String> obsoleteProps, boolean hiveEngineEnabled,
+                                     Map<String, String> summary) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
@@ -299,6 +305,17 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
           "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler");
     } else {
       parameters.remove(hive_metastoreConstants.META_TABLE_STORAGE);
+    }
+
+    // Set the basic statistics
+    if (summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP) != null) {
+      parameters.put(StatsSetupConst.NUM_FILES, summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    }
+    if (summary.get(SnapshotSummary.TOTAL_RECORDS_PROP) != null) {
+      parameters.put(StatsSetupConst.ROW_COUNT, summary.get(SnapshotSummary.TOTAL_RECORDS_PROP));
+    }
+    if (summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP) != null) {
+      parameters.put(StatsSetupConst.TOTAL_SIZE, summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
     }
 
     tbl.setParameters(parameters);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -54,16 +54,22 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS_DEFAULT;
 
 /**
  * TODO we should be able to extract some more commonalities to BaseMetastoreTableOperations to
@@ -71,6 +77,8 @@ import org.slf4j.LoggerFactory;
  */
 public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTableOperations.class);
+
+  private static final int COMMIT_STATUS_CHECK_WAIT_MS = 1000;
 
   private static final String HIVE_ACQUIRE_LOCK_TIMEOUT_MS = "iceberg.hive.lock-timeout-ms";
   private static final String HIVE_LOCK_CHECK_MIN_WAIT_MS = "iceberg.hive.lock-check-min-wait-ms";
@@ -89,6 +97,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     WaitingForLockException(String message) {
       super(message);
     }
+  }
+
+  private enum CommitStatus {
+    FAILURE,
+    SUCCESS,
+    UNKNOWN
   }
 
   private final HiveClientPool metaClients;
@@ -158,12 +172,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     refreshFromMetadataLocation(metadataLocation);
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     String newMetadataLocation = writeNewMetadata(metadata, currentVersion() + 1);
     boolean hiveEngineEnabled = hiveEngineEnabled(metadata, conf);
 
-    boolean threw = true;
+    CommitStatus commitStatus = CommitStatus.FAILURE;
     boolean updateHiveTable = false;
     Optional<Long> lockId = Optional.empty();
     try {
@@ -208,8 +223,23 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
           .orElseGet(ImmutableMap::of);
       setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary);
 
-      persistTable(tbl, updateHiveTable);
-      threw = false;
+      try {
+        persistTable(tbl, updateHiveTable);
+        commitStatus = CommitStatus.SUCCESS;
+      } catch (Throwable persistFailure) {
+        LOG.error("Cannot tell if commit to {}.{} succeeded, attempting to reconnect and check.",
+            database, tableName, persistFailure);
+        commitStatus = checkCommitStatus(newMetadataLocation, metadata);
+        switch (commitStatus) {
+          case SUCCESS:
+            break;
+          case FAILURE:
+            throw persistFailure;
+          case UNKNOWN:
+            throw new CommitStateUnknownException(persistFailure);
+        }
+      }
+
     } catch (org.apache.hadoop.hive.metastore.api.AlreadyExistsException e) {
       throw new AlreadyExistsException("Table already exists: %s.%s", database, tableName);
 
@@ -227,11 +257,56 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       throw new RuntimeException("Interrupted during commit", e);
 
     } finally {
-      cleanupMetadataAndUnlock(threw, newMetadataLocation, lockId);
+      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId);
     }
   }
 
-  private void persistTable(Table hmsTable, boolean updateHiveTable) throws TException, InterruptedException {
+  /**
+   * Attempt to load the table and see if any current or past metadata location matches the one we were attempting
+   * to set. This is used as a last resort when we are dealing with exceptions that may indicate the commit has
+   * failed but are not proof that this is the case. Past locations must also be searched on the chance that a second
+   * committer was able to successfully commit on top of our commit.
+   *
+   * @param newMetadataLocation the path of the new commit file
+   * @param config metadata to use for configuration
+   * @return Commit Status of Success, Failure or Unknown
+   */
+  private CommitStatus checkCommitStatus(String newMetadataLocation, TableMetadata config) {
+    int maxAttempts = PropertyUtil.propertyAsInt(config.properties(), COMMIT_NUM_STATUS_CHECKS,
+        COMMIT_NUM_STATUS_CHECKS_DEFAULT);
+
+    AtomicReference<CommitStatus> status = new AtomicReference<>(CommitStatus.UNKNOWN);
+
+    Tasks.foreach(newMetadataLocation)
+        .retry(maxAttempts)
+        .suppressFailureWhenFinished()
+        .exponentialBackoff(COMMIT_STATUS_CHECK_WAIT_MS, COMMIT_STATUS_CHECK_WAIT_MS, Long.MAX_VALUE, 2.0)
+        .onFailure((location, checkException) ->
+            LOG.error("Cannot check if commit to {}.{} exists.", database, tableName, checkException))
+        .run(location -> {
+          TableMetadata metadata = refresh();
+          String currentMetadataLocation = metadata.metadataFileLocation();
+          boolean commitSuccess = currentMetadataLocation.equals(newMetadataLocation) ||
+              metadata.previousFiles().stream().anyMatch(log -> log.file().equals(newMetadataLocation));
+          if (commitSuccess) {
+            LOG.info("Commit status check: Commit to {}.{} of {} succeeded", database, tableName, newMetadataLocation);
+            status.set(CommitStatus.SUCCESS);
+          } else {
+            LOG.info("Commit status check: Commit to {}.{} of {} failed", database, tableName, newMetadataLocation);
+            status.set(CommitStatus.FAILURE);
+          }
+        });
+
+    if (status.get() == CommitStatus.UNKNOWN) {
+      LOG.error("Cannot determine commit state to {}.{}. Failed during checking {} times. " +
+              "Treating commit state as unknown.",
+          database, tableName, maxAttempts);
+    }
+    return status.get();
+  }
+
+  @VisibleForTesting
+  void persistTable(Table hmsTable, boolean updateHiveTable) throws TException, InterruptedException {
     if (updateHiveTable) {
       metaClients.run(client -> {
         EnvironmentContext envContext = new EnvironmentContext(
@@ -340,6 +415,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return storageDescriptor;
   }
 
+  @VisibleForTesting
   long acquireLock() throws UnknownHostException, TException, InterruptedException {
     final LockComponent lockComponent = new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, database);
     lockComponent.setTablename(tableName);
@@ -406,10 +482,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return lockId;
   }
 
-  private void cleanupMetadataAndUnlock(boolean errorThrown, String metadataLocation, Optional<Long> lockId) {
+  private void cleanupMetadataAndUnlock(CommitStatus commitStatus, String metadataLocation, Optional<Long> lockId) {
     try {
-      if (errorThrown) {
-        // if anything went wrong, clean up the uncommitted metadata file
+      if (commitStatus == CommitStatus.FAILURE) {
+        // If we are sure the commit failed, clean up the uncommitted metadata file
         io().deleteFile(metadataLocation);
       }
     } catch (RuntimeException e) {
@@ -430,8 +506,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     }
   }
 
-  // visible for testing
-  protected void doUnlock(long lockId) throws TException, InterruptedException {
+  @VisibleForTesting
+  void doUnlock(long lockId) throws TException, InterruptedException {
     metaClients.run(client -> {
       client.unlock(lockId);
       return null;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -99,7 +99,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     }
   }
 
-  private enum CommitStatus {
+  protected enum CommitStatus {
     FAILURE,
     SUCCESS,
     UNKNOWN
@@ -271,7 +271,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
    * @param config metadata to use for configuration
    * @return Commit Status of Success, Failure or Unknown
    */
-  private CommitStatus checkCommitStatus(String newMetadataLocation, TableMetadata config) {
+  CommitStatus checkCommitStatus(String newMetadataLocation, TableMetadata config) {
     int maxAttempts = PropertyUtil.propertyAsInt(config.properties(), COMMIT_NUM_STATUS_CHECKS,
         COMMIT_NUM_STATUS_CHECKS_DEFAULT);
 
@@ -352,7 +352,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return newTable;
   }
 
-  private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
+  void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
                                      Set<String> obsoleteProps, boolean hiveEngineEnabled,
                                      Map<String, String> summary) {
     Map<String, String> parameters = tbl.getParameters();
@@ -482,7 +482,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return lockId;
   }
 
-  private void cleanupMetadataAndUnlock(CommitStatus commitStatus, String metadataLocation, Optional<Long> lockId) {
+  void cleanupMetadataAndUnlock(CommitStatus commitStatus, String metadataLocation, Optional<Long> lockId) {
     try {
       if (commitStatus == CommitStatus.FAILURE) {
         // If we are sure the commit failed, clean up the uncommitted metadata file

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -337,8 +337,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     long duration = 0;
     boolean timeout = false;
 
-    if (state.get().equals(LockState.WAITING)) {
-      try {
+    try {
+      if (state.get().equals(LockState.WAITING)) {
         // Retry count is the typical "upper bound of retries" for Tasks.run() function. In fact, the maximum number of
         // attempts the Tasks.run() would try is `retries + 1`. Here, for checking locks, we use timeout as the
         // upper bound of retries. So it is just reasonable to set a large retry count. However, if we set
@@ -366,9 +366,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
                 LOG.warn("Interrupted while waiting for lock.", e);
               }
             }, TException.class);
-      } catch (WaitingForLockException waitingForLockException) {
-        timeout = true;
-        duration = System.currentTimeMillis() - start;
+      }
+    } catch (WaitingForLockException waitingForLockException) {
+      timeout = true;
+      duration = System.currentTimeMillis() - start;
+    } finally {
+      if (!state.get().equals(LockState.ACQUIRED)) {
+        unlock(Optional.of(lockId));
       }
     }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -27,7 +27,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -191,7 +193,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             baseMetadataLocation, metadataLocation, database, tableName);
       }
 
-      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), hiveEngineEnabled);
+      // get Iceberg props that have been removed
+      Set<String> removedProps = Collections.emptySet();
+      if (base != null) {
+        removedProps = base.properties().keySet().stream()
+            .filter(key -> !metadata.properties().containsKey(key))
+            .collect(Collectors.toSet());
+      }
+
+      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled);
 
       persistTable(tbl, updateHiveTable);
       threw = false;
@@ -263,7 +273,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   }
 
   private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
-      boolean hiveEngineEnabled) {
+                                     Set<String> obsoleteProps, boolean hiveEngineEnabled) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
@@ -272,6 +282,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
     // push all Iceberg table properties into HMS
     icebergTableProps.forEach(parameters::put);
+
+    // remove any props from HMS that are no longer present in Iceberg table props
+    obsoleteProps.forEach(parameters::remove);
 
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -19,17 +19,26 @@
 
 package org.apache.iceberg.hive;
 
+import java.io.File;
+import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class TestHiveCommits extends HiveTableBaseTest {
 
@@ -65,5 +74,249 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     // the commit must succeed
     Assert.assertEquals(1, ops.current().schema().columns().size());
+  }
+
+  /**
+   * Pretends we throw an error while persisting that actually fails to commit serverside
+   */
+  @Test
+  public void testThriftExceptionFailureOnCommit() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    failCommitAndThrowException(spyOps);
+
+    AssertHelpers.assertThrows("We should rethrow generic runtime errors if the " +
+        "commit actually doesn't succeed", RuntimeException.class, "Metastore operation failed",
+        () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
+    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+  }
+
+  /**
+   * Pretends we throw an error while persisting that actually does commit serverside
+   */
+  @Test
+  public void testThriftExceptionSuccessOnCommit() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    // Simulate a communication error after a successful commit
+    commitAndThrowException(ops, spyOps);
+
+    // Shouldn't throw because the commit actually succeeds even though persistTable throws an exception
+    spyOps.commit(metadataV2, metadataV1);
+
+    ops.refresh();
+    Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals("Commit should have been successful and new metadata file should be made",
+        3, metadataFileCount(ops.current()));
+  }
+
+  /**
+   * Pretends we throw an exception while persisting and don't know what happened, can't check to find out,
+   * but in reality the commit failed
+   */
+  @Test
+  public void testThriftExceptionUnknownFailedCommit() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    failCommitAndThrowException(spyOps);
+    breakFallbackCatalogCommitCheck(spyOps);
+
+    AssertHelpers.assertThrows("Should throw CommitStateUnknownException since the catalog check was blocked",
+        CommitStateUnknownException.class, "Datacenter on fire",
+        () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals("Client could not determine outcome so new metadata file should also exist",
+        3, metadataFileCount(ops.current()));
+  }
+
+  /**
+   * Pretends we throw an exception while persisting and don't know what happened, can't check to find out,
+   * but in reality the commit succeeded
+   */
+  @Test
+  public void testThriftExceptionsUnknownSuccessCommit() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    commitAndThrowException(ops, spyOps);
+    breakFallbackCatalogCommitCheck(spyOps);
+
+    AssertHelpers.assertThrows("Should throw CommitStateUnknownException since the catalog check was blocked",
+        CommitStateUnknownException.class, "Datacenter on fire",
+        () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+
+    Assert.assertFalse("Current metadata should have changed", ops.current().equals(metadataV2));
+    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
+  }
+
+  /**
+   * Pretends we threw an exception while persisting, the commit succeeded, the lock expired,
+   * and a second committer placed a commit on top of ours before the first committer was able to check
+   * if their commit succeeded or not
+   *
+   * Timeline:
+   *   Client 1 commits which throws an exception but suceeded
+   *   Client 1's lock expires while waiting to do the recheck for commit success
+   *   Client 2 acquires a lock, commits successfully on top of client 1's commit and release lock
+   *   Client 1 check's to see if their commit was successful
+   *
+   * This tests to make sure a disconnected client 1 doesn't think their commit failed just because it isn't the
+   * current one during the recheck phase.
+   */
+  @Test
+  public void testThriftExceptionConcurrentCommit() throws TException, InterruptedException, UnknownHostException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    AtomicLong lockId = new AtomicLong();
+    doAnswer(i -> {
+      lockId.set(ops.acquireLock());
+      return lockId.get();
+    }).when(spyOps).acquireLock();
+
+    concurrentCommitAndThrowException(ops, spyOps, table, lockId);
+
+    /*
+    This commit and our concurrent commit should succeed even though this commit throws an exception
+    after the persist operation succeeds
+     */
+    spyOps.commit(metadataV2, metadataV1);
+
+    ops.refresh();
+    Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals("The column addition from the concurrent commit should have been successful",
+        2, ops.current().schema().columns().size());
+  }
+
+  private void commitAndThrowException(HiveTableOperations realOperations, HiveTableOperations spyOperations)
+      throws TException, InterruptedException {
+    // Simulate a communication error after a successful commit
+    doAnswer(i -> {
+      org.apache.hadoop.hive.metastore.api.Table tbl =
+          i.getArgumentAt(0, org.apache.hadoop.hive.metastore.api.Table.class);
+      realOperations.persistTable(tbl, true);
+      throw new TException("Datacenter on fire");
+    }).when(spyOperations).persistTable(any(), anyBoolean());
+  }
+
+  private void concurrentCommitAndThrowException(HiveTableOperations realOperations, HiveTableOperations spyOperations,
+                                                 Table table, AtomicLong lockId)
+      throws TException, InterruptedException {
+    // Simulate a communication error after a successful commit
+    doAnswer(i -> {
+      org.apache.hadoop.hive.metastore.api.Table tbl =
+          i.getArgumentAt(0, org.apache.hadoop.hive.metastore.api.Table.class);
+      realOperations.persistTable(tbl, true);
+      // Simulate lock expiration or removal
+      realOperations.doUnlock(lockId.get());
+      table.refresh();
+      table.updateSchema().addColumn("newCol", Types.IntegerType.get()).commit();
+      throw new TException("Datacenter on fire");
+    }).when(spyOperations).persistTable(any(), anyBoolean());
+  }
+
+  private void failCommitAndThrowException(HiveTableOperations spyOperations) throws TException, InterruptedException {
+    doThrow(new TException("Datacenter on fire"))
+        .when(spyOperations)
+        .persistTable(any(), anyBoolean());
+  }
+
+  private void breakFallbackCatalogCommitCheck(HiveTableOperations spyOperations) {
+    when(spyOperations.refresh())
+        .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
+  }
+
+  private boolean metadataFileExists(TableMetadata metadata) {
+    return new File(metadata.metadataFileLocation().replace("file:", "")).exists();
+  }
+
+  private int metadataFileCount(TableMetadata metadata) {
+    return new File(metadata.metadataFileLocation().replace("file:", "")).getParentFile()
+        .listFiles(file -> file.getName().endsWith("metadata.json")).length;
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -38,9 +38,11 @@ import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.RetryingHMSHandler;
 import org.apache.hadoop.hive.metastore.TSetIpAddressProcessor;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.hadoop.Util;
+import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
@@ -154,10 +156,6 @@ public class TestHiveMetastore {
     return hiveConf;
   }
 
-  public HiveClientPool clientPool() {
-    return clientPool;
-  }
-
   public String getDatabasePath(String dbName) {
     File dbDir = new File(hiveLocalDir, dbName + ".db");
     return dbDir.getPath();
@@ -189,6 +187,10 @@ public class TestHiveMetastore {
         fs.delete(fileStatus.getPath(), true);
       }
     }
+  }
+
+  public Table getTable(String dbName, String tableName) throws TException, InterruptedException {
+    return clientPool.run(client -> client.getTable(dbName, tableName));
   }
 
   private TServer newThriftServer(TServerSocket socket, int poolSize, HiveConf conf) throws Exception {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -27,12 +27,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -43,6 +45,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.hive.HiveSchemaUtil;
+import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -165,39 +168,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
 
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    // This is only set for HiveCatalog based tables. Check the value, then remove it so the other checks can be general
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertTrue(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
-          .startsWith(icebergTable.location()));
-      hmsParams.remove(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
-    }
-
-    // General metadata checks
-    Assert.assertEquals(6, hmsParams.size());
-    Assert.assertEquals("test", hmsParams.get("dummy"));
-    Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
-    Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
-    Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
-    Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
-        hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
-    Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
-        hmsTable.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
-
-    // verify that storage descriptor is filled out with inputformat/outputformat/serde
-    Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
-    Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
-    Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
-
     if (!Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(Collections.singletonMap("dummy", "test"), icebergTable.properties());
-
       shell.executeStatement("DROP TABLE customers");
 
       // Check if the table was really dropped even from the Catalog
@@ -207,13 +178,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
-      Map<String, String> expectedIcebergProperties = new HashMap<>(2);
-      expectedIcebergProperties.put("dummy", "test");
-      expectedIcebergProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
-      Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
-
-      // Check the HMS table parameters
-      hmsTable = shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -238,7 +203,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testCreateTableWithoutSpec() throws TException, InterruptedException {
+  public void testCreateTableWithoutSpec() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
@@ -250,26 +215,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
-
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    // Just check that the PartitionSpec is not set in the metadata
-    Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
-
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
-    } else {
-      Assert.assertEquals(5, hmsParams.size());
-    }
   }
 
   @Test
-  public void testCreateTableWithUnpartitionedSpec() throws TException, InterruptedException {
+  public void testCreateTableWithUnpartitionedSpec() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     // We need the location for HadoopTable based tests only
@@ -284,21 +233,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     Assert.assertEquals(SPEC, icebergTable.spec());
-
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    // Just check that the PartitionSpec is not set in the metadata
-    Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
-    } else {
-      Assert.assertEquals(5, hmsParams.size());
-    }
   }
 
   @Test
@@ -319,8 +253,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       testTables.loadTable(identifier);
     } else {
       // Check the HMS table parameters
-      org.apache.hadoop.hive.metastore.api.Table hmsTable =
-          shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -377,13 +310,12 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testCreateTableAboveExistingTable() throws TException, IOException, InterruptedException {
+  public void testCreateTableAboveExistingTable() throws IOException {
     // Create the Iceberg table
     testTables.createIcebergTable(shell.getHiveConf(), "customers", COMPLEX_SCHEMA, FileFormat.PARQUET,
         Collections.emptyList());
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-
       // In HiveCatalog we just expect an exception since the table is already exists
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "customers already exists", () -> {
@@ -394,24 +326,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
+      // With other catalogs, table creation should succeed
       shell.executeStatement("CREATE EXTERNAL TABLE customers " +
           "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
           testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")));
-
-      // Check the HMS table parameters
-      org.apache.hadoop.hive.metastore.api.Table hmsTable =
-          shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-      Map<String, String> hmsParams = hmsTable.getParameters();
-      IGNORED_PARAMS.forEach(hmsParams::remove);
-
-      Assert.assertEquals(4, hmsParams.size());
-      Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
-      Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
-      Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
-          hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
-      Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
-          hmsTable.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
     }
   }
 
@@ -561,5 +479,96 @@ public class TestHiveIcebergStorageHandlerNoScan {
       Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
           "from deserializer"}, rows.get(i));
     }
+  }
+
+  @Test
+  public void testIcebergAndHmsTableProperties() throws TException, InterruptedException {
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+
+    shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
+        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' %s" +
+        "TBLPROPERTIES ('%s'='%s', '%s'='%s', '%s'='%s')",
+        testTables.locationForCreateTableSQL(identifier), // we need the location for HadoopTable based tests only
+        InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA),
+        InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(SPEC),
+        "custom_property", "initial_val"));
+
+
+    // Check the Iceberg table parameters
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+
+    Map<String, String> expectedIcebergProperties = new HashMap<>();
+    expectedIcebergProperties.put("custom_property", "initial_val");
+    expectedIcebergProperties.put("EXTERNAL", "TRUE");
+    expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      expectedIcebergProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
+    }
+    if (MetastoreUtil.hive3PresentOnClasspath()) {
+      expectedIcebergProperties.put("bucketing_version", "2");
+    }
+    Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
+
+    // Check the HMS table parameters
+    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
+    Map<String, String> hmsParams = hmsTable.getParameters()
+        .entrySet().stream()
+        .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      Assert.assertEquals(9, hmsParams.size());
+      Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
+      Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
+      Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
+      Assert.assertEquals("true", hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
+          hmsParams.get(hive_metastoreConstants.META_TABLE_STORAGE));
+      Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
+          hmsParams.get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
+      Assert.assertEquals(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP),
+              getCurrentSnapshotForHiveCatalogTable(icebergTable));
+      Assert.assertNull(hmsParams.get(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP));
+      Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
+    } else {
+      Assert.assertEquals(7, hmsParams.size());
+      Assert.assertNull(hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
+    }
+
+    // Check HMS inputformat/outputformat/serde
+    Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
+    Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
+    Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
+
+    // Add two new properties to the Iceberg table and update an existing one
+    icebergTable.updateProperties()
+        .set("new_prop_1", "true")
+        .set("new_prop_2", "false")
+        .set("custom_property", "new_val")
+        .commit();
+
+    // Refresh the HMS table to see if new Iceberg properties got synced into HMS
+    hmsParams = shell.metastore().getTable("default", "customers").getParameters()
+        .entrySet().stream()
+        .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      Assert.assertEquals(12, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals("true", hmsParams.get("new_prop_1"));
+      Assert.assertEquals("false", hmsParams.get("new_prop_2"));
+      Assert.assertEquals("new_val", hmsParams.get("custom_property"));
+      String prevSnapshot = getCurrentSnapshotForHiveCatalogTable(icebergTable);
+      icebergTable.refresh();
+      String newSnapshot = getCurrentSnapshotForHiveCatalogTable(icebergTable);
+      Assert.assertEquals(hmsParams.get(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP), prevSnapshot);
+      Assert.assertEquals(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP), newSnapshot);
+    } else {
+      Assert.assertEquals(7, hmsParams.size());
+    }
+  }
+
+  private String getCurrentSnapshotForHiveCatalogTable(org.apache.iceberg.Table icebergTable) {
+    return ((BaseMetastoreTableOperations) ((BaseTable) icebergTable).operations()).currentMetadataLocation();
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -566,6 +566,21 @@ public class TestHiveIcebergStorageHandlerNoScan {
     } else {
       Assert.assertEquals(7, hmsParams.size());
     }
+
+    // Remove some Iceberg props and see if they're removed from HMS table props as well
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      icebergTable.updateProperties()
+          .remove("custom_property")
+          .remove("new_prop_1")
+          .commit();
+      hmsParams = shell.metastore().getTable("default", "customers").getParameters()
+          .entrySet().stream()
+          .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      Assert.assertFalse(hmsParams.containsKey("custom_property"));
+      Assert.assertFalse(hmsParams.containsKey("new_prop_1"));
+      Assert.assertTrue(hmsParams.containsKey("new_prop_2"));
+    }
   }
 
   private String getCurrentSnapshotForHiveCatalogTable(org.apache.iceberg.Table icebergTable) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -40,8 +40,10 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.hive.HiveSchemaUtil;
@@ -103,9 +105,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       ))
   );
 
-  private static final Set<String> IGNORED_PARAMS =
-      ImmutableSet.of("bucketing_version", StatsSetupConst.ROW_COUNT,
-          StatsSetupConst.RAW_DATA_SIZE, StatsSetupConst.TOTAL_SIZE, StatsSetupConst.NUM_FILES, "numFilesErasureCoded");
+  private static final Set<String> IGNORED_PARAMS = ImmutableSet.of("bucketing_version", "numFilesErasureCoded");
 
   @Parameters(name = "catalog={0}")
   public static Collection<Object[]> parameters() {
@@ -482,7 +482,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testIcebergAndHmsTableProperties() throws TException, InterruptedException {
+  public void testIcebergAndHmsTableProperties() throws Exception {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
@@ -573,13 +573,21 @@ public class TestHiveIcebergStorageHandlerNoScan {
           .remove("custom_property")
           .remove("new_prop_1")
           .commit();
-      hmsParams = shell.metastore().getTable("default", "customers").getParameters()
-          .entrySet().stream()
-          .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      hmsParams = shell.metastore().getTable("default", "customers").getParameters();
       Assert.assertFalse(hmsParams.containsKey("custom_property"));
       Assert.assertFalse(hmsParams.containsKey("new_prop_1"));
       Assert.assertTrue(hmsParams.containsKey("new_prop_2"));
+    }
+
+    // append some data and check whether HMS stats are aligned with snapshot summary
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
+      testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, FileFormat.PARQUET, null, records);
+      hmsParams = shell.metastore().getTable("default", "customers").getParameters();
+      Map<String, String> summary = icebergTable.currentSnapshot().summary();
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP), hmsParams.get(StatsSetupConst.NUM_FILES));
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_RECORDS_PROP), hmsParams.get(StatsSetupConst.ROW_COUNT));
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP), hmsParams.get(StatsSetupConst.TOTAL_SIZE));
     }
   }
 


### PR DESCRIPTION
## Identifying commits required 
To patch the PR of interests https://github.com/apache/iceberg/pull/2328 I identified four PRs that has a bunch of overlapping with it by scanning through the file git history of `HiveTableOperations.java` which is the file being modified the most. Specifically, the git history of this file in Li-Iceberg and Apache Iceberg are compared, from which I identified four PRs to be ported: 
https://github.com/apache/iceberg/pull/2123 [Push Iceberg table property values to HMS table properties]
https://github.com/apache/iceberg/pull/2252 [Change a key method's signature in  `HiveTableOperations.java` ]
https://github.com/apache/iceberg/pull/2263 [`acquireLock` method fixing in  `HiveTableOperations.java` ]
https://github.com/apache/iceberg/pull/2329 [Introduce total-files-size snapshot metric and populate HMS]

These are changes need to make `HiveTableOperations.java`  right. 
To logically replicate the fix into `HiveMetadataPreservingTableOperations.java`, did the following: 
- Change a couple of methods' access modifier to make them available in extended class, 
- Refactor HMS client code block into `persistTable` method, as well as the clean up method in finally block, 
- apply the try-catch of `checkCommitStatus` in the `doCommit` method, 
- remove `metadataUpdatedSuccessfully` which is no longer needed (and the original impl. is buggy since it only checks if the current version is exactly the same as new metadata version instead of checking if current version is in the lineage of new metadata version as the PR 2328 did). 

## Conflicts 
There's no conflicts if all four are ported, in the `HiveTableOperations.java` We have two commits that are not contributed back to upstream that: 
- simply remove the "private" access modifier from "unlock", "storageDescriptor", "acquireLock" and "setParameters" methods in the `HiveTableOperations.java`
- adding a code block for more log message in `HiveTableOperations.java` 

They are easily resolved. Overall, there should be minimal work to bring `HiveTableOperations.java` exactly the same as upstream. 
