### PR TITLE
Column projection of union type

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -385,6 +385,7 @@ public class Avro {
     };
     private Long start = null;
     private Long length = null;
+    private Schema fileSchema = null;
 
     private ReadBuilder(InputFile file) {
       Preconditions.checkNotNull(file, "Input file cannot be null");
@@ -446,6 +447,11 @@ public class Avro {
       return this;
     }
 
+    public ReadBuilder setFileSchema(Schema fileSchema) {
+      this.fileSchema = fileSchema;
+      return this;
+    }
+
     public <D> AvroIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
       Function<Schema, DatumReader<?>> readerFunc;
@@ -458,7 +464,7 @@ public class Avro {
       }
 
       return new AvroIterable<>(file,
-          new ProjectionDatumReader<>(readerFunc, schema, renames, nameMapping),
+          new ProjectionDatumReader<>(readerFunc, schema, renames, nameMapping, fileSchema),
           start, length, reuseContainers);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -20,9 +20,7 @@
 package org.apache.iceberg.avro;
 
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -101,27 +99,65 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
         options.add(visit(type, branch, visitor));
       }
     } else { // complex union case
-      Map<Integer, Types.NestedField> icebergFieldMap = new HashMap<>();
-      for (Types.NestedField icebergField : type.asStructType().fields()) {
-        String fieldName = icebergField.name();
-        if (fieldName.equals(UNION_TAG_FIELD_NAME)) {
-          continue;
-        }
-        int fieldId = Integer.valueOf(fieldName.substring(5));
-        icebergFieldMap.put(fieldId, icebergField);
-      }
-
-      for (int i = 0; i < types.size(); ++i) {
-        Schema schema = types.get(i);
-        int fieldIdxInIceberg = types.get(0).getType() == Schema.Type.NULL ? i - 1 : i;
-        if (schema.getType() == Schema.Type.NULL || !icebergFieldMap.containsKey(fieldIdxInIceberg)) {
-          options.add(visit((Type) null, schema, visitor));
-        } else {
-          options.add(visit(icebergFieldMap.get(fieldIdxInIceberg).type(), schema, visitor));
-        }
-      }
+      visitComplexUnion(type, union, visitor, options);
     }
     return visitor.union(type, union, options);
+  }
+
+  /*
+  A complex union with multiple types of Avro schema is converted into a struct with multiple fields of Iceberg schema.
+  A field is related to a type in the order defined in Avro schema. Also, an extra tag field is added into the struct of
+  Iceberg schema. The user can query the column of union type with the field projected (e.g. colUnion.field0) in which
+  the maximum number of the fields to be projected equals to the number of fields of the complete struct converted
+  from the union. The case of without field projection equals to the case of full fields projection.
+  Therefore, this function visits the complex union by assuming the field projection always happens.
+   */
+  private static <T> void visitComplexUnion(Type type, Schema union,
+                                            AvroSchemaWithTypeVisitor<T> visitor, List<T> options) {
+    boolean nullTypeFound = false;
+    int typeIndex = 0;
+    int fieldIndexInStruct = 0;
+    while (typeIndex < union.getTypes().size()) {
+      Schema schema = union.getTypes().get(typeIndex);
+      // in some cases, a NULL type exists in the union of Avro schema besides the actual types,
+      // and it affects the index of the actual types of the order in the union
+      if (schema.getType() == Schema.Type.NULL) {
+        nullTypeFound = true;
+        options.add(visit((Type) null, schema, visitor));
+        typeIndex++;
+        continue;
+      }
+
+      // If a NULL type is found before current type, the type index is one larger than the actual type index which
+      // can be used to track the corresponding field in the struct of Iceberg schema.
+      int actualTypeIndex = nullTypeFound ? typeIndex - 1 : typeIndex;
+      boolean relatedFieldInStructFound = false;
+      while (fieldIndexInStruct < type.asStructType().fields().size()) {
+        String structFieldName = type.asStructType().fields().get(fieldIndexInStruct).name();
+        if (UNION_TAG_FIELD_NAME.equals(structFieldName)) {
+          fieldIndexInStruct++;
+          continue;
+        }
+
+        int indexFromStructFieldName = Integer.valueOf(structFieldName.substring(5));
+        if (actualTypeIndex == indexFromStructFieldName) {
+          relatedFieldInStructFound = true;
+          options.add(visit(type.asStructType().fields().get(fieldIndexInStruct).type(), schema, visitor));
+          fieldIndexInStruct++;
+        }
+        break;
+      }
+
+      // If a field is not projected, a corresponding field in the struct of Iceberg schema cannot be found
+      // for current type of union in Avro schema, a reader for current type still needs to be created and
+      // used to make the reading of Avro file successfully. In this case, a null field type is used to
+      // create the option for the reader of the current type which still can read the corresponding content
+      // in Avro file successfully.
+      if (!relatedFieldInStructFound) {
+        options.add(visit((Type) null, schema, visitor));
+      }
+      typeIndex++;
+    }
   }
 
   private static <T> T visitArray(Type type, Schema array, AvroSchemaWithTypeVisitor<T> visitor) {

--- a/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
@@ -50,6 +50,18 @@ public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosi
     this.nameMapping = nameMapping;
   }
 
+  public ProjectionDatumReader(Function<Schema, DatumReader<?>> getReader,
+      org.apache.iceberg.Schema expectedSchema,
+      Map<String, String> renames,
+      NameMapping nameMapping,
+      Schema fileSchema) {
+    this.getReader = getReader;
+    this.expectedSchema = expectedSchema;
+    this.renames = renames;
+    this.nameMapping = nameMapping;
+    this.fileSchema = fileSchema;
+  }
+
   @Override
   public void setRowPositionSupplier(Supplier<Long> posSupplier) {
     if (wrapped instanceof SupportsRowPosition) {
@@ -59,7 +71,9 @@ public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosi
 
   @Override
   public void setSchema(Schema newFileSchema) {
-    this.fileSchema = newFileSchema;
+    if (this.fileSchema == null) {
+      this.fileSchema = newFileSchema;
+    }
     if (nameMapping == null && !AvroSchemaUtil.hasIds(fileSchema)) {
       nameMapping = MappingUtil.create(expectedSchema);
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -83,7 +83,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
       if (AvroSchemaUtil.isOptionSchema(union) || AvroSchemaUtil.isSingleTypeUnion(union)) {
         return ValueReaders.union(options);
       } else {
-        return SparkValueReaders.union(union, options);
+        return SparkValueReaders.union(union, options, expected);
       }
     }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroUnions.java
@@ -533,4 +533,45 @@ public class TestSparkAvroUnions {
     // making sure the rows can be read successfully
     Assert.assertEquals(2, rows.size());
   }
+
+  @Test
+  public void writeAndValidateRequiredComplexUnionWithProjection() throws IOException {
+    org.apache.avro.Schema avroSchema = SchemaBuilder.record("root")
+        .fields()
+        .name("unionCol")
+        .type()
+        .unionOf()
+        .intType()
+        .and()
+        .stringType()
+        .endUnion()
+        .noDefault()
+        .endRecord();
+
+    GenericData.Record unionRecord1 = new GenericData.Record(avroSchema);
+    unionRecord1.put("unionCol", "foo");
+    GenericData.Record unionRecord2 = new GenericData.Record(avroSchema);
+    unionRecord2.put("unionCol", 1);
+
+    File testFile = temp.newFile();
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(avroSchema, testFile);
+      writer.append(unionRecord1);
+      writer.append(unionRecord2);
+    }
+
+    Schema expectedSchema = AvroSchemaUtil.toIceberg(avroSchema).select("unionCol.field0");
+
+    List<InternalRow> rows;
+    try (AvroIterable<InternalRow> reader = Avro.read(Files.localInput(testFile))
+        .createReaderFunc(SparkAvroReader::new)
+        .project(expectedSchema)
+        .build()) {
+      rows = Lists.newArrayList(reader);
+
+      Assert.assertEquals(1, rows.get(0).getStruct(0, 1).numFields());
+      Assert.assertTrue(rows.get(0).getStruct(0, 1).isNullAt(0));
+      Assert.assertEquals(1, rows.get(1).getStruct(0, 1).getInt(0));
+    }
+  }
 }


### PR DESCRIPTION
**Problem**
Currently column projection does not work for union type. The root cause of the problem is as follows: 
- The current code assumes that the types inside a union from Avro schema should match the type fields inside a union struct from Iceberg schema when Avro union reader is created.
-  In case of column projection of union type, the current code only prune the schema of union in Iceberg schema with the projected fields, while the union of Avro schema still contains all the types. It results in the mismatch between Avro schema and Iceberg schema for the union in this case. 
- However, as all the contents of each data type in a union in Avro file should be read by Avro readers correctly no matter this data type is projected or not based on the decoding procedure of Avro file, all the types in a union from Avro schema are needed to create the corresponding type readers in AvroUnionReader even in case of column projection. Therefore the union in Avro schema cannot be pruned like what is done to the union struct in Iceberg schema.

**Solution**
Assuming there are N types in a union, there are N+1 fields including "tag" field in the struct corresponding to the union in Iceberg schema. The user can project any K fields (K>=1 and K<=N+1 and including the tag field) of the union in a query. The case of without column projection equals to full fields projection namely K=N+1. Therefore the solution does not differentiate the cases of with and without column projections.
In addition, the order of the types in a union in Iceberg schema can be identified from its field name like "field0".."fieldK". K is the index which can be used to match the order of the types in the union of Avro schema.

In the code of create the readers of all types in the union of Avro schema (namely `AvroSchemaWithTypeVisitor.visitUnion`), checking the fields of the struct corresponding union in Iceberg schema to create a map between the order index and the field type in Iceberg schema. When iterating through all the types in Avro schema, using the order index to check if the corresponding type exists in the map, if yes which means the field is projected, creating the option of creating the reader with the type in Iceberg schema, otherwise, creating the option with type null. 

In the code of AvroUnionReader, Iceberg schema needs to be passed into it. The fields of the returned row should be constructed based on the fields in Iceberg schema not the types in Avro schema. If tag field is projected, one more field is added in the beginning of the row and updated with the index of the field in Avro file.


**Test**
All the test cases in `TestSparkAvroUnions.java` with a new test case `writeAndValidateRequiredComplexUnionWithProjection`

Manual test with Spark3 with all the following queries on a table with a union:
```
val df = spark.sql("select c1.field0 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field0,c1.field1 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.tag,c1.field0 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.tag,c1.field0,c1.field1 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field1,c1.field0,c1.tag from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field1,c1.field0 from u_yiqding.avro_union_table_test")
```