### PR TITLE
Support single type union for ORC-vectorization reader

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -432,11 +432,11 @@ public class VectorizedSparkOrcReaders {
   }
 
   private static class UnionConverter implements Converter {
-    private final Types.StructType structType;
+    private final Type type;
     private final List<Converter> optionConverters;
 
     private UnionConverter(Type type, List<Converter> optionConverters) {
-      this.structType = type.asStructType();
+      this.type = type;
       this.optionConverters = optionConverters;
     }
 
@@ -444,24 +444,28 @@ public class VectorizedSparkOrcReaders {
     public ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector vector, int batchSize,
         long batchOffsetInFile) {
       UnionColumnVector unionColumnVector = (UnionColumnVector) vector;
-      List<Types.NestedField> fields = structType.fields();
-      List<ColumnVector> fieldVectors = Lists.newArrayListWithExpectedSize(fields.size());
+      if (optionConverters.size() > 1) {
+        List<Types.NestedField> fields = type.asStructType().fields();
+        List<ColumnVector> fieldVectors = Lists.newArrayListWithExpectedSize(fields.size());
 
-      LongColumnVector longColumnVector = new LongColumnVector();
-      longColumnVector.vector = Arrays.stream(unionColumnVector.tags).asLongStream().toArray();
+        LongColumnVector longColumnVector = new LongColumnVector();
+        longColumnVector.vector = Arrays.stream(unionColumnVector.tags).asLongStream().toArray();
 
-      fieldVectors.add(new PrimitiveOrcColumnVector(Types.IntegerType.get(), batchSize, longColumnVector,
-          OrcValueReaders.ints(), batchOffsetInFile));
-      for (int i = 0; i < fields.size() - 1; i += 1) {
-        fieldVectors.add(optionConverters.get(i).convert(unionColumnVector.fields[i], batchSize, batchOffsetInFile));
-      }
-
-      return new BaseOrcColumnVector(structType, batchSize, vector) {
-        @Override
-        public ColumnVector getChild(int ordinal) {
-          return fieldVectors.get(ordinal);
+        fieldVectors.add(new PrimitiveOrcColumnVector(Types.IntegerType.get(), batchSize, longColumnVector,
+            OrcValueReaders.ints(), batchOffsetInFile));
+        for (int i = 0; i < fields.size() - 1; i += 1) {
+          fieldVectors.add(optionConverters.get(i).convert(unionColumnVector.fields[i], batchSize, batchOffsetInFile));
         }
-      };
+
+        return new BaseOrcColumnVector(type.asStructType(), batchSize, vector) {
+          @Override
+          public ColumnVector getChild(int ordinal) {
+            return fieldVectors.get(ordinal);
+          }
+        };
+      } else {
+        return optionConverters.get(0).convert(unionColumnVector.fields[0], batchSize, batchOffsetInFile);
+      }
     }
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -293,7 +293,6 @@ public class TestSparkOrcUnions {
     }
 
     // Test vectorized reader
-    /*
     try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
         .project(expectedSchema)
         .createBatchedReaderFunc(readOrcSchema ->
@@ -304,7 +303,6 @@ public class TestSparkOrcUnions {
       assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
       assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
     }
-     */
   }
 
   @Test
@@ -366,7 +364,6 @@ public class TestSparkOrcUnions {
     }
 
     // Test vectorized reader
-    /*
     try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
         .project(expectedSchema)
         .createBatchedReaderFunc(readOrcSchema ->
@@ -377,7 +374,6 @@ public class TestSparkOrcUnions {
       assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
       assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
     }
-     */
   }
 
   @Test
@@ -441,7 +437,6 @@ public class TestSparkOrcUnions {
     }
 
     // Test vectorized reader
-    /*
     try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
         .project(expectedSchema)
         .createBatchedReaderFunc(readOrcSchema ->
@@ -452,7 +447,6 @@ public class TestSparkOrcUnions {
       assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
       assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
     }
-     */
   }
 
   private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {


### PR DESCRIPTION
**Problem**
The class of `UnionConverter` in `VectorizedSparkOrcReaders` always treats the type of the input Iceberg schema as Struct and creates a `BaseOrcColumnVector` with a list of ColumnVector to multiple types.  However it is valid only in case of the complex union with multiple types. The type of the input iceberg schema is not Struct in case of single type union so that `UnionConverter` fails to be constructed in this case.

**Solution**
- The type of input Iceberg schema is stored as the original type in `UnionConverter` instead of converting to Struct type.
- Along with the type of input Iceberg schema, a list of `Converter` are passed to `UnionConverter`. The list is generated based on the types in the union by `OrcSchemaWithTypeVistor`. The number of `Converter` in the list equals to the number of types in the union. Therefore, if there is only one `Converter` in the list, it indicates that the union is a single type union, and the corresponding `ColumnVector` can be generated by the only `Converter` in the list.