### PR TITLE
Support timestamp as partition type

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -28,8 +28,11 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
@@ -72,7 +75,12 @@ public class Conversions {
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
       case TIMESTAMP:
-        return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
+        if (!asString.contains("T")) {
+          final Instant instant = Timestamp.valueOf(asString).toInstant();
+          return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
+        } else {
+          return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
+        }
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -28,14 +28,12 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
+
 
 public class Conversions {
 
@@ -75,12 +73,8 @@ public class Conversions {
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
       case TIMESTAMP:
-        if (!asString.contains("T")) {
-          final Instant instant = Timestamp.valueOf(asString).toInstant();
-          return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
-        } else {
-          return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
-        }
+        final String isoFormatTs = asString.replaceFirst(" ", "T");
+        return Literal.of(isoFormatTs).to(Types.TimestampType.withoutZone()).value();
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);


### PR DESCRIPTION
This PR enhances https://github.com/linkedin/iceberg/pull/78 to backport the [upstream PR](https://github.com/apache/iceberg/pull/3933) to support timestamp as a partition type. 

Hard to add unit tests given we don't have corresponding `TestAddFilesProcedure` test class in li-0.11.x branch.
Tested on our Spark shell and it worked well.