### PR TITLE
Handle null default in nested type default value situations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -333,6 +333,10 @@ public class SchemaParser {
   }
 
   private static String defaultValueToJsonString(Object value) {
+    if (value == null) {
+      // Json string representation of null object is string "null"
+      return "null";
+    }
     if (isPrimitiveClass(value)) {
       return value.toString();
     }


### PR DESCRIPTION
This will handle NPE in stack trace like:

```
27-04-2022 20:37:01 UTC generateLearners INFO - 	 diagnostics: User class threw exception: java.lang.NullPointerException
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.isPrimitiveClass(SchemaParser.java:348)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.defaultValueToJsonString(SchemaParser.java:336)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.lambda$defaultValueToJsonString$1(SchemaParser.java:317)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:671)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.defaultValueToJsonString(SchemaParser.java:316)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.writeDefaultValue(SchemaParser.java:83)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.toJson(SchemaParser.java:103)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.toJson(SchemaParser.java:154)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.toJson(SchemaParser.java:102)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.toJson(SchemaParser.java:183)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.SchemaParser.toJson(SchemaParser.java:173)
27-04-2022 20:37:01 UTC generateLearners INFO - 	at dali2_shaded.org.apache.iceberg.spark.source.SparkBatchScan.planInputPartitions(SparkBatchScan.java:142)
```

Where the `null` default value can occur in the default value of a nested type such as a map.