### PR TITLE
PoC of the mapping from Avro field name to Iceberg field id

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -84,6 +84,10 @@ public class AvroSchemaUtil {
     return AvroSchemaVisitor.visit(schema, new SchemaToType(schema));
   }
 
+  public static Type convertToDeriveNameMapping(Schema schema) {
+    return AvroSchemaVisitor.visit(schema, new SchemaToType(schema, true));
+  }
+
   public static org.apache.iceberg.Schema toIceberg(Schema schema) {
     final List<Types.NestedField> fields = convert(schema).asNestedType().asStructType().fields();
     return new org.apache.iceberg.Schema(fields);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -47,7 +48,6 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
         Types.MapType map = iType != null ? iType.asMapType() : null;
         return visitor.map(map, schema,
             visit(map != null ? map.valueType() : null, schema.getValueType(), visitor));
-
       default:
         return visitor.primitive(iType != null ? iType.asPrimitiveType() : null, schema);
     }
@@ -97,13 +97,24 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
         options.add(visit(type, branch, visitor));
       }
     } else { // complex union case
-      int index = 1;
+      Map<String, Integer> fieldNameToId = (Map) union.getObjectProp(SchemaToType.AVRO_FIELD_NAME_TO_ICEBERG_ID);
       for (Schema branch : types) {
         if (branch.getType() == Schema.Type.NULL) {
           options.add(visit((Type) null, branch, visitor));
         } else {
-          options.add(visit(type.asStructType().fields().get(index).type(), branch, visitor));
-          index += 1;
+          String name = branch.getType().equals(Schema.Type.RECORD) ? branch.getName() : branch.getType().getName();
+          if (fieldNameToId.containsKey(name)) {
+            int fieldId = fieldNameToId.get(name);
+            Types.NestedField branchType = type.asStructType().field(fieldId);
+            if (branchType != null) {
+              options.add(visit(branchType.type(), branch, visitor));
+            } else {
+              Type pseudoBranchType = AvroSchemaUtil.convert(branch);
+              options.add(visit(pseudoBranchType, branch, visitor));
+            }
+          } else {
+            options.add(visit((Type) null, branch, visitor));
+          }
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
@@ -60,6 +60,7 @@ public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosi
   @Override
   public void setSchema(Schema newFileSchema) {
     this.fileSchema = newFileSchema;
+    AvroSchemaUtil.convertToDeriveNameMapping(this.fileSchema);
     if (nameMapping == null && !AvroSchemaUtil.hasIds(fileSchema)) {
       nameMapping = MappingUtil.create(expectedSchema);
     }

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -275,6 +275,11 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
         alts.add(visitResults.get(i));
       }
     }
-    return Schema.createUnion(alts);
+    Schema schema = Schema.createUnion(alts);
+    if (record.getObjectProp(SchemaToType.AVRO_FIELD_NAME_TO_ICEBERG_ID) != null) {
+      schema.addProp(SchemaToType.AVRO_FIELD_NAME_TO_ICEBERG_ID,
+          record.getObjectProp(SchemaToType.AVRO_FIELD_NAME_TO_ICEBERG_ID));
+    }
+    return schema;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -20,7 +20,10 @@
 package org.apache.iceberg.avro;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -30,13 +33,21 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 class SchemaToType extends AvroSchemaVisitor<Type> {
+  public static final String AVRO_FIELD_NAME_TO_ICEBERG_ID = "AvroFieldNameToIcebergId";
   private final Schema root;
+  private boolean deriveNameMapping;
 
   SchemaToType(Schema root) {
     this.root = root;
     if (root.getType() == Schema.Type.RECORD) {
       this.nextId = root.getFields().size();
     }
+    this.deriveNameMapping = false;
+  }
+
+  SchemaToType(Schema root, boolean deriveNameMapping) {
+    this(root);
+    this.deriveNameMapping = deriveNameMapping;
   }
 
   private int nextId = 1;
@@ -88,19 +99,27 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       this.nextId = 0;
     }
 
+    Map<String, Integer> fieldNameToId = new HashMap<>();
     for (int i = 0; i < fields.size(); i += 1) {
       Schema.Field field = fields.get(i);
       Type fieldType = fieldTypes.get(i);
       int fieldId = getId(field);
 
-      Object defaultValue = AvroSchemaUtil.hasNonNullDefaultValue(field) ?
-          AvroSchemaUtil.convertToJavaDefaultValue(field.defaultVal()) : null;
+      Object defaultValue =
+          AvroSchemaUtil.hasNonNullDefaultValue(field) ?
+              AvroSchemaUtil.convertToJavaDefaultValue(field.defaultVal()) : null;
 
       if (AvroSchemaUtil.isOptionSchema(field.schema()) || AvroSchemaUtil.isOptionalComplexUnion(field.schema())) {
         newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, defaultValue, field.doc()));
       } else {
         newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, defaultValue, field.doc()));
       }
+
+      fieldNameToId.put(field.name(), fieldId);
+    }
+
+    if (deriveNameMapping && record.getObjectProp(AVRO_FIELD_NAME_TO_ICEBERG_ID) == null) {
+      record.addProp(AVRO_FIELD_NAME_TO_ICEBERG_ID, fieldNameToId);
     }
 
     return Types.StructType.of(newFields);
@@ -121,14 +140,22 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       return options.get(0);
     } else {
       // Complex union
+      Map<String, Integer> fieldNameToId = new HashMap<>();
       List<Types.NestedField> newFields = new ArrayList<>();
       newFields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
 
       int tagIndex = 0;
       for (Type type : options) {
         if (type != null) {
-          newFields.add(Types.NestedField.optional(allocateId(), "field" + tagIndex++, type));
+          int fieldId = allocateId();
+          Schema schema = union.getTypes().get(tagIndex);
+          newFields.add(Types.NestedField.optional(fieldId, "field" + tagIndex++, type));
+          String name = schema.getType().equals(Schema.Type.RECORD) ? schema.getName() : schema.getType().getName();
+          fieldNameToId.put(name, fieldId);
         }
+      }
+      if (deriveNameMapping && union.getObjectProp(AVRO_FIELD_NAME_TO_ICEBERG_ID) == null) {
+        union.addProp(AVRO_FIELD_NAME_TO_ICEBERG_ID, fieldNameToId);
       }
 
       return Types.StructType.of(newFields);
@@ -147,6 +174,12 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       Types.NestedField keyField = keyValueType.field("key");
       Types.NestedField valueField = keyValueType.field("value");
 
+      if (deriveNameMapping && array.getObjectProp(AVRO_FIELD_NAME_TO_ICEBERG_ID) == null) {
+        Map<String, Integer> fieldNameToId = new HashMap<>();
+        fieldNameToId.put("key", keyField.fieldId());
+        fieldNameToId.put("value", valueField.fieldId());
+        array.addProp(AVRO_FIELD_NAME_TO_ICEBERG_ID, fieldNameToId);
+      }
       if (keyValueType.field("value").isOptional()) {
         return Types.MapType.ofOptional(
             keyField.fieldId(), valueField.fieldId(), keyField.type(), valueField.type());
@@ -159,6 +192,9 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       // normal array
       Schema elementSchema = array.getElementType();
       int id = getElementId(array);
+      if (deriveNameMapping && array.getObjectProp(AVRO_FIELD_NAME_TO_ICEBERG_ID) == null) {
+        array.addProp(AVRO_FIELD_NAME_TO_ICEBERG_ID, Collections.singletonMap("element", id));
+      }
       if (AvroSchemaUtil.isOptionSchema(elementSchema)) {
         return Types.ListType.ofOptional(id, elementType);
       } else {
@@ -172,6 +208,12 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     Schema valueSchema = map.getValueType();
     int keyId = getKeyId(map);
     int valueId = getValueId(map);
+    if (deriveNameMapping && map.getObjectProp(AVRO_FIELD_NAME_TO_ICEBERG_ID) == null) {
+      Map<String, Integer> fieldNameToId = new HashMap<>();
+      fieldNameToId.put("key", keyId);
+      fieldNameToId.put("value", valueId);
+      map.addProp(AVRO_FIELD_NAME_TO_ICEBERG_ID, fieldNameToId);
+    }
 
     if (AvroSchemaUtil.isOptionSchema(valueSchema)) {
       return Types.MapType.ofOptional(keyId, valueId, Types.StringType.get(), valueType);

--- a/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
@@ -59,6 +59,9 @@ public class RandomAvroData {
 
     private RandomDataGenerator(Schema schema, long seed) {
       this.typeToSchema = AvroSchemaUtil.convertTypes(schema.asStruct(), "test");
+      for (org.apache.avro.Schema s : typeToSchema.values()) {
+        AvroSchemaUtil.convertToDeriveNameMapping(s);
+      }
       this.random = new Random(seed);
     }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -73,7 +75,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
 
     Schema readSchema = writeSchema;
 
-    Record projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    Record projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     // field id 5 comes from read schema
     Assert.assertNotNull("Field missing from table mapping is renamed", projected.getSchema().getField("location_r5"));
     Assert.assertNull("location field should not be read", projected.get("location_r5"));
@@ -87,7 +89,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
             Types.StructType.of(
                 Types.NestedField.required(1, "lat", Types.FloatType.get()))))));
 
-    projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     Record projectedL1 = ((Map<String, Record>) projected.get("location")).get("l1");
     Assert.assertNotNull("Field missing from table mapping is renamed", projectedL1.getSchema().getField("long_r2"));
     Assert.assertNull("location.value.long, should not be read", projectedL1.get("long_r2"));
@@ -145,7 +147,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
             )
         )));
 
-    Record projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    Record projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     // The data is read back as a map
     Map<Record, Record> projectedLocation = (Map<Record, Record>) projected.get("location");
     Record projectedKey = projectedLocation.keySet().iterator().next();
@@ -175,7 +177,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
     AssertHelpers.assertThrows("Missing required field in nameMapping",
         IllegalArgumentException.class,
         // In this case, pruneColumns result is an empty record
-        () -> writeAndRead(writeSchema, readSchema, record, nameMapping));
+        () -> writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping));
   }
 
   @Test
@@ -204,7 +206,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
 
     Schema readSchema = writeSchema;
 
-    Record projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    Record projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     Assert.assertNotNull("Field missing from table mapping is renamed", projected.getSchema().getField("point_r22"));
     Assert.assertNull("point field is not projected", projected.get("point_r22"));
     Assert.assertEquals(34L, projected.get("id"));
@@ -218,7 +220,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
         )
     ));
 
-    projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     Record point = ((List<Record>) projected.get("point")).get(0);
 
     Assert.assertNotNull("Field missing from table mapping is renamed", point.getSchema().getField("y_r18"));
@@ -252,7 +254,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
                 // x renamed to y
                 Types.NestedField.required(19, "y", Types.IntegerType.get())))));
 
-    Record projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    Record projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     Assert.assertEquals("x is read as y", 1, ((List<Record>) projected.get("points")).get(0).get("y"));
 
     readSchema = new Schema(
@@ -261,7 +263,7 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
                 // x renamed to z
                 Types.NestedField.required(19, "z", Types.IntegerType.get())))));
 
-    projected = writeAndRead(writeSchema, readSchema, record, nameMapping);
+    projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, nameMapping);
     Assert.assertEquals("x is read as z", 1, ((List<Record>) projected.get("points")).get(0).get("z"));
   }
 
@@ -271,13 +273,15 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
         Types.NestedField.required(0, "id", Types.LongType.get()),
         Types.NestedField.optional(1, "data", Types.StringType.get()));
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     record.put("data", "data");
 
     Schema readSchema = writeSchema;
     // Pass null for nameMapping so that it is automatically inferred from read schema
-    Record projected = writeAndRead(writeSchema, readSchema, record, null);
+    Record projected = writeAndReadWithoutFieldId(writeSchema, readSchema, record, null);
     Assert.assertEquals(record, projected);
   }
 
@@ -287,25 +291,314 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
     // no-op
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testListOfStructsProjection() throws IOException {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(22, "points",
+            Types.ListType.ofOptional(21, Types.StructType.of(
+                Types.NestedField.required(19, "x", Types.IntegerType.get()),
+                Types.NestedField.optional(18, "y", Types.IntegerType.get())
+            ))
+        )
+    );
+
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
+    record.put("id", 34L);
+    Record p1 = new Record(AvroSchemaUtil.fromOption(
+        AvroSchemaUtil.fromOption(record.getSchema().getField("points").schema())
+            .getElementType()));
+    p1.put("x", 1);
+    p1.put("y", 2);
+    Record p2 = new Record(p1.getSchema());
+    p2.put("x", 3);
+    p2.put("y", null);
+    record.put("points", ImmutableList.of(p1, p2));
+
+    Schema idOnly = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get())
+    );
+
+    Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    assertNotProjected("Should not project points list", projected, "points");
+    Record projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        idOnly, record, MappingUtil.create(writeSchema));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projectedWithoutFieldId.get("id"));
+    assertNotProjected("Should not project points list", projectedWithoutFieldId, "points");
+
+    projected = writeAndRead("all_points", writeSchema, writeSchema.select("points"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    Assert.assertEquals("Should project points list",
+        record.get("points"), projected.get("points"));
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("points"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    List<Record> points = (List<Record>) projected.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    Record projectedP1 = points.get(0);
+    Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
+    Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
+    Record projectedP2 = points.get(1);
+    Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
+    Assert.assertEquals("Should project y", null, (Integer) projectedP2.get("y"));
+
+
+    projected = writeAndRead("x_only", writeSchema, writeSchema.select("points.x"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    Assert.assertNotNull("Should project points list", projected.get("points"));
+    points = (List<Record>) projected.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
+    assertNotProjected("Should not project y", projectedP1, "y");
+    projectedP2 = points.get(1);
+    Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
+    assertNotProjected("Should not project y", projectedP2, "y");
+
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("points.x"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    Assert.assertNotNull("Should project points list", projectedWithoutFieldId.get("points"));
+    points = (List<Record>) projectedWithoutFieldId.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
+    assertNotProjected("Should not project y", projectedP1, "y");
+    projectedP2 = points.get(1);
+    Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
+    assertNotProjected("Should not project y", projectedP2, "y");
+
+    projected = writeAndRead("y_only", writeSchema, writeSchema.select("points.y"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    Assert.assertNotNull("Should project points list", projected.get("points"));
+    points = (List<Record>) projected.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    assertNotProjected("Should not project x", projectedP1, "x");
+    Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
+    projectedP2 = points.get(1);
+    assertNotProjected("Should not project x", projectedP2, "x");
+    Assert.assertEquals("Should project null y", null, projectedP2.get("y"));
+
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("points.y"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    Assert.assertNotNull("Should project points list", projectedWithoutFieldId.get("points"));
+    points = (List<Record>) projected.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    assertNotProjected("Should not project x", projectedP1, "x");
+    Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
+    projectedP2 = points.get(1);
+    assertNotProjected("Should not project x", projectedP2, "x");
+    Assert.assertEquals("Should project null y", null, projectedP2.get("y"));
+
+    Schema yRenamed = new Schema(
+        Types.NestedField.optional(22, "points",
+            Types.ListType.ofOptional(21, Types.StructType.of(
+                Types.NestedField.optional(18, "z", Types.IntegerType.get())
+            ))
+        )
+    );
+
+    projected = writeAndRead("y_renamed", writeSchema, yRenamed, record);
+    assertNotProjected("Should not project id", projected, "id");
+    Assert.assertNotNull("Should project points list", projected.get("points"));
+    points = (List<Record>) projected.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    assertNotProjected("Should not project x", projectedP1, "x");
+    assertNotProjected("Should not project y", projectedP1, "y");
+    Assert.assertEquals("Should project z", 2, (int) projectedP1.get("z"));
+    projectedP2 = points.get(1);
+    assertNotProjected("Should not project x", projectedP2, "x");
+    assertNotProjected("Should not project y", projectedP2, "y");
+    Assert.assertEquals("Should project null z", null, projectedP2.get("z"));
+
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        yRenamed, record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    Assert.assertNotNull("Should project points list", projectedWithoutFieldId.get("points"));
+    points = (List<Record>) projectedWithoutFieldId.get("points");
+    Assert.assertEquals("Should read 2 points", 2, points.size());
+    projectedP1 = points.get(0);
+    assertNotProjected("Should not project x", projectedP1, "x");
+    assertNotProjected("Should not project y", projectedP1, "y");
+    Assert.assertEquals("Should project z", 2, (int) projectedP1.get("z"));
+    projectedP2 = points.get(1);
+    assertNotProjected("Should not project x", projectedP2, "x");
+    assertNotProjected("Should not project y", projectedP2, "y");
+    Assert.assertEquals("Should project null z", null, projectedP2.get("z"));
+  }
+
+  @Test
+  public void testMapOfStructsProjection() throws IOException {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StringType.get(),
+            Types.StructType.of(
+                Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                Types.NestedField.required(2, "long", Types.FloatType.get())
+            )
+        ))
+    );
+
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+
+    Record record = new Record(avroWriteSchema);
+    record.put("id", 34L);
+    Record l1 = new Record(AvroSchemaUtil.fromOption(
+        AvroSchemaUtil.fromOption(record.getSchema().getField("locations").schema())
+            .getValueType()));
+    l1.put("lat", 53.992811f);
+    l1.put("long", -1.542616f);
+    Record l2 = new Record(l1.getSchema());
+    l2.put("lat", 52.995143f);
+    l2.put("long", -1.539054f);
+    record.put("locations", ImmutableMap.of("L1", l1, "L2", l2));
+
+    Schema idOnly = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get())
+    );
+
+    Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
+    assertNotProjected("Should not project locations map", projected, "locations");
+    Record projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        idOnly, record, MappingUtil.create(writeSchema));
+    Assert.assertEquals("Should contain the correct id value", 34L, (long) projectedWithoutFieldId.get("id"));
+    assertNotProjected("Should not project locations map", projectedWithoutFieldId, "locations");
+
+    projected = writeAndRead("all_locations", writeSchema, writeSchema.select("locations"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    Assert.assertEquals("Should project locations map",
+        record.get("locations"), toStringMap((Map) projected.get("locations")));
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("locations"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    verifyLocationData(projectedWithoutFieldId);
+
+    projected = writeAndRead("lat_only",
+        writeSchema, writeSchema.select("locations.lat"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    verifyLatOnlyLocationData(projected);
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("locations.lat"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    verifyLatOnlyLocationData(projectedWithoutFieldId);
+
+
+    projected = writeAndRead("long_only",
+        writeSchema, writeSchema.select("locations.long"), record);
+    assertNotProjected("Should not project id", projected, "id");
+    verifyLongOnlyLocationData(projected);
+    projectedWithoutFieldId = writeAndReadWithoutFieldId(writeSchema,
+        writeSchema.select("locations.long"), record, MappingUtil.create(writeSchema));
+    assertNotProjected("Should not project id", projectedWithoutFieldId, "id");
+    verifyLongOnlyLocationData(projectedWithoutFieldId);
+
+    Schema latitiudeRenamed = new Schema(
+        Types.NestedField.optional(5, "locations", Types.MapType.ofOptional(6, 7,
+            Types.StringType.get(),
+            Types.StructType.of(
+                Types.NestedField.required(1, "latitude", Types.FloatType.get())
+            )
+        ))
+    );
+
+    projected = writeAndRead("latitude_renamed", writeSchema, latitiudeRenamed, record);
+    assertNotProjected("Should not project id", projected, "id");
+    verifyLatRenameLocationData(projected);
+  }
+
+  private void verifyLatOnlyLocationData(Record record) {
+    Map<String, ?> locations = toStringMap((Map) record.get("locations"));
+    Assert.assertNotNull("Should project locations map", locations);
+    Assert.assertEquals("Should contain L1 and L2",
+        Sets.newHashSet("L1", "L2"), locations.keySet());
+    Record projectedL1 = (Record) locations.get("L1");
+    Assert.assertNotNull("L1 should not be null", projectedL1);
+    Assert.assertEquals("L1 should contain lat",
+        53.992811f, (float) projectedL1.get("lat"), 0.000001);
+    assertNotProjected("L1 should not contain long", projectedL1, "long");
+    Record projectedL2 = (Record) locations.get("L2");
+    Assert.assertNotNull("L2 should not be null", projectedL2);
+    Assert.assertEquals("L2 should contain lat",
+        52.995143f, (float) projectedL2.get("lat"), 0.000001);
+    assertNotProjected("L1 should not contain long", projectedL1, "long");
+  }
+
+  private void verifyLongOnlyLocationData(Record record) {
+    Map<String, ?> locations = toStringMap((Map) record.get("locations"));
+    Assert.assertNotNull("Should project locations map", locations);
+    Assert.assertEquals("Should contain L1 and L2",
+        Sets.newHashSet("L1", "L2"), locations.keySet());
+    Record projectedL1 = (Record) locations.get("L1");
+    Assert.assertNotNull("L1 should not be null", projectedL1);
+    assertNotProjected("L1 should not contain lat", projectedL1, "lat");
+    Assert.assertEquals("L1 should contain long",
+        -1.542616f, (float) projectedL1.get("long"), 0.000001);
+    Record projectedL2 = (Record) locations.get("L2");
+    Assert.assertNotNull("L2 should not be null", projectedL2);
+    assertNotProjected("L2 should not contain lat", projectedL2, "lat");
+    Assert.assertEquals("L2 should contain long",
+        -1.539054f, (float) projectedL2.get("long"), 0.000001);
+  }
+
+  private void verifyLatRenameLocationData(Record record) {
+    Map<String, ?> locations = toStringMap((Map) record.get("locations"));
+    Assert.assertNotNull("Should project locations map", locations);
+    Assert.assertEquals("Should contain L1 and L2",
+        Sets.newHashSet("L1", "L2"), locations.keySet());
+    Record projectedL1 = (Record) locations.get("L1");
+    Assert.assertNotNull("L1 should not be null", projectedL1);
+    Assert.assertEquals("L1 should contain latitude",
+        53.992811f, (float) projectedL1.get("latitude"), 0.000001);
+    assertNotProjected("L1 should not contain lat", projectedL1, "lat");
+    assertNotProjected("L1 should not contain long", projectedL1, "long");
+    Record projectedL2 = (Record) locations.get("L2");
+    Assert.assertNotNull("L2 should not be null", projectedL2);
+    Assert.assertEquals("L2 should contain latitude",
+        52.995143f, (float) projectedL2.get("latitude"), 0.000001);
+    assertNotProjected("L2 should not contain lat", projectedL2, "lat");
+    assertNotProjected("L2 should not contain long", projectedL2, "long");
+  }
+
+  private void verifyLocationData(Record record) {
+    Map<String, ?> locations = toStringMap((Map) record.get("locations"));
+    Assert.assertNotNull("Should project locations map", locations);
+    Assert.assertEquals("Should contain L1 and L2",
+        Sets.newHashSet("L1", "L2"), locations.keySet());
+    Record projectedL1 = (Record) locations.get("L1");
+    Assert.assertNotNull("L1 should not be null", projectedL1);
+    Assert.assertEquals("L1 should contain lat",
+        53.992811f, (float) projectedL1.get("lat"), 0.000001);
+    Assert.assertEquals("L1 should contain long",
+        -1.542616f, (float) projectedL1.get("long"), 0.000001);
+    Record projectedL2 = (Record) locations.get("L2");
+    Assert.assertNotNull("L2 should not be null", projectedL2);
+    Assert.assertEquals("L2 should contain lat",
+        52.995143f, (float) projectedL2.get("lat"), 0.000001);
+    Assert.assertEquals("L2 should contain long",
+        -1.539054f, (float) projectedL2.get("long"), 0.000001);
+  }
+
   @Override
   protected Record writeAndRead(String desc,
                                 Schema writeSchema,
                                 Schema readSchema,
                                 Record inputRecord) throws IOException {
-
-    // Use all existing TestAvroReadProjection tests to verify that
-    // we get the same projected Avro record whether we use
-    // NameMapping together with file schema without field-ids or we
-    // use a file schema having field-ids
-    Record record = super.writeAndRead(desc, writeSchema, readSchema, inputRecord);
-    Record projectedWithNameMapping = writeAndRead(
-        writeSchema, readSchema, inputRecord, MappingUtil.create(writeSchema));
-    Assert.assertEquals(record, projectedWithNameMapping);
-    return record;
+    return super.writeAndRead(desc, writeSchema, readSchema, inputRecord);
   }
 
 
-  private Record writeAndRead(Schema writeSchema,
+  private Record writeAndReadWithoutFieldId(Schema writeSchema,
                               Schema readSchema,
                               Record record,
                               NameMapping nameMapping) throws IOException {
@@ -325,5 +618,17 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
         .build();
 
     return Iterables.getOnlyElement(records);
+  }
+
+  private Map<String, ?> toStringMap(Map<?, ?> map) {
+    Map<String, Object> stringMap = Maps.newHashMap();
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      if (entry.getValue() instanceof CharSequence) {
+        stringMap.put(entry.getKey().toString(), entry.getValue().toString());
+      } else {
+        stringMap.put(entry.getKey().toString(), entry.getValue());
+      }
+    }
+    return stringMap;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -192,13 +192,15 @@ public abstract class TestReadProjection {
   public void testNestedStructProjection() throws Exception {
     Schema writeSchema = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
-        Types.NestedField.optional(3, "location", Types.StructType.of(
-            Types.NestedField.required(1, "lat", Types.FloatType.get()),
-            Types.NestedField.required(2, "long", Types.FloatType.get())
+        Types.NestedField.optional(1, "location", Types.StructType.of(
+            Types.NestedField.required(2, "lat", Types.FloatType.get()),
+            Types.NestedField.required(3, "long", Types.FloatType.get())
         ))
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     Record location = new Record(
         AvroSchemaUtil.fromOption(record.getSchema().getField("location").schema()));
@@ -215,8 +217,8 @@ public abstract class TestReadProjection {
     assertNotProjected("should not project location", projected, "location");
 
     Schema latOnly = new Schema(
-        Types.NestedField.optional(3, "location", Types.StructType.of(
-            Types.NestedField.required(1, "lat", Types.FloatType.get())
+        Types.NestedField.optional(1, "location", Types.StructType.of(
+            Types.NestedField.required(2, "lat", Types.FloatType.get())
         ))
     );
 
@@ -229,8 +231,8 @@ public abstract class TestReadProjection {
         52.995143f, (float) projectedLocation.get("lat"), 0.000001f);
 
     Schema longOnly = new Schema(
-        Types.NestedField.optional(3, "location", Types.StructType.of(
-            Types.NestedField.required(2, "long", Types.FloatType.get())
+        Types.NestedField.optional(1, "location", Types.StructType.of(
+            Types.NestedField.required(3, "long", Types.FloatType.get())
         ))
     );
 
@@ -257,13 +259,15 @@ public abstract class TestReadProjection {
   public void testMapProjection() throws IOException {
     Schema writeSchema = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
-        Types.NestedField.optional(5, "properties",
-            Types.MapType.ofOptional(6, 7, Types.StringType.get(), Types.StringType.get()))
+        Types.NestedField.optional(1, "properties",
+            Types.MapType.ofOptional(2, 3, Types.StringType.get(), Types.StringType.get()))
     );
 
     Map<String, String> properties = ImmutableMap.of("a", "A", "b", "B");
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     record.put("properties", properties);
 
@@ -319,7 +323,10 @@ public abstract class TestReadProjection {
         ))
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     Record l1 = new Record(AvroSchemaUtil.fromOption(
         AvroSchemaUtil.fromOption(record.getSchema().getField("locations").schema())
@@ -413,13 +420,15 @@ public abstract class TestReadProjection {
   public void testListProjection() throws IOException {
     Schema writeSchema = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
-        Types.NestedField.optional(10, "values",
+        Types.NestedField.optional(1, "values",
             Types.ListType.ofOptional(11, Types.LongType.get()))
     );
 
     List<Long> values = ImmutableList.of(56L, 57L, 58L);
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     record.put("values", values);
 
@@ -455,7 +464,9 @@ public abstract class TestReadProjection {
         )
     );
 
-    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    org.apache.avro.Schema avroWriteSchema = AvroSchemaUtil.convert(writeSchema, "table");
+    AvroSchemaUtil.convertToDeriveNameMapping(avroWriteSchema);
+    Record record = new Record(avroWriteSchema);
     record.put("id", 34L);
     Record p1 = new Record(AvroSchemaUtil.fromOption(
         AvroSchemaUtil.fromOption(record.getSchema().getField("points").schema())

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -83,7 +83,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
       if (AvroSchemaUtil.isOptionSchema(union) || AvroSchemaUtil.isSingleTypeUnion(union)) {
         return ValueReaders.union(options);
       } else {
-        return SparkValueReaders.union(union, options);
+        return SparkValueReaders.union(union, options, expected);
       }
     }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -25,6 +25,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +35,7 @@ import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -86,8 +88,8 @@ public class SparkValueReaders {
     return new StructReader(readers, struct, idToConstant);
   }
 
-  static ValueReader<InternalRow> union(Schema schema, List<ValueReader<?>> readers) {
-    return new UnionReader(schema, readers);
+  static ValueReader<InternalRow> union(Schema schema, List<ValueReader<?>> readers, Type expected) {
+    return new UnionReader(schema, readers, expected);
   }
 
   private static class StringReader implements ValueReader<UTF8String> {
@@ -302,54 +304,75 @@ public class SparkValueReaders {
   }
 
   private static class UnionReader implements ValueReader<InternalRow> {
+    private static final String UNION_TAG_FIELD_NAME = "tag";
     private final Schema schema;
     private final ValueReader[] readers;
+    private final int[] projectedFieldIdsToIdxInReturnedRow;
+    private boolean isTagFieldProjected;
+    private int numOfFieldsInReturnedRow;
+    private int nullTypeIndex;
 
-    private UnionReader(Schema schema, List<ValueReader<?>> readers) {
+    private UnionReader(Schema schema, List<ValueReader<?>> readers, Type expected) {
       this.schema = schema;
       this.readers = new ValueReader[readers.size()];
       for (int i = 0; i < this.readers.length; i += 1) {
         this.readers[i] = readers.get(i);
       }
-    }
 
-    @Override
-    public InternalRow read(Decoder decoder, Object reuse) throws IOException {
-      // first we need to filter out NULL alternative if it exists in the union schema
-      int nullIndex = -1;
-      List<Schema> alts = schema.getTypes();
-      for (int i = 0; i < alts.size(); i++) {
-        Schema alt = alts.get(i);
+      // checking if NULL type exists in Avro union schema
+      this.nullTypeIndex = -1;
+      for (int i = 0; i < this.schema.getTypes().size(); i++) {
+        Schema alt = this.schema.getTypes().get(i);
         if (Objects.equals(alt.getType(), Schema.Type.NULL)) {
-          nullIndex = i;
+          this.nullTypeIndex = i;
           break;
         }
       }
 
+      // Creating an integer array to track the mapping between the index of fields to be projected
+      // and the index of the value for the field stored in the returned row,
+      // if the value for a field equals to -1, it means the value of this field should not be stored
+      // in the returned row
+      int numberOfTypes = this.nullTypeIndex == -1 ?
+          this.schema.getTypes().size() : this.schema.getTypes().size() - 1;
+      this.projectedFieldIdsToIdxInReturnedRow = new int[numberOfTypes];
+      Arrays.fill(this.projectedFieldIdsToIdxInReturnedRow, -1);
+      this.numOfFieldsInReturnedRow = 0;
+      this.isTagFieldProjected = false;
+      for (Types.NestedField expectedStructField : expected.asStructType().fields()) {
+        String fieldName = expectedStructField.name();
+        if (fieldName.equals(UNION_TAG_FIELD_NAME)) {
+          this.isTagFieldProjected = true;
+          this.numOfFieldsInReturnedRow++;
+          continue;
+        }
+        int projectedFieldIndex = Integer.valueOf(fieldName.substring(5));
+        this.projectedFieldIdsToIdxInReturnedRow[projectedFieldIndex] = this.numOfFieldsInReturnedRow++;
+      }
+    }
+
+    @Override
+    public InternalRow read(Decoder decoder, Object reuse) throws IOException {
       int index = decoder.readIndex();
-      if (index == nullIndex) {
+      if (index == nullTypeIndex) {
         // if it is a null data, directly return null as the whole union result
         // we know for sure it is a null so the casting will always work.
-        return (InternalRow) readers[nullIndex].read(decoder, reuse);
+        return (InternalRow) readers[nullTypeIndex].read(decoder, reuse);
       }
 
       // otherwise, we need to return an InternalRow as a struct data
-      InternalRow struct = new GenericInternalRow(nullIndex >= 0 ? alts.size() : alts.size() + 1);
+      InternalRow struct = new GenericInternalRow(numOfFieldsInReturnedRow);
       for (int i = 0; i < struct.numFields(); i += 1) {
         struct.setNullAt(i);
       }
+      int fieldIndex = (nullTypeIndex < 0 || index < nullTypeIndex) ? index : index - 1;
+      if (isTagFieldProjected) {
+        struct.setInt(0, fieldIndex);
+      }
 
       Object value = readers[index].read(decoder, reuse);
-
-      if (nullIndex < 0) {
-        struct.update(index + 1, value);
-        struct.setInt(0, index);
-      } else if (index < nullIndex) {
-        struct.update(index + 1, value);
-        struct.setInt(0, index);
-      } else {
-        struct.update(index, value);
-        struct.setInt(0, index - 1);
+      if (projectedFieldIdsToIdxInReturnedRow[fieldIndex] != -1) {
+        struct.update(projectedFieldIdsToIdxInReturnedRow[fieldIndex], value);
       }
 
       return struct;


### PR DESCRIPTION
- The mapping from the field name in Avro schema to the field id in Iceberg schema is derived during the conversion from Avro schema to Iceberg schema in the function of `AvroSchemaUtil.convertToDeriveNameMapping` and the class of `SchemaToType`.
- The mapping of direct child fields of an Avro schema field is stored as a property named `AvroFieldNameToIcebergId` in this Avro schema field, therefore it can be easily accessed when Avro schema is traversed to generate the correspond readers to read Avro data file.
- In case of union, the key of the mapping is the name of the branch in the union.
- In case of complex union, the code of `AvroSchemaWithTypeVisitor.visitUnion()` first gets the mapping from the property of Avro schema, then get the field id in Iceberg schema using the type name in Avro schema, finally it uses the field id to get the field type in Iceberg schema:
  if the corresponding field in Iceberg schema exists, the field is used to create the reader together with Avro schema node; 
  if the field for the given field id does not exist in Iceberg schema (which means this field is not projected in Iceberg schema), a pseudo branch type is created based on the corresponding Avro schema node to faciltate the creation of the reader. 
- In the class of UnionReader, the rows read from Avro data file are filtered according to the fields existing in Iceberg schema. 