### PR TITLE
Patch upstream PR #3717 and its dependencies with some refactor

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -36,8 +36,17 @@ public class TableProperties {
   public static final String COMMIT_TOTAL_RETRY_TIME_MS = "commit.retry.total-timeout-ms";
   public static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 1800000; // 30 minutes
 
-  public static final String COMMIT_NUM_STATUS_CHECKS = "commit.num-status-checks";
+  public static final String COMMIT_NUM_STATUS_CHECKS = "commit.status-check.num-retries";
   public static final int COMMIT_NUM_STATUS_CHECKS_DEFAULT = 3;
+
+  public static final String COMMIT_STATUS_CHECKS_MIN_WAIT_MS = "commit.status-check.min-wait-ms";
+  public static final long COMMIT_STATUS_CHECKS_MIN_WAIT_MS_DEFAULT = 1000L; // 1s
+
+  public static final String COMMIT_STATUS_CHECKS_MAX_WAIT_MS = "commit.status-check.max-wait-ms";
+  public static final long COMMIT_STATUS_CHECKS_MAX_WAIT_MS_DEFAULT = 60000L; // 1 minute
+
+  public static final String COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS = "commit.status-check.total-timeout-ms";
+  public static final long COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS_DEFAULT = 1800000; // 30 minutes
 
   public static final String MANIFEST_TARGET_SIZE_BYTES = "commit.manifest.target-size-bytes";
   public static final long MANIFEST_TARGET_SIZE_BYTES_DEFAULT = 8388608; // 8 MB

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -62,14 +62,10 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS_DEFAULT;
 
 /**
  * TODO we should be able to extract some more commonalities to BaseMetastoreTableOperations to
@@ -77,9 +73,6 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_STATUS_CHECKS_DEFAUL
  */
 public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTableOperations.class);
-
-  private static final int COMMIT_STATUS_CHECK_WAIT_MS = 1000;
-
   private static final String HIVE_ACQUIRE_LOCK_TIMEOUT_MS = "iceberg.hive.lock-timeout-ms";
   private static final String HIVE_LOCK_CHECK_MIN_WAIT_MS = "iceberg.hive.lock-check-min-wait-ms";
   private static final String HIVE_LOCK_CHECK_MAX_WAIT_MS = "iceberg.hive.lock-check-max-wait-ms";
@@ -97,12 +90,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     WaitingForLockException(String message) {
       super(message);
     }
-  }
-
-  protected enum CommitStatus {
-    FAILURE,
-    SUCCESS,
-    UNKNOWN
   }
 
   private final HiveClientPool metaClients;
@@ -259,50 +246,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     } finally {
       cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId);
     }
-  }
-
-  /**
-   * Attempt to load the table and see if any current or past metadata location matches the one we were attempting
-   * to set. This is used as a last resort when we are dealing with exceptions that may indicate the commit has
-   * failed but are not proof that this is the case. Past locations must also be searched on the chance that a second
-   * committer was able to successfully commit on top of our commit.
-   *
-   * @param newMetadataLocation the path of the new commit file
-   * @param config metadata to use for configuration
-   * @return Commit Status of Success, Failure or Unknown
-   */
-  protected CommitStatus checkCommitStatus(String newMetadataLocation, TableMetadata config) {
-    int maxAttempts = PropertyUtil.propertyAsInt(config.properties(), COMMIT_NUM_STATUS_CHECKS,
-        COMMIT_NUM_STATUS_CHECKS_DEFAULT);
-
-    AtomicReference<CommitStatus> status = new AtomicReference<>(CommitStatus.UNKNOWN);
-
-    Tasks.foreach(newMetadataLocation)
-        .retry(maxAttempts)
-        .suppressFailureWhenFinished()
-        .exponentialBackoff(COMMIT_STATUS_CHECK_WAIT_MS, COMMIT_STATUS_CHECK_WAIT_MS, Long.MAX_VALUE, 2.0)
-        .onFailure((location, checkException) ->
-            LOG.error("Cannot check if commit to {}.{} exists.", database, tableName, checkException))
-        .run(location -> {
-          TableMetadata metadata = refresh();
-          String currentMetadataLocation = metadata.metadataFileLocation();
-          boolean commitSuccess = currentMetadataLocation.equals(newMetadataLocation) ||
-              metadata.previousFiles().stream().anyMatch(log -> log.file().equals(newMetadataLocation));
-          if (commitSuccess) {
-            LOG.info("Commit status check: Commit to {}.{} of {} succeeded", database, tableName, newMetadataLocation);
-            status.set(CommitStatus.SUCCESS);
-          } else {
-            LOG.info("Commit status check: Commit to {}.{} of {} failed", database, tableName, newMetadataLocation);
-            status.set(CommitStatus.FAILURE);
-          }
-        });
-
-    if (status.get() == CommitStatus.UNKNOWN) {
-      LOG.error("Cannot determine commit state to {}.{}. Failed during checking {} times. " +
-              "Treating commit state as unknown.",
-          database, tableName, maxAttempts);
-    }
-    return status.get();
   }
 
   @VisibleForTesting

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableOperations.java
@@ -78,6 +78,8 @@ public class LegacyHiveTableOperations extends BaseMetastoreTableOperations {
   private final HiveClientPool metaClients;
   private final String databaseName;
   private final String tableName;
+
+  private final String fullName;
   private final Configuration conf;
 
   private FileIO fileIO;
@@ -87,6 +89,12 @@ public class LegacyHiveTableOperations extends BaseMetastoreTableOperations {
     this.metaClients = metaClients;
     this.databaseName = database;
     this.tableName = table;
+    this.fullName = database + "." + table;
+  }
+
+  @Override
+  protected String tableName() {
+    return fullName;
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -60,6 +60,11 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
   }
 
   @Override
+  protected String tableName() {
+    return key.toString();
+  }
+
+  @Override
   protected void doRefresh() {
     try {
       reference.refresh();


### PR DESCRIPTION
This PR patches https://github.com/apache/iceberg/pull/3717 and its dependencies to make it work in LI-Iceberg 0.11. It will address our production issues where a commit succeeds but its metadata file is deleted (because Iceberg wrongly thinks it fails) and the table is corrupted.

A more detailed explanation could be found in the description of the upstream PR.