### PR TITLE
Modify support for reading timestamp without timezone to be aligned with upstream

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -47,6 +47,4 @@ public class SparkReadOptions {
 
   // Overrides the table's read.parquet.vectorization.batch-size
   public static final String VECTORIZATION_BATCH_SIZE = "batch-size";
-
-  public static final String READ_TIMESTAMP_WITHOUT_ZONE = "read-timestamp-without-zone";
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -127,6 +127,30 @@ public class SparkSchemaUtil {
   }
 
   /**
+   * Convert a Spark {@link StructType struct} to a {@link Schema} with new field ids.
+   * <p>
+   * This conversion assigns fresh ids.
+   * <p>
+   * Some data types are represented as the same Spark type. These are converted to a default type.
+   * <p>
+   * To convert using a reference schema for field ids and ambiguous types, use
+   * {@link #convert(Schema, StructType)}.
+   *
+   * @param sparkType a Spark StructType
+   * @param useTimestampWithoutZone boolean flag indicates that timestamp should be stored without timezone
+   * @return the equivalent Schema
+   * @throws IllegalArgumentException if the type cannot be converted
+   */
+  public static Schema convert(StructType sparkType, boolean useTimestampWithoutZone) {
+    Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
+    Schema schema = new Schema(converted.asNestedType().asStructType().fields());
+    if (useTimestampWithoutZone) {
+      schema = SparkFixupTimestampType.fixup(schema);
+    }
+    return schema;
+  }
+
+  /**
    * Convert a Spark {@link DataType struct} to a {@link Type} with new field ids.
    * <p>
    * This conversion assigns fresh ids.

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -20,21 +20,37 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.UnknownTransform;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.util.SerializableConfiguration;
 
 public class SparkUtil {
+
+  public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE = "read-timestamp-without-zone";
+  public static final String TIMESTAMP_WITHOUT_TIMEZONE_ERROR = String.format("Cannot handle timestamp without" +
+      " timezone fields in Spark. Spark does not natively support this type but if you would like to handle all" +
+      " timestamps as timestamp with timezone set '%s' to true. This will not change the underlying values stored" +
+      " but will change their displayed values in Spark. For more information please see" +
+      " https://docs.databricks.com/spark/latest/dataframes-datasets/dates-timestamps.html#ansi-sql-and" +
+      "-spark-sql-timestamps", HANDLE_TIMESTAMP_WITHOUT_TIMEZONE);
+  public static final String USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES =
+      "spark.sql.iceberg.use-timestamp-without-timezone-in-new-tables";
+
   private SparkUtil() {
   }
 
@@ -99,5 +115,58 @@ public class SparkUtil {
         return Pair.of(catalog, identiferProvider.apply(namespace, name));
       }
     }
+  }
+
+  /**
+   * Responsible for checking if the table schema has a timestamp without timezone column
+   * @param schema table schema to check if it contains a timestamp without timezone column
+   * @return boolean indicating if the schema passed in has a timestamp field without a timezone
+   */
+  public static boolean hasTimestampWithoutZone(Schema schema) {
+    return TypeUtil.find(schema, t -> Types.TimestampType.withoutZone().equals(t)) != null;
+  }
+
+  /**
+   * Allow reading/writing timestamp without time zone as timestamp with time zone. Generally,
+   * this is not safe as timestamp without time zone is supposed to represent wall clock time semantics,
+   * i.e. no matter the reader/writer timezone 3PM should always be read as 3PM,
+   * but timestamp with time zone represents instant semantics, i.e the timestamp
+   * is adjusted so that the corresponding time in the reader timezone is displayed.
+   * When set to false (default), we throw an exception at runtime
+   * "Spark does not support timestamp without time zone fields" if reading timestamp without time zone fields
+   *
+   * @param readerConfig table read options
+   * @param sessionConf spark session configurations
+   * @return boolean indicating if reading timestamps without timezone is allowed
+   */
+  public static boolean canHandleTimestampWithoutZone(Map<String, String> readerConfig, RuntimeConfig sessionConf) {
+    String readerOption = readerConfig.get(HANDLE_TIMESTAMP_WITHOUT_TIMEZONE);
+    if (readerOption != null) {
+      return Boolean.parseBoolean(readerOption);
+    }
+    String sessionConfValue = sessionConf.get(HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, null);
+    if (sessionConfValue != null) {
+      return Boolean.parseBoolean(sessionConfValue);
+    }
+    return false;
+  }
+
+  /**
+   * Check whether the spark session config contains a {@link SparkUtil#USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES}
+   * property.
+   * Default value - false
+   * If true in new table all timestamp fields will be stored as {@link Types.TimestampType#withoutZone()},
+   * otherwise {@link Types.TimestampType#withZone()} will be used
+   *
+   * @param sessionConf a spark runtime config
+   * @return true if the session config has {@link SparkUtil#USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES} property
+   * and this property is set to true
+   */
+  public static boolean useTimestampWithoutZoneInNewTables(RuntimeConfig sessionConf) {
+    String sessionConfValue = sessionConf.get(USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES, null);
+    if (sessionConfValue != null) {
+      return Boolean.parseBoolean(sessionConfValue);
+    }
+    return false;
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
@@ -110,6 +110,7 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         case DECIMAL:
           return SparkOrcValueWriters.decimal(primitive.getPrecision(), primitive.getScale());
         case TIMESTAMP_INSTANT:
+        case TIMESTAMP:
           return SparkOrcValueWriters.timestampTz();
         default:
           throw new IllegalArgumentException("Unhandled type " + primitive);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -20,15 +20,20 @@
 package org.apache.iceberg.spark.data;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.spark.sql.internal.SQLConf;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -184,5 +189,52 @@ public abstract class AvroDataTest {
         .asStructType().fields());
 
     writeAndValidate(schema);
+  }
+
+  @Test
+  public void testTimestampWithoutZone() throws IOException {
+    withSQLConf(ImmutableMap.of(SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true"), () -> {
+      Schema schema = TypeUtil.assignIncreasingFreshIds(new Schema(
+          required(0, "id", LongType.get()),
+          optional(1, "ts_without_zone", Types.TimestampType.withoutZone())));
+
+      writeAndValidate(schema);
+    });
+  }
+
+  protected void withSQLConf(Map<String, String> conf, Action action) throws IOException {
+    SQLConf sqlConf = SQLConf.get();
+
+    Map<String, String> currentConfValues = Maps.newHashMap();
+    conf.keySet().forEach(confKey -> {
+      if (sqlConf.contains(confKey)) {
+        String currentConfValue = sqlConf.getConfString(confKey);
+        currentConfValues.put(confKey, currentConfValue);
+      }
+    });
+
+    conf.forEach((confKey, confValue) -> {
+      if (SQLConf.staticConfKeys().contains(confKey)) {
+        throw new RuntimeException("Cannot modify the value of a static config: " + confKey);
+      }
+      sqlConf.setConfString(confKey, confValue);
+    });
+
+    try {
+      action.invoke();
+    } finally {
+      conf.forEach((confKey, confValue) -> {
+        if (currentConfValues.containsKey(confKey)) {
+          sqlConf.setConfString(confKey, currentConfValues.get(confKey));
+        } else {
+          sqlConf.unsetConf(confKey);
+        }
+      });
+    }
+  }
+
+  @FunctionalInterface
+  protected interface Action {
+    void invoke() throws IOException;
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
@@ -248,9 +249,16 @@ public class GenericsHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
         break;
       case TIMESTAMP:
-        Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
-        long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
-        Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
+        Types.TimestampType timestampType = (Types.TimestampType) type;
+        if (timestampType.shouldAdjustToUTC()) {
+          Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
+          long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
+          Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
+        } else {
+          Assert.assertTrue("Should expect an LocalDateTime", expected instanceof LocalDateTime);
+          long expectedMicros = ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
+          Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
+        }
         break;
       case STRING:
         Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -260,4 +260,9 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     assertRecordsMatch(readSchema, 30000, data, dataFile, false,
         true, BATCH_SIZE);
   }
+
+  @Test
+  @Ignore
+  public void testTimestampWithoutZone() {
+  }
 }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -91,6 +91,10 @@ public class IcebergSource implements DataSourceV2, ReadSupport, WriteSupport, D
         "Save mode %s is not supported", mode);
     Configuration conf = new Configuration(lazyBaseConf());
     Table table = getTableAndResolveHadoopConfiguration(options, conf);
+    boolean handleTimestampWithoutZone =
+        SparkUtil.canHandleTimestampWithoutZone(options.asMap(), lazySparkSession().conf());
+    Preconditions.checkArgument(handleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
+        SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
     Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsStruct);
     TypeUtil.validateWriteSchema(table.schema(), writeSchema, checkNullability(options), checkOrdering(options));
     SparkUtil.validatePartitionTransforms(table.spec());

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -54,12 +54,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkFilters;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.Filter;
@@ -178,16 +177,8 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     this.batchSize = options.get(SparkReadOptions.VECTORIZATION_BATCH_SIZE).map(Integer::parseInt).orElseGet(() ->
         PropertyUtil.propertyAsInt(table.properties(),
           TableProperties.PARQUET_BATCH_SIZE, TableProperties.PARQUET_BATCH_SIZE_DEFAULT));
-    // Allow reading timestamp without time zone as timestamp with time zone. Generally, this is not safe as timestamp
-    // without time zone is supposed to represent wall clock time semantics, i.e. no matter the reader/writer timezone
-    // 3PM should always be read as 3PM, but timestamp with time zone represents instant semantics, i.e the timestamp
-    // is adjusted so that the corresponding time in the reader timezone is displayed. However, at LinkedIn, all readers
-    // and writers are in the UTC timezone as our production machines are set to UTC. So, timestamp with/without time
-    // zone is the same.
-    // When set to false (default), we throw an exception at runtime
-    // "Spark does not support timestamp without time zone fields" if reading timestamp without time zone fields
-    this.readTimestampWithoutZone = options.get(SparkReadOptions.READ_TIMESTAMP_WITHOUT_ZONE)
-            .map(Boolean::parseBoolean).orElse(false);
+    RuntimeConfig sessionConf = SparkSession.active().conf();
+    this.readTimestampWithoutZone = SparkUtil.canHandleTimestampWithoutZone(options.asMap(), sessionConf);
   }
 
   private Schema lazySchema() {
@@ -211,8 +202,8 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
   private StructType lazyType() {
     if (type == null) {
-      Preconditions.checkArgument(readTimestampWithoutZone || !hasTimestampWithoutZone(lazySchema()),
-          "Spark does not support timestamp without time zone fields");
+      Preconditions.checkArgument(readTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(lazySchema()),
+          SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
       this.type = SparkSchemaUtil.convert(lazySchema());
     }
     return type;
@@ -381,18 +372,12 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
       boolean hasNoDeleteFiles = tasks().stream().noneMatch(TableScanUtil::hasDeletes);
 
-      boolean hasTimestampWithoutZone = hasTimestampWithoutZone(lazySchema());
+      boolean hasTimestampWithoutZone = SparkUtil.hasTimestampWithoutZone(lazySchema());
 
       this.readUsingBatch = batchReadsEnabled && hasNoDeleteFiles && ((allOrcFileScanTasks && hasNoRowFilters) ||
           (allParquetFileScanTasks && atLeastOneColumn && onlyPrimitives && !hasTimestampWithoutZone));
     }
     return readUsingBatch;
-  }
-
-  private static boolean hasTimestampWithoutZone(Schema schema) {
-    return TypeUtil.find(schema, t ->
-        t.typeId().equals(Type.TypeID.TIMESTAMP) && !((Types.TimestampType) t).shouldAdjustToUTC()
-    ) != null;
   }
 
   private static void mergeIcebergHadoopConfs(

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -85,6 +85,7 @@ public class SparkCatalog extends BaseCatalog {
   private SupportsNamespaces asNamespaceCatalog = null;
   private String[] defaultNamespace = null;
   private HadoopTables tables;
+  private boolean useTimestampsWithoutZone;
 
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
@@ -124,7 +125,7 @@ public class SparkCatalog extends BaseCatalog {
   public SparkTable createTable(Identifier ident, StructType schema,
                                 Transform[] transforms,
                                 Map<String, String> properties) throws TableAlreadyExistsException {
-    Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    Schema icebergSchema = SparkSchemaUtil.convert(schema, useTimestampsWithoutZone);
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Table icebergTable = builder
@@ -141,7 +142,7 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public StagedTable stageCreate(Identifier ident, StructType schema, Transform[] transforms,
                                  Map<String, String> properties) throws TableAlreadyExistsException {
-    Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    Schema icebergSchema = SparkSchemaUtil.convert(schema, useTimestampsWithoutZone);
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction = builder.withPartitionSpec(Spark3Util.toPartitionSpec(icebergSchema, transforms))
@@ -157,7 +158,7 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public StagedTable stageReplace(Identifier ident, StructType schema, Transform[] transforms,
                                   Map<String, String> properties) throws NoSuchTableException {
-    Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    Schema icebergSchema = SparkSchemaUtil.convert(schema, useTimestampsWithoutZone);
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction = builder.withPartitionSpec(Spark3Util.toPartitionSpec(icebergSchema, transforms))
@@ -173,7 +174,7 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public StagedTable stageCreateOrReplace(Identifier ident, StructType schema, Transform[] transforms,
                                           Map<String, String> properties) {
-    Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    Schema icebergSchema = SparkSchemaUtil.convert(schema, useTimestampsWithoutZone);
     Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
     Transaction transaction = builder.withPartitionSpec(Spark3Util.toPartitionSpec(icebergSchema, transforms))
         .withLocation(properties.get("location"))
@@ -380,7 +381,9 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
-    this.tables = new HadoopTables(SparkSession.active().sessionState().newHadoopConf());
+    SparkSession sparkSession = SparkSession.active();
+    this.useTimestampsWithoutZone = SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
+    this.tables = new HadoopTables(sparkSession.sessionState().newHadoopConf());
     this.icebergCatalog = cacheEnabled ? CachingCatalog.wrap(catalog) : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -55,6 +55,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
   private final StructType dsSchema;
   private final CaseInsensitiveStringMap options;
   private final String overwriteMode;
+  private final boolean canHandleTimestampWithoutZone;
   private boolean overwriteDynamic = false;
   private boolean overwriteByFilter = false;
   private Expression overwriteExpr = null;
@@ -73,6 +74,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     this.options = info.options();
     this.overwriteMode = options.containsKey("overwrite-mode") ?
         options.get("overwrite-mode").toLowerCase(Locale.ROOT) : null;
+    this.canHandleTimestampWithoutZone = SparkUtil.canHandleTimestampWithoutZone(options, spark.conf());
   }
 
   private JavaSparkContext lazySparkContext() {
@@ -117,6 +119,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
   @Override
   public BatchWrite buildForBatch() {
     // Validate
+    Preconditions.checkArgument(canHandleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
+        SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
+
     Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
     TypeUtil.validateWriteSchema(table.schema(), writeSchema,
         checkNullability(spark, options), checkOrdering(spark, options));

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.sql;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.SparkUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+public class TestTimestampWithoutZone extends SparkCatalogTestBase {
+
+  private static final String newTableName = "created_table";
+  private final Map<String, String> config;
+
+  private static final Schema schema = new Schema(
+      Types.NestedField.required(1, "id", Types.LongType.get()),
+      Types.NestedField.required(2, "ts", Types.TimestampType.withoutZone()),
+      Types.NestedField.required(3, "tsz", Types.TimestampType.withZone())
+  );
+
+  private final List<Object[]> values = ImmutableList.of(
+      row(1L, toTimestamp("2021-01-01T00:00:00.0"), toTimestamp("2021-02-01T00:00:00.0")),
+      row(2L, toTimestamp("2021-01-01T00:00:00.0"), toTimestamp("2021-02-01T00:00:00.0")),
+      row(3L, toTimestamp("2021-01-01T00:00:00.0"), toTimestamp("2021-02-01T00:00:00.0"))
+  );
+
+  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return new Object[][]{{"spark_catalog",
+        SparkSessionCatalog.class.getName(),
+        ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            "parquet-enabled", "true",
+            "cache-enabled", "false"
+        )}
+    };
+  }
+
+  public TestTimestampWithoutZone(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+    this.config = config;
+  }
+
+  @Before
+  public void createTables() {
+    validationCatalog.createTable(tableIdent, schema);
+  }
+
+  @After
+  public void removeTables() {
+    validationCatalog.dropTable(tableIdent, true);
+    sql("DROP TABLE IF EXISTS %s", newTableName);
+  }
+
+  @Test
+  public void testWriteTimestampWithoutZoneError() {
+    AssertHelpers.assertThrows(
+        String.format("Write operation performed on a timestamp without timezone field while " +
+            "'%s' set to false should throw exception", SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE),
+        IllegalArgumentException.class,
+        SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR,
+        () -> sql("INSERT INTO %s VALUES %s", tableName, rowToSqlValues(values)));
+  }
+
+  @Test
+  public void testAppendTimestampWithoutZone() {
+    withSQLConf(ImmutableMap.of(SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true"), () -> {
+      sql("INSERT INTO %s VALUES %s", tableName, rowToSqlValues(values));
+
+      Assert.assertEquals("Should have " + values.size() + " row",
+          (long) values.size(), scalarSql("SELECT count(*) FROM %s", tableName));
+
+      assertEquals("Row data should match expected",
+          values, sql("SELECT * FROM %s ORDER BY id", tableName));
+    });
+  }
+
+  @Test
+  public void testCreateAsSelectWithTimestampWithoutZone() {
+    withSQLConf(ImmutableMap.of(SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true"), () -> {
+      sql("INSERT INTO %s VALUES %s", tableName, rowToSqlValues(values));
+
+      sql("CREATE TABLE %s USING iceberg AS SELECT * FROM %s", newTableName, tableName);
+
+      Assert.assertEquals("Should have " + values.size() + " row", (long) values.size(),
+          scalarSql("SELECT count(*) FROM %s", newTableName));
+
+      assertEquals("Row data should match expected",
+          sql("SELECT * FROM %s ORDER BY id", tableName),
+          sql("SELECT * FROM %s ORDER BY id", newTableName));
+    });
+  }
+
+  @Test
+  public void testCreateNewTableShouldHaveTimestampWithZoneIcebergType() {
+    withSQLConf(ImmutableMap.of(SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true"), () -> {
+      sql("INSERT INTO %s VALUES %s", tableName, rowToSqlValues(values));
+
+      sql("CREATE TABLE %s USING iceberg AS SELECT * FROM %s", newTableName, tableName);
+
+      Assert.assertEquals("Should have " + values.size() + " row", (long) values.size(),
+          scalarSql("SELECT count(*) FROM %s", newTableName));
+
+      assertEquals("Data from created table should match data from base table",
+          sql("SELECT * FROM %s ORDER BY id", tableName),
+          sql("SELECT * FROM %s ORDER BY id", newTableName));
+
+      Table createdTable = validationCatalog.loadTable(TableIdentifier.of("default", newTableName));
+      assertFieldsType(createdTable.schema(), Types.TimestampType.withZone(), "ts", "tsz");
+    });
+  }
+
+  @Test
+  public void testCreateNewTableShouldHaveTimestampWithoutZoneIcebergType() {
+    withSQLConf(ImmutableMap.of(
+        SparkUtil.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true",
+        SparkUtil.USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES, "true"), () -> {
+        spark.sessionState().catalogManager().currentCatalog()
+            .initialize(catalog.name(), new CaseInsensitiveStringMap(config));
+        sql("INSERT INTO %s VALUES %s", tableName, rowToSqlValues(values));
+
+        sql("CREATE TABLE %s USING iceberg AS SELECT * FROM %s", newTableName, tableName);
+
+        Assert.assertEquals("Should have " + values.size() + " row", (long) values.size(),
+            scalarSql("SELECT count(*) FROM %s", newTableName));
+
+        assertEquals("Row data should match expected",
+            sql("SELECT * FROM %s ORDER BY id", tableName),
+            sql("SELECT * FROM %s ORDER BY id", newTableName));
+        Table createdTable = validationCatalog.loadTable(TableIdentifier.of("default", newTableName));
+        assertFieldsType(createdTable.schema(), Types.TimestampType.withoutZone(), "ts", "tsz");
+      });
+  }
+
+  private Timestamp toTimestamp(String value) {
+    return new Timestamp(DateTime.parse(value).getMillis());
+  }
+
+  private String rowToSqlValues(List<Object[]> rows) {
+    List<String> rowValues = rows.stream().map(row -> {
+      List<String> columns = Arrays.stream(row).map(value -> {
+        if (value instanceof Long) {
+          return value.toString();
+        } else if (value instanceof Timestamp) {
+          return String.format("timestamp '%s'", value);
+        }
+        throw new RuntimeException("Type is not supported");
+      }).collect(Collectors.toList());
+      return "(" + Joiner.on(",").join(columns) + ")";
+    }).collect(Collectors.toList());
+    return Joiner.on(",").join(rowValues);
+  }
+
+  private void assertFieldsType(Schema actual, Type.PrimitiveType expected, String... fields) {
+    actual.select(fields).asStruct().fields().forEach(field -> Assert.assertEquals(expected, field.type()));
+  }
+}


### PR DESCRIPTION
This PR is to modify [this commit](https://github.com/linkedin/iceberg/commit/c7f97aefff3d201cd949b8a55f833eec97346d8c) to be aligned with the [upstream PR](https://github.com/apache/iceberg/pull/2757/files), mainly in the following aspects:
1. Add support for writing timestamp without timezone
2. Move previous `READ_TIMESTAMP_WITHOUT_ZONE` flag to `HANDLE_TIMESTAMP_WITHOUT_TIMEZONE` in `SparkUtil`. We still keep using `"read-timestamp-without-zone"` as the value of `HANDLE_TIMESTAMP_WITHOUT_TIMEZONE` so that we don't need to modify its value internally
3. Add more tests

Tests:
1. `./gradlew clean build`
2. All the existing and new unit tests
3. Tested on gateway, worked well