### PR TITLE
[Hivelink] Refactor support hive non string partition cols to rid of …

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/And.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/And.java
@@ -19,10 +19,7 @@
 
 package org.apache.iceberg.expressions;
 
-import org.apache.iceberg.StructLike;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
-public class And implements Expression, Bound<Boolean> {
+public class And implements Expression {
   private final Expression left;
   private final Expression right;
 
@@ -48,21 +45,6 @@ public class And implements Expression, Bound<Boolean> {
   public Expression negate() {
     // not(and(a, b)) => or(not(a), not(b))
     return Expressions.or(left.negate(), right.negate());
-  }
-
-  @Override
-  public BoundReference<?> ref() {
-    return null;
-  }
-
-  @Override
-  public Boolean eval(StructLike struct) {
-    Preconditions.checkNotNull(left, "Left expression cannot be null.");
-    Preconditions.checkNotNull(right, "Right expression cannot be null.");
-    if (!(left instanceof Bound) || !(right instanceof Bound)) {
-      throw new IllegalStateException("Unbound predicate not expected");
-    }
-    return ((Bound<Boolean>) left).eval(struct) && ((Bound<Boolean>) right).eval(struct);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Or.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Or.java
@@ -19,10 +19,7 @@
 
 package org.apache.iceberg.expressions;
 
-import org.apache.iceberg.StructLike;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
-public class Or implements Expression, Bound<Boolean> {
+public class Or implements Expression {
   private final Expression left;
   private final Expression right;
 
@@ -48,21 +45,6 @@ public class Or implements Expression, Bound<Boolean> {
   public Expression negate() {
     // not(or(a, b)) => and(not(a), not(b))
     return Expressions.and(left.negate(), right.negate());
-  }
-
-  @Override
-  public BoundReference<?> ref() {
-    return null;
-  }
-
-  @Override
-  public Boolean eval(StructLike struct) {
-    Preconditions.checkNotNull(left, "Left expression cannot be null.");
-    Preconditions.checkNotNull(right, "Right expression cannot be null.");
-    if (!(left instanceof Bound) || !(right instanceof Bound)) {
-      throw new IllegalStateException("Unbound predicate not expected");
-    }
-    return ((Bound<Boolean>) left).eval(struct) || ((Bound<Boolean>) right).eval(struct);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
 
-
 public class Conversions {
 
   private Conversions() {
@@ -72,9 +71,6 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
-      case TIMESTAMP:
-        final String isoFormatTs = asString.replaceFirst(" ", "T");
-        return Literal.of(isoFormatTs).to(Types.TimestampType.withoutZone()).value();
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.expressions.Binder;
-import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Bound;
+import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -202,6 +203,7 @@ public class LegacyHiveTableOperations extends BaseMetastoreTableOperations {
             databaseName, tableName, null, (short) -1));
       } else {
         boundExpression = Binder.bind(partitionSchema, simplified, false);
+        Evaluator evaluator = new Evaluator(partitionSchema, simplified, false);
         String partitionFilterString = HiveExpressions.toPartitionFilterString(boundExpression);
         LOG.info("Listing partitions for {}.{} with filter string: {}", databaseName, tableName, partitionFilterString);
         try {
@@ -239,7 +241,7 @@ public class LegacyHiveTableOperations extends BaseMetastoreTableOperations {
                   break;
               }
             }
-            return ((Bound<Boolean>) boundExpression).eval(record);
+            return evaluator.eval(record);
           }).collect(Collectors.toList());
         }
       }


### PR DESCRIPTION
…Iceberg-oss code changes

This patch refactors the previous pr #78 , to utilize an existing class `Evaluator` to evaluate records against the partition expression. This will rid of the changes previously made in `And` and `Or` classes and still achieve the same functionality.

@wmoustafa @ljfgem 