### PR TITLE
Handle non-nullable union of single type for Avro

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -139,9 +139,7 @@ public class AvroSchemaUtil {
   }
 
   /**
-   * This method decides whether a schema is single type union
-   *
-   * single type union: a schema is of type union and there is only one option
+   * This method decides whether a schema represents a single type union, i.e., a union that contains only one option
    *
    * @param schema input schema
    * @return true if schema is single type union

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -139,6 +139,22 @@ public class AvroSchemaUtil {
   }
 
   /**
+   * This method decides whether a schema is single type union
+   *
+   * single type union: a schema is of type union and there is only one option
+   *
+   * @param schema input schema
+   * @return true if schema is single type union
+   */
+  public static boolean isSingleTypeUnion(Schema schema) {
+    if (schema.getType() == UNION && schema.getTypes().size() == 1) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * This method decides whether a schema is of type union and is complex union and is optional
    *
    * Complex union: the number of options in union not equals to 2

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -147,11 +147,7 @@ public class AvroSchemaUtil {
    * @return true if schema is single type union
    */
   public static boolean isSingleTypeUnion(Schema schema) {
-    if (schema.getType() == UNION && schema.getTypes().size() == 1) {
-      return true;
-    }
-
-    return false;
+    return schema.getType() == UNION && schema.getTypes().size() == 1;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -89,6 +89,13 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
           options.add(visit(type, branch, visitor));
         }
       }
+    } else if (AvroSchemaUtil.isSingleTypeUnion(union)) { // single type union case
+      Schema branch = types.get(0);
+      if (branch.getType() == Schema.Type.NULL) {
+        options.add(visit((Type) null, branch, visitor));
+      } else {
+        options.add(visit(type, branch, visitor));
+      }
     } else { // complex union case
       int index = 1;
       for (Schema branch : types) {

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -116,6 +116,9 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       } else {
         return options.get(0);
       }
+    } else if (AvroSchemaUtil.isSingleTypeUnion(union)) {
+      // Single type union
+      return options.get(0);
     } else {
       // Complex union
       List<Types.NestedField> newFields = new ArrayList<>();

--- a/core/src/test/java/org/apache/iceberg/avro/TestUnionSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestUnionSchemaConversions.java
@@ -74,7 +74,7 @@ public class TestUnionSchemaConversions {
   }
 
   @Test
-  public void testSimpleUnionSchema() {
+  public void testOptionalSingleUnionSchema() {
     Schema avroSchema = SchemaBuilder.record("root")
         .fields()
         .name("optionCol")
@@ -89,6 +89,64 @@ public class TestUnionSchemaConversions {
 
     org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
     String expectedIcebergSchema = "table {\n" + "  0: optionCol: optional int\n" + "}";
+
+    Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
+  }
+
+  @Test
+  public void testSingleTypeUnionSchema() {
+    Schema avroSchema = SchemaBuilder.record("root")
+        .fields()
+        .name("unionCol")
+        .type()
+        .unionOf()
+        .intType()
+        .endUnion()
+        .noDefault()
+        .endRecord();
+
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
+    String expectedIcebergSchema = "table {\n" + "  0: unionCol: required int\n" + "}";
+
+    Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
+  }
+
+  @Test
+  public void testNestedSingleTypeUnionSchema() {
+    Schema avroSchema = SchemaBuilder.record("root")
+        .fields()
+        .name("col1")
+        .type()
+        .array()
+        .items()
+        .unionOf()
+        .stringType()
+        .endUnion()
+        .noDefault()
+        .endRecord();
+
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
+    String expectedIcebergSchema = "table {\n" + "  0: col1: required list<string>\n" + "}";
+
+    Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
+  }
+
+  @Test
+  public void testSingleTypeUnionOfComplexTypeSchema() {
+    Schema avroSchema = SchemaBuilder.record("root")
+        .fields()
+        .name("unionCol")
+        .type()
+        .unionOf()
+        .array()
+        .items()
+        .intType()
+        .endUnion()
+        .noDefault()
+        .endRecord();
+
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(avroSchema);
+    String expectedIcebergSchema = "table {\n" + "  0: unionCol: required list<int>\n" + "}";
 
     Assert.assertEquals(expectedIcebergSchema, icebergSchema.toString());
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -80,7 +80,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
 
     @Override
     public ValueReader<?> union(Type expected, Schema union, List<ValueReader<?>> options) {
-      if (AvroSchemaUtil.isOptionSchema(union)) {
+      if (AvroSchemaUtil.isOptionSchema(union) || AvroSchemaUtil.isSingleTypeUnion(union)) {
         return ValueReaders.union(options);
       } else {
         return SparkValueReaders.union(union, options);


### PR DESCRIPTION
This PR handles non-nullable union of single type to be consistent with Trino representation for Avro.

Non-nullable single type union ```[type]``` should be read as ```type``` instead of ```struct<tag, field0>```