### PR TITLE
[LI] Align default value validation align with avro semantics in terms of nullable (nested) fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -462,9 +462,8 @@ public class Types {
           if (defaultStruct.isEmpty()) {
             return;
           }
-          Preconditions.checkArgument(defaultStruct.size() == type.asStructType().fields().size());
-          for (String fieldName : defaultStruct.keySet()) {
-            NestedField.validateDefaultValue(defaultStruct.get(fieldName), type.asStructType().field(fieldName).type);
+          for (NestedField field : type.asStructType().fields()) {
+            validateDefaultValue(defaultStruct.getOrDefault(field.name(), field.getDefaultValue()), field.type());
           }
           break;
 

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -93,7 +93,8 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       Type fieldType = fieldTypes.get(i);
       int fieldId = getId(field);
 
-      Object defaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field) ? field.defaultVal() : null;
+      Object defaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field) ?
+          AvroSchemaUtil.convertToJavaDefaultValue(field.defaultVal()) : null;
 
       if (AvroSchemaUtil.isOptionSchema(field.schema()) || AvroSchemaUtil.isOptionalComplexUnion(field.schema())) {
         newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, defaultValue, field.doc()));

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -325,4 +325,52 @@ public class TestSchemaConversions {
     List<String> origFieldDocs = Lists.newArrayList(Iterables.transform(origSchema.columns(), Types.NestedField::doc));
     Assert.assertEquals(origFieldDocs, fieldDocs);
   }
+
+  @Test
+  public void testConversionOfRecordDefaultWithOptionalNestedField() {
+    String schemaString = "{\n" +
+            "    \"type\": \"record\",\n" +
+            "    \"name\": \"root\",\n" +
+            "    \"fields\": [\n" +
+            "        {\n" +
+            "            \"name\": \"outer\",\n" +
+            "            \"type\": {\n" +
+            "                \"type\": \"record\",\n" +
+            "                \"name\": \"outerRecord\",\n" +
+            "                \"fields\": [\n" +
+            "                    {\n" +
+            "                        \"name\": \"mapField\",\n" +
+            "                        \"type\": {\n" +
+            "                            \"type\": \"map\",\n" +
+            "                            \"values\": \"string\"\n" +
+            "                        }\n" +
+            "                    },\n" +
+            "                    {\n" +
+            "                        \"name\": \"recordField\",\n" +
+            "                        \"type\": [\n" +
+            "                            \"null\",\n" +
+            "                            {\n" +
+            "                                \"type\": \"record\",\n" +
+            "                                \"name\": \"inner\",\n" +
+            "                                \"fields\": [\n" +
+            "                                    {\n" +
+            "                                        \"name\": \"innerString\",\n" +
+            "                                        \"type\": \"string\"\n" +
+            "                                    }\n" +
+            "                                ]\n" +
+            "                            }\n" +
+            "                        ],\n" +
+            "                        \"default\": null\n" +
+            "                    }\n" +
+            "                ]\n" +
+            "            },\n" +
+            "            \"default\": {\n" +
+            "                \"mapField\": {}\n" +
+            "            }\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+    Schema schema = new Schema.Parser().parse(schemaString);
+    AvroSchemaUtil.toIceberg(schema);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -371,6 +371,67 @@ public class TestSchemaConversions {
             "    ]\n" +
             "}";
     Schema schema = new Schema.Parser().parse(schemaString);
-    AvroSchemaUtil.toIceberg(schema);
+    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(schema);
+    Assert.assertEquals("table {\n" +
+        "  0: outer: required struct<4: mapField: required map<string, string>, " +
+        "5: recordField: optional struct<3: innerString: required string>>, default value: {mapField={}}, \n" +
+        "}", iSchema.toString());
+  }
+
+  @Test
+  public void testConversionOfRecordDefaultWithOptionalNestedField2() {
+    String schemaString = "{\n" +
+            "    \"type\": \"record\",\n" +
+            "    \"name\": \"root\",\n" +
+            "    \"fields\": [\n" +
+            "        {\n" +
+            "            \"name\": \"outer\",\n" +
+            "            \"type\": {\n" +
+            "                \"type\": \"record\",\n" +
+            "                \"name\": \"outerRecord\",\n" +
+            "                \"fields\": [\n" +
+            "                    {\n" +
+            "                        \"name\": \"mapField\",\n" +
+            "                        \"type\": {\n" +
+            "                            \"type\": \"map\",\n" +
+            "                            \"values\": \"string\"\n" +
+            "                        }\n" +
+            "                    },\n" +
+            "                    {\n" +
+            "                        \"name\": \"recordField\",\n" +
+            "                        \"type\": [\n" +
+            "                            \"null\",\n" +
+            "                            {\n" +
+            "                                \"type\": \"record\",\n" +
+            "                                \"name\": \"inner\",\n" +
+            "                                \"fields\": [\n" +
+            "                                    {\n" +
+            "                                        \"name\": \"innerString\",\n" +
+            "                                        \"type\": \"string\"\n" +
+            "                                    }\n" +
+            "                                ]\n" +
+            "                            }\n" +
+            "                        ],\n" +
+            "                        \"default\": null\n" +
+            "                    }\n" +
+            "                ]\n" +
+            "            },\n" +
+            "            \"default\": {\n" +
+            "                \"mapField\": {\n" +
+            "                    \"foo\": \"bar\",\n" +
+            "                    \"x\": \"y\"\n" +
+            "                },\n" +
+            "                \"recordField\": null\n" +
+            "            }\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+    Schema schema = new Schema.Parser().parse(schemaString);
+    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(schema);
+    Assert.assertEquals("table {\n" +
+        "  0: outer: required struct<4: mapField: required map<string, string>, " +
+        "5: recordField: optional struct<3: innerString: required string>>, " +
+        "default value: {mapField={foo=bar, x=y}, recordField=null}, \n" +
+        "}", iSchema.toString());
   }
 }


### PR DESCRIPTION
Avro record level default values behave this way:

say we have a avro schema:
```
record: {
  f1: string,
  f2: int
}
```
its default value should defined sth like:
```
{f1: "foo", f2: 1}
```

(Case-1)
But when the inner field `f1` is nullable, i.e. optional with the default value null, then the record level default value can be defined as below, omitting the default value for it.
```
{f2: 1}
```

(Case-2)
Since the inner field `f1` is nullable, its default value should be `null` as always, however, it's also fine to repeat this default value in the record default, as:
```
{f1: null, f2: 1}
```

This change is to cover these 2 cases and allow the schema validation for default value to pass.
