### PR TITLE
Remove `activeSparkSession`

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -76,7 +76,6 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.Option;
 
 import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 
@@ -144,7 +143,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     if (io.getValue() instanceof HadoopFileIO) {
       String fsscheme = "no_exist";
       try {
-        Configuration conf = new Configuration(activeSparkSession().sessionState().newHadoopConf());
+        Configuration conf = new Configuration(SparkSession.active().sessionState().newHadoopConf());
         // merge hadoop config set on table
         mergeIcebergHadoopConfs(conf, table.properties());
         // merge hadoop config passed as options and overwrite the one on table
@@ -521,22 +520,8 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
         return new String[0];
       }
 
-      Configuration conf = activeSparkSession().sparkContext().hadoopConfiguration();
+      Configuration conf = SparkSession.active().sparkContext().hadoopConfiguration();
       return Util.blockLocations(task, conf);
-    }
-  }
-
-  private static SparkSession activeSparkSession() {
-    final Option<SparkSession> activeSession = SparkSession.getActiveSession();
-    if (activeSession.isDefined()) {
-      return activeSession.get();
-    } else {
-      final Option<SparkSession> defaultSession = SparkSession.getDefaultSession();
-      if (defaultSession.isDefined()) {
-        return defaultSession.get();
-      } else {
-        throw new IllegalStateException("No active spark session found");
-      }
     }
   }
 


### PR DESCRIPTION
This PR is to revert [Spark 2.3: Replace SparkSession.active() calls with 2.3 supported methods](https://github.com/linkedin/iceberg/commit/7291f7362ac3e4c5618ce74ec9dba8e28cc5af0e), because such a commit is not necessary according to the test on gateway with Spark 2.3. Actually, we have used [SparkSession.active()](https://github.com/linkedin/iceberg/blob/li-0.11.x/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java#L168) in production directly for long without any issue.

Tests:
1. Existing unit tests
2. Tested on the gateway, worked well