### PR TITLE
Patch PR 3733 from upstream

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -247,6 +248,9 @@ class BaseTransaction implements Transaction {
     try {
       ops.commit(null, createMetadata);
 
+    } catch (CommitStateUnknownException e) {
+      throw e;
+
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
       Tasks.foreach(updates)
@@ -301,6 +305,9 @@ class BaseTransaction implements Transaction {
 
             underlyingOps.commit(base, replaceMetadata);
           });
+
+    } catch (CommitStateUnknownException e) {
+      throw e;
 
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
@@ -359,6 +366,9 @@ class BaseTransaction implements Transaction {
             // fix up the snapshot log, which should not contain intermediate snapshots
             underlyingOps.commit(base, current.removeSnapshotLogEntries(intermediateSnapshotIds));
           });
+
+    } catch (CommitStateUnknownException e) {
+      throw e;
 
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -141,6 +142,10 @@ public class TableTestBase {
   List<File> listManifestFiles(File tableDirToList) {
     return Lists.newArrayList(new File(tableDirToList, "metadata").listFiles((dir, name) ->
         !name.startsWith("snap") && Files.getFileExtension(name).equalsIgnoreCase("avro")));
+  }
+
+  public static long countAllMetadataFiles(File tableDir) {
+    return Arrays.stream(new File(tableDir, "metadata").listFiles()).filter(f -> f.isFile()).count();
   }
 
   protected TestTables.TestTable create(Schema schema, PartitionSpec spec) {

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transform;
@@ -358,6 +360,85 @@ public class TestReplaceTransaction extends TableTestBase {
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
         assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+
+    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+  }
+
+  @Test
+  public void testReplaceTransactionWithUnknownState() {
+    Schema newSchema = new Schema(
+        required(4, "id", Types.IntegerType.get()),
+        required(5, "data", Types.StringType.get()));
+
+    Snapshot start = table.currentSnapshot();
+    Schema schema = table.schema();
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+
+    TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test");
+    Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned(),
+        SortOrder.unsorted(),  ImmutableMap.of(), ops);
+
+    replace.newAppend()
+        .appendFile(FILE_B)
+        .commit();
+
+    AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
+
+    table.refresh();
+
+    Assert.assertEquals("Version should be 2", 2L, (long) version());
+    Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
+    Assert.assertEquals("Schema should use new schema, not compatible with previous",
+        schema.asStruct(), table.schema().asStruct());
+    Assert.assertEquals("Should have 4 files in metadata", 4, countAllMetadataFiles(tableDir));
+    validateSnapshot(null, table.currentSnapshot(), FILE_B);
+  }
+
+  @Test
+  public void testCreateTransactionWithUnknownState() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    // this table doesn't exist.
+    TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test_append");
+    Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned(),
+        SortOrder.unsorted(), ImmutableMap.of(), ops);
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
+
+    Assert.assertTrue("Should return a transaction table", replace.table() instanceof BaseTransaction.TransactionTable);
+
+    replace.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertNull("Appending in a transaction should not commit metadata",
+                      TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+                      TestTables.metadataVersion("test_append"));
+
+    AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
+
+    TableMetadata meta = TestTables.readMetadata("test_append");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0", 0, (int) TestTables.metadataVersion("test_append"));
+    Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
+    Assert.assertEquals("Should have 2 files in metadata", 2, countAllMetadataFiles(tableDir));
+    Assert.assertEquals("Table schema should match with reassigned IDs", assignFreshIds(SCHEMA).asStruct(),
+        meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 


### PR DESCRIPTION
Patching PR https://github.com/apache/iceberg/pull/3733 which fixes an issue we saw in production, tables had their snapshot files incorrectly deleted when commits were in unknown state.