### PR TITLE
Retain the type of field while copying the default values.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -94,8 +94,11 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
         // if the expectedField has a defaultValue, but the avroField does not, we need to
         // create a newField to copy over the non-null default value.
         if (expectedField.hasDefaultValue() && !AvroSchemaUtil.hasNonNullDefaultValue(avroField)) {
+          Schema newFiledSchema = (expectedField.isOptional()) ?
+                  AvroSchemaUtil.toOption(avroField.schema(), true) :
+                  avroField.schema();
           Schema.Field newField =
-              new Schema.Field(avroField.name(), avroField.schema(), avroField.doc(), expectedField.getDefaultValue());
+                  new Schema.Field(avroField.name(), newFiledSchema, avroField.doc(), expectedField.getDefaultValue());
           newField.addProp(AvroSchemaUtil.FIELD_ID_PROP, expectedField.fieldId());
           updatedFields.add(newField);
           hasChange = true;

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -92,13 +92,10 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
       if (avroField != null) {
         // if the expectedField has a defaultValue, but the avroField does not, we need to
-        // create a newField to copy over the non-null default value
+        // create a newField to copy over the non-null default value.
         if (expectedField.hasDefaultValue() && !AvroSchemaUtil.hasNonNullDefaultValue(avroField)) {
-          Schema newFiledSchema = (expectedField.isOptional()) ?
-              AvroSchemaUtil.toOption(AvroSchemaUtil.convert(expectedField.type()), true) :
-              AvroSchemaUtil.convert(expectedField.type());
           Schema.Field newField =
-              new Schema.Field(avroField.name(), newFiledSchema, avroField.doc(), expectedField.getDefaultValue());
+              new Schema.Field(avroField.name(), avroField.schema(), avroField.doc(), expectedField.getDefaultValue());
           newField.addProp(AvroSchemaUtil.FIELD_ID_PROP, expectedField.fieldId());
           updatedFields.add(newField);
           hasChange = true;


### PR DESCRIPTION
While building  a read schema to support custom readers the field types should be retained.  If default values are present in table schema the values should be copied over but without changing the type.