### PR TITLE
Disable default value preserving

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -100,7 +100,8 @@ public class SchemaParser {
       generator.writeBooleanField(REQUIRED, field.isRequired());
       generator.writeFieldName(TYPE);
       toJson(field.type(), generator);
-      writeDefaultValue(field.getDefaultValue(), field.type(), generator);
+      // BDP-xxx: Disable serializing default value
+//      writeDefaultValue(field.getDefaultValue(), field.type(), generator);
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
       }
@@ -248,13 +249,14 @@ public class SchemaParser {
       int id = JsonUtil.getInt(ID, field);
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(field.get(TYPE));
-      Object defaultValue = defaultValueFromJson(field, type);
+      // BDP-xxx: Disable deserializing default value
+//      Object defaultValue = defaultValueFromJson(field, type);
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
       if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type, defaultValue, doc));
+        fields.add(Types.NestedField.required(id, name, type, doc));
       } else {
-        fields.add(Types.NestedField.optional(id, name, type, defaultValue, doc));
+        fields.add(Types.NestedField.optional(id, name, type, doc));
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -100,7 +100,7 @@ public class SchemaParser {
       generator.writeBooleanField(REQUIRED, field.isRequired());
       generator.writeFieldName(TYPE);
       toJson(field.type(), generator);
-      // BDP-xxx: Disable serializing default value
+      // BDP-11826: Disable serializing default value
 //      writeDefaultValue(field.getDefaultValue(), field.type(), generator);
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
@@ -249,7 +249,7 @@ public class SchemaParser {
       int id = JsonUtil.getInt(ID, field);
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(field.get(TYPE));
-      // BDP-xxx: Disable deserializing default value
+      // BDP-11826: Disable deserializing default value
 //      Object defaultValue = defaultValueFromJson(field, type);
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParserForDefaultValues.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types.NestedField;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.avro.Schema.Type.BOOLEAN;
@@ -42,7 +43,7 @@ import static org.apache.avro.Schema.Type.LONG;
 import static org.apache.avro.Schema.Type.NULL;
 import static org.apache.avro.Schema.Type.STRING;
 
-
+@Ignore("BDP-11826: Disable default value preserving in iceberg schema")
 public class TestSchemaParserForDefaultValues {
 
   private void assertEqualStructs(org.apache.iceberg.Schema expected, org.apache.iceberg.Schema actual) {


### PR DESCRIPTION
This patch disable the LI-Iceberg implementation of default value preserving.
Since the related code exposes several bugs and impact production, and since in our current environment we don't really rely on Iceberg metadata. So I feel disabling this piece is the best short term solution.

In long term, after we switch to apache/iceberg and start using iceberg metadata, we can get default value feature for free https://github.com/apache/iceberg/pull/4301 so the implementation in LI-Iceberg is irrelevant at that time.