### PR TITLE
Fix MergeHiveSchemaWithAvro to make it copy full Avro schema attributes

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hivelink.core.schema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalTypes;
@@ -113,6 +114,11 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
     // if there was no matching Avro list, or if matching Avro list was an option, return an optional list
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
     Schema result = Schema.createArray(elementResult);
+    if (partner != null) {
+      for (Map.Entry<String, Object> prop : partner.getObjectProps().entrySet()) {
+        result.addProp(prop.getKey(), prop.getValue());
+      }
+    }
     return shouldResultBeOptional ? AvroSchemaUtil.toOption(result) : result;
   }
 
@@ -123,6 +129,11 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
     // if there was no matching Avro map, or if matching Avro map was an option, return an optional map
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
     Schema result = Schema.createMap(valueResult);
+    if (partner != null) {
+      for (Map.Entry<String, Object> prop : partner.getObjectProps().entrySet()) {
+        result.addProp(prop.getKey(), prop.getValue());
+      }
+    }
     return shouldResultBeOptional ? AvroSchemaUtil.toOption(result) : result;
   }
 

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -114,11 +114,7 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
     // if there was no matching Avro list, or if matching Avro list was an option, return an optional list
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
     Schema result = Schema.createArray(elementResult);
-    if (partner != null) {
-      for (Map.Entry<String, Object> prop : partner.getObjectProps().entrySet()) {
-        result.addProp(prop.getKey(), prop.getValue());
-      }
-    }
+    copySchemaProps(partner, result);
     return shouldResultBeOptional ? AvroSchemaUtil.toOption(result) : result;
   }
 
@@ -129,11 +125,7 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
     // if there was no matching Avro map, or if matching Avro map was an option, return an optional map
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
     Schema result = Schema.createMap(valueResult);
-    if (partner != null) {
-      for (Map.Entry<String, Object> prop : partner.getObjectProps().entrySet()) {
-        result.addProp(prop.getKey(), prop.getValue());
-      }
-    }
+    copySchemaProps(partner, result);
     return shouldResultBeOptional ? AvroSchemaUtil.toOption(result) : result;
   }
 
@@ -161,6 +153,14 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
     // TODO: Check if schema is compatible with partner
     //       Also do type promotion if required, schema = string & partner = enum, schema = bytes & partner = fixed, etc
     return schema;
+  }
+
+  private static void copySchemaProps(Schema from, Schema to) {
+    if (from != null) {
+      for (Map.Entry<String, Object> prop : from.getObjectProps().entrySet()) {
+        to.addProp(prop.getKey(), prop.getValue());
+      }
+    }
   }
 
   /**

--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
@@ -291,6 +291,27 @@ public class TestMergeHiveSchemaWithAvro {
   }
 
   @Test
+  public void shouldRetainMapProp() {
+    String hive = "struct<fa:map<string,int>>";
+    Schema fa = map(Schema.Type.INT);
+    fa.addProp("key-id", 1);
+    fa.addProp("value-id", 2);
+    Schema avro = struct("r1", required("fa", fa));
+
+    assertSchema(avro, merge(hive, avro));
+  }
+
+  @Test
+  public void shouldRetainListProp() {
+    String hive = "struct<fa:array<int>>";
+    Schema fa = array(Schema.Type.INT);
+    fa.addProp("element-id", 1);
+    Schema avro = struct("r1", required("fA", fa));
+
+    assertSchema(avro, merge(hive, avro));
+  }
+
+  @Test
   public void shouldRecoverLogicalType() {
     String hive = "struct<fa:date,fb:timestamp,fc:decimal(4,2)>";
     Schema avro = struct("r1",


### PR DESCRIPTION
The MergeHiveSchemaWithAvro merges a Hive Schema (input 1) and a corresponding Avro schema (input 2) to derive a more information-rich Avro schema.

For Avro map and array types, the existing logic doesn't copy over the attribute metadata associated with input 2 into the final output, resulting in metadata information loss in the final result Avro schema.

This patch fix that by copying over the metadata for those 2 types. This will ensure further Avro -> Iceberg conversions are correct (since Iceberg depends on Avro id metadata such as key-id, value-id and element-id) .