### PR TITLE
Add logic to derive partition column id from partition.column.ids pro…

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
@@ -127,6 +127,14 @@ class LegacyHiveTableUtils {
     return new Schema(partitionFields);
   }
 
+  /**
+   *
+   * @param idMapping A comma separated string representation of column name
+   *                  and its id, e.g. partitionCol1:10,partitionCol2:11, no
+   *                  whitespace is allowed in the middle
+   * @return          The parsed in-mem Map representation of the name to
+   *                  id mapping
+   */
   private static Map<String, Integer> parsePartitionColId(String idMapping) {
     Map<String, Integer> nameToId = Maps.newHashMap();
     if (idMapping != null) {

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.hivelink.core;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ import org.apache.iceberg.hivelink.core.schema.MergeHiveSchemaWithAvro;
 import org.apache.iceberg.hivelink.core.utils.HiveTypeUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -88,7 +90,8 @@ class LegacyHiveTableUtils {
     Types.StructType dataStructType = schema.asStruct();
     List<Types.NestedField> fields = Lists.newArrayList(dataStructType.fields());
 
-    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema);
+    String partitionColumnIdMappingString = props.get("partition.column.ids");
+    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema, partitionColumnIdMappingString);
     Types.StructType partitionStructType = partitionSchema.asStruct();
     fields.addAll(partitionStructType.fields());
     return new Schema(fields);
@@ -107,7 +110,8 @@ class LegacyHiveTableUtils {
     return (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(fieldNames, fieldTypeInfos);
   }
 
-  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema) {
+  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema, String idMapping) {
+    Map<String, Integer> nameToId = parsePartitionColId(idMapping);
     AtomicInteger fieldId = new AtomicInteger(10000);
     List<Types.NestedField> partitionFields = Lists.newArrayList();
     partitionKeys.forEach(f -> {
@@ -117,9 +121,29 @@ class LegacyHiveTableUtils {
       }
       partitionFields.add(
           Types.NestedField.optional(
-              fieldId.incrementAndGet(), f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
+              nameToId.containsKey(f.getName()) ? nameToId.get(f.getName()) : fieldId.incrementAndGet(),
+              f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
     });
     return new Schema(partitionFields);
+  }
+
+  private static Map<String, Integer> parsePartitionColId(String idMapping) {
+    Map<String, Integer> nameToId = Maps.newHashMap();
+    if (idMapping != null) {
+      // parse idMapping string
+      Arrays.stream(idMapping.split(",")).forEach(kv -> {
+        String[] split = kv.split(":");
+        if (split.length != 2) {
+          throw new IllegalStateException(String.format(
+              "partition.column.ids property is invalid format: %s",
+              idMapping));
+        }
+        String name = split[0];
+        Integer id = Integer.parseInt(split[1]);
+        nameToId.put(name, id);
+      });
+    }
+    return nameToId;
   }
 
   private static Type primitiveIcebergType(String hiveTypeString) {


### PR DESCRIPTION
…perty

We worked with gobblin team to honor a new hive table property `partition.column.ids` to correctly derive the Iceberg ids for the hive partition columns in the table. This will ensure LI-Iceberg can read gobblin double registered hive/Iceberg tables.

I didn't add unit test because this kind of gobblin table is hard to mimic in local unit test. Since it need to be written by a native Iceberg writer as an Iceberg table and then using custom code to registered it as a Hive table. So in order to recreate such a test table, I essentially need to re-implement all the gobblin logic myself in here again. 
We already did manual testing on all the scenarios on the cluster and in the future I think we should rely on gobblin integration test to guarantee this part of the logic.