### PR TITLE
Handle non-nullable union of single type for ORC spark non-vectorized reader

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -284,15 +284,21 @@ public final class ORCSchemaUtil {
       default:
         if (mapping.containsKey(fieldId)) {
           TypeDescription originalType = mapping.get(fieldId).type();
-          Optional<TypeDescription> promotedType = getPromotedType(type, originalType);
-
-          if (promotedType.isPresent()) {
-            orcType = promotedType.get();
-          } else {
-            Preconditions.checkArgument(isSameType(originalType, type),
-                "Can not promote %s type to %s",
-                originalType.getCategory(), type.typeId().name());
+          if (originalType != null && originalType.getCategory().equals(TypeDescription.Category.UNION)) {
+            Preconditions.checkState(originalType.getChildren().size() == 1,
+                "TODO: add proper error message");
             orcType = originalType.clone();
+          } else {
+            Optional<TypeDescription> promotedType = getPromotedType(type, originalType);
+
+            if (promotedType.isPresent()) {
+              orcType = promotedType.get();
+            } else {
+              Preconditions.checkArgument(isSameType(originalType, type),
+                  "Can not promote %s type to %s",
+                  originalType.getCategory(), type.typeId().name());
+              orcType = originalType.clone();
+            }
           }
         } else {
           if (isRequired) {

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -280,7 +280,7 @@ public final class ORCSchemaUtil {
           TypeDescription originalType = mapping.get(fieldId).type();
           if (originalType != null && originalType.getCategory().equals(TypeDescription.Category.UNION)) {
             Preconditions.checkState(originalType.getChildren().size() == 1,
-                "TODO: add proper error message");
+                "Expect single type union for orc schema.");
             orcType = originalType.clone();
           } else {
             Optional<TypeDescription> promotedType = getPromotedType(type, originalType);
@@ -312,7 +312,7 @@ public final class ORCSchemaUtil {
     final TypeDescription orcType;
     if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
       Preconditions.checkState(orcField.type.getChildren().size() == 1,
-          "TODO: add proper error message");
+          "Expect single type union for orc schema.");
 
       orcType = TypeDescription.createUnion();
       Types.MapType map = type;
@@ -335,7 +335,7 @@ public final class ORCSchemaUtil {
     final TypeDescription orcType;
     if (orcField != null && orcField.type.getCategory().equals(TypeDescription.Category.UNION)) {
       Preconditions.checkState(orcField.type.getChildren().size() == 1,
-          "TODO: add proper error message");
+          "Expect single type union for orc schema.");
 
       orcType = TypeDescription.createUnion();
       Types.ListType list = type;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
@@ -49,14 +49,20 @@ public abstract class OrcSchemaVisitor<T> {
       case UNION:
         List<TypeDescription> types = schema.getChildren();
         List<T> options = Lists.newArrayListWithExpectedSize(types.size());
-        for (int i = 0; i < types.size(); i++) {
-          visitor.beforeUnionOption(types.get(i), i);
-          try {
-            options.add(visit(types.get(i), visitor));
-          } finally {
-            visitor.afterUnionOption(types.get(i), i);
+
+        if (types.size() == 1) {
+          options.add(visit(types.get(0), visitor));
+        } else {
+          for (int i = 0; i < types.size(); i++) {
+            visitor.beforeUnionOption(types.get(i), i);
+            try {
+              options.add(visit(types.get(i), visitor));
+            } finally {
+              visitor.afterUnionOption(types.get(i), i);
+            }
           }
         }
+
         return visitor.union(schema, options);
 
       case LIST:

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -75,8 +75,12 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     List<TypeDescription> types = union.getChildren();
     List<T> options = Lists.newArrayListWithCapacity(types.size());
 
-    for (int i = 0; i < types.size(); i += 1) {
-      options.add(visit(type.asStructType().fields().get(i + 1).type(), types.get(i), visitor));
+    if (types.size() == 1) { // single type union
+      options.add(visit(type, types.get(0), visitor));
+    } else { // complex union
+      for (int i = 0; i < types.size(); i += 1) {
+        options.add(visit(type.asStructType().fields().get(i + 1).type(), types.get(i), visitor));
+      }
     }
 
     return visitor.union(type, union, options);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -380,6 +380,81 @@ public class TestSparkOrcUnions {
      */
   }
 
+  @Test
+  public void testDeepNestedSingleTypeUnion() throws IOException {
+    TypeDescription orcSchema =
+        TypeDescription.fromString("struct<outerUnion:uniontype<struct<innerUnion:uniontype<string>>>>");
+
+    Schema expectedSchema = new Schema(
+        Types.NestedField.optional(0, "outerUnion", Types.StructType.of(
+            Types.NestedField.optional(1, "innerUnion", Types.StringType.get())
+        )));
+
+    final InternalRow expectedFirstRow = new GenericInternalRow(1);
+    final InternalRow innerExpectedFirstRow = new GenericInternalRow(1);
+    innerExpectedFirstRow.update(0, UTF8String.fromString("foo-0"));
+    expectedFirstRow.update(0, innerExpectedFirstRow);
+
+    final InternalRow expectedSecondRow = new GenericInternalRow(1);
+    final InternalRow innerExpectedSecondRow = new GenericInternalRow(1);
+    innerExpectedSecondRow.update(0, UTF8String.fromString("foo-1"));
+    expectedSecondRow.update(0, innerExpectedSecondRow);
+
+    Configuration conf = new Configuration();
+
+    File orcFile = temp.newFile();
+    Path orcFilePath = new Path(orcFile.getPath());
+
+    Writer writer = OrcFile.createWriter(orcFilePath,
+        OrcFile.writerOptions(conf)
+            .setSchema(orcSchema).overwrite(true));
+
+    VectorizedRowBatch batch = orcSchema.createRowBatch();
+    UnionColumnVector outerUnion = (UnionColumnVector) batch.cols[0];
+    StructColumnVector structColumnVector = (StructColumnVector) outerUnion.fields[0];
+    UnionColumnVector innerUnion = (UnionColumnVector) structColumnVector.fields[0];
+    BytesColumnVector bytesColumnVector = (BytesColumnVector) innerUnion.fields[0];
+
+    for (int i = 0; i < NUM_OF_ROWS; i += 1) {
+      outerUnion.tags[i] = 0;
+      innerUnion.tags[i] = 0;
+      String stringValue = "foo-" + i;
+      bytesColumnVector.setVal(i, stringValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    batch.size = NUM_OF_ROWS;
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    // Test non-vectorized reader
+    List<InternalRow> actualRows = Lists.newArrayList();
+    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
+        .project(expectedSchema)
+        .createReaderFunc(readOrcSchema -> new SparkOrcReader(expectedSchema, readOrcSchema))
+        .build()) {
+      reader.forEach(actualRows::add);
+
+      Assert.assertEquals(actualRows.size(), NUM_OF_ROWS);
+      assertEquals(expectedSchema, expectedFirstRow, actualRows.get(0));
+      assertEquals(expectedSchema, expectedSecondRow, actualRows.get(1));
+    }
+
+    // Test vectorized reader
+    /*
+    try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+        .project(expectedSchema)
+        .createBatchedReaderFunc(readOrcSchema ->
+            VectorizedSparkOrcReaders.buildReader(expectedSchema, readOrcSchema, ImmutableMap.of()))
+        .build()) {
+      final Iterator<InternalRow> actualRowsIt = batchesToRows(reader.iterator());
+
+      assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
+      assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
+    }
+     */
+  }
+
   private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
     return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -307,6 +307,79 @@ public class TestSparkOrcUnions {
      */
   }
 
+  @Test
+  public void testSingleTypeUnionOfStruct() throws IOException {
+    TypeDescription orcSchema =
+        TypeDescription.fromString("struct<unionCol:uniontype<struct<c:string>>>");
+
+    Schema expectedSchema = new Schema(
+        Types.NestedField.optional(0, "unionCol", Types.StructType.of(
+          Types.NestedField.optional(1, "c", Types.StringType.get())
+    )));
+
+    final InternalRow expectedFirstRow = new GenericInternalRow(1);
+    final InternalRow innerExpectedFirstRow = new GenericInternalRow(1);
+    innerExpectedFirstRow.update(0, UTF8String.fromString("foo-0"));
+    expectedFirstRow.update(0, innerExpectedFirstRow);
+
+    final InternalRow expectedSecondRow = new GenericInternalRow(1);
+    final InternalRow innerExpectedSecondRow = new GenericInternalRow(1);
+    innerExpectedSecondRow.update(0, UTF8String.fromString("foo-1"));
+    expectedSecondRow.update(0, innerExpectedSecondRow);
+
+    Configuration conf = new Configuration();
+
+    File orcFile = temp.newFile();
+    Path orcFilePath = new Path(orcFile.getPath());
+
+    Writer writer = OrcFile.createWriter(orcFilePath,
+        OrcFile.writerOptions(conf)
+            .setSchema(orcSchema).overwrite(true));
+
+    VectorizedRowBatch batch = orcSchema.createRowBatch();
+    UnionColumnVector complexUnion = (UnionColumnVector) batch.cols[0];
+    StructColumnVector structColumnVector = (StructColumnVector) complexUnion.fields[0];
+    BytesColumnVector bytesColumnVector = (BytesColumnVector) structColumnVector.fields[0];
+
+    for (int i = 0; i < NUM_OF_ROWS; i += 1) {
+      complexUnion.tags[i] = 0;
+      String stringValue = "foo-" + i;
+      bytesColumnVector.setVal(i, stringValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    batch.size = NUM_OF_ROWS;
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    // Test non-vectorized reader
+    List<InternalRow> actualRows = Lists.newArrayList();
+    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
+        .project(expectedSchema)
+        .createReaderFunc(readOrcSchema -> new SparkOrcReader(expectedSchema, readOrcSchema))
+        .build()) {
+      reader.forEach(actualRows::add);
+
+      Assert.assertEquals(actualRows.size(), NUM_OF_ROWS);
+      assertEquals(expectedSchema, expectedFirstRow, actualRows.get(0));
+      assertEquals(expectedSchema, expectedSecondRow, actualRows.get(1));
+    }
+
+    // Test vectorized reader
+    /*
+    try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+        .project(expectedSchema)
+        .createBatchedReaderFunc(readOrcSchema ->
+            VectorizedSparkOrcReaders.buildReader(expectedSchema, readOrcSchema, ImmutableMap.of()))
+        .build()) {
+      final Iterator<InternalRow> actualRowsIt = batchesToRows(reader.iterator());
+
+      assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
+      assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
+    }
+     */
+  }
+
   private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
     return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
   }


### PR DESCRIPTION
This PR handles non-nullable union of single type to be consistent with Trino representation for ORC spark non-vectorized reader.

Non-nullable single type union `[type]` should be read as `type` instead of `struct<tag, field0>`