### PR TITLE
Hive: Return null for currentSnapshot()

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTable.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTable.java
@@ -118,7 +118,7 @@ public class LegacyHiveTable implements Table, HasTableOperations {
 
   @Override
   public Snapshot currentSnapshot() {
-    throw new UnsupportedOperationException("Snapshots not supported for Hive tables without Iceberg metadata");
+    return null;
   }
 
   @Override

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTable.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTable.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.hivelink.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.AppendFiles;
@@ -128,7 +129,7 @@ public class LegacyHiveTable implements Table, HasTableOperations {
 
   @Override
   public Iterable<Snapshot> snapshots() {
-    throw new UnsupportedOperationException("Snapshots not supported for Hive tables without Iceberg metadata");
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
We encounter an error when fetching properties for Hive tables read through Spark

```
java.lang.UnsupportedOperationException: Snapshots not supported for Hive tables without Iceberg metadata
  at xxx_shaded.org.apache.iceberg.hivelink.core.LegacyHiveTable.currentSnapshot(LegacyHiveTable.java:121)
  at xxx_shaded.org.apache.iceberg.spark.source.SparkTable.properties(SparkTable.java:138)
  ... 85 elided
```

This is because `SparkTable.properties()` tries to [fetch currentSnapshot()](https://github.com/linkedin/iceberg/blob/ddba6efc82034358a5e1bcc2502b36264d05a40c/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java#L138) which is not supported in `LegacyHiveTable`.

I propose here to change the behavior of currentSnapshot() to return a null and hence signal that no snapshot exists. This is also what vanilla Iceberg tables do and can be seen from how its handled at these examples [1](https://github.com/linkedin/iceberg/blob/ddba6efc82034358a5e1bcc2502b36264d05a40c/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java#L138) [2](https://github.com/linkedin/iceberg/blob/ddba6efc82034358a5e1bcc2502b36264d05a40c/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java#L66) [3](https://github.com/linkedin/iceberg/blob/ddba6efc82034358a5e1bcc2502b36264d05a40c/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java#L309)

Unfortunately does not seem like there is an easy way to write a unit test for this as the bug is encountered during Spark scan of such a table, but the hivelink-core module is not set up to run Spark datasource tests.