### PR TITLE
Call unlock lockId before throwing an exception in acquireLock method

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -357,11 +357,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
     // timeout and do not have lock acquired
     if (timeout && !state.get().equals(LockState.ACQUIRED)) {
+      LOG.debug("Unlocking lock id for {}.{} ", database, tableName);
+      unlock(Optional.of(lockId));
       throw new CommitFailedException("Timed out after %s ms waiting for lock on %s.%s",
           duration, database, tableName);
     }
 
     if (!state.get().equals(LockState.ACQUIRED)) {
+      LOG.debug("Unlocking lock id for {}.{} ", database, tableName);
+      unlock(Optional.of(lockId));
       throw new CommitFailedException("Could not acquire the lock on %s.%s, " +
           "lock request ended in state %s", database, tableName, state);
     }


### PR DESCRIPTION
In the [cleans up](https://github.com/linkedin/iceberg/blob/2c59857a4f8bde052121d2edb562ed83d135863f/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L381.)  path  lockId is not returned in [code](https://github.com/linkedin/iceberg/blob/2c59857a4f8bde052121d2edb562ed83d135863f/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L368) for cleanup and hence becomes a no-op during unlock. 