### PR TITLE
Improve the logging when the deserailzed index is invalid to read the symbol from enum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -998,10 +998,6 @@ project(':iceberg-spark3') {
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-data', configuration: 'testArtifacts')
-    //snappy-java supports Apple M1 cpu at the version of 1.1.8.2 when the tests are executed with JDK 11
-    if(JavaVersion.current() == JavaVersion.VERSION_11){
-      testRuntime "org.xerial.snappy:snappy-java:1.1.8.2"
-    }
   }
 
   test {
@@ -1048,10 +1044,6 @@ project(":iceberg-spark3-extensions") {
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-spark', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-spark3', configuration: 'testArtifacts')
-    //snappy-java supports Apple M1 cpu at the version of 1.1.8.2 when the tests are executed with JDK 11
-    if(JavaVersion.current() == JavaVersion.VERSION_11){
-      testRuntime "org.xerial.snappy:snappy-java:1.1.8.2"
-    }
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtime "org.antlr:antlr4-runtime:4.7.1"

--- a/build.gradle
+++ b/build.gradle
@@ -998,6 +998,10 @@ project(':iceberg-spark3') {
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-data', configuration: 'testArtifacts')
+    //snappy-java supports Apple M1 cpu at the version of 1.1.8.2 when the tests are executed with JDK 11
+    if(JavaVersion.current() == JavaVersion.VERSION_11){
+      testRuntime "org.xerial.snappy:snappy-java:1.1.8.2"
+    }
   }
 
   test {
@@ -1044,6 +1048,10 @@ project(":iceberg-spark3-extensions") {
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-spark', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-spark3', configuration: 'testArtifacts')
+    //snappy-java supports Apple M1 cpu at the version of 1.1.8.2 when the tests are executed with JDK 11
+    if(JavaVersion.current() == JavaVersion.VERSION_11){
+      testRuntime "org.xerial.snappy:snappy-java:1.1.8.2"
+    }
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtime "org.antlr:antlr4-runtime:4.7.1"

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -43,6 +43,9 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class SparkValueReaders {
 
@@ -111,6 +114,7 @@ public class SparkValueReaders {
   }
 
   private static class EnumReader implements ValueReader<UTF8String> {
+    private static final Logger LOG = LoggerFactory.getLogger(EnumReader.class);
     private final UTF8String[] symbols;
 
     private EnumReader(List<String> symbols) {
@@ -123,7 +127,12 @@ public class SparkValueReaders {
     @Override
     public UTF8String read(Decoder decoder, Object ignore) throws IOException {
       int index = decoder.readEnum();
-      return symbols[index];
+      if (index < 0 || index >= symbols.length) {
+        LOG.error("Unable to read the symbol in the given enum as the deserialized index {} is out of bound", index);
+        return null;
+      } else {
+        return symbols[index];
+      }
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -127,11 +127,11 @@ public class SparkValueReaders {
     @Override
     public UTF8String read(Decoder decoder, Object ignore) throws IOException {
       int index = decoder.readEnum();
-      try {
-        return symbols[index];
-      } catch (ArrayIndexOutOfBoundsException ex) {
+      if (index >= symbols.length) {
         LOG.error("Unable to read the symbol in the given enum as the deserialized index {} is out of bound", index);
-        throw ex;
+        throw new ArrayIndexOutOfBoundsException();
+      } else {
+        return symbols[index];
       }
     }
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -127,11 +127,11 @@ public class SparkValueReaders {
     @Override
     public UTF8String read(Decoder decoder, Object ignore) throws IOException {
       int index = decoder.readEnum();
-      if (index < 0 || index >= symbols.length) {
-        LOG.error("Unable to read the symbol in the given enum as the deserialized index {} is out of bound", index);
-        return null;
-      } else {
+      try {
         return symbols[index];
+      } catch (ArrayIndexOutOfBoundsException ex) {
+        LOG.error("Unable to read the symbol in the given enum as the deserialized index {} is out of bound", index);
+        throw ex;
       }
     }
   }


### PR DESCRIPTION
**Problem**
According to a ticket issued by a user,  `ArrayIndexOutOfBoundsException` is thrown from the code of the class of `SparkValueReaders$EnumReader` when a Spark job is executed. It happens when an enum evolves with new symbols, EnumReader tries to use the index of the new symbol to read the enum before the evolution which results in an `ArrayIndexOutOfBoundsException`.

**Solution**
In EnumReader.read(), it checks if the value of the index deserialized for a symbol is in the bound of the number of the symbols in the target enum. If not, write an error log to help the investigation by the users and return null. If yes, read the symbol from enum.