### PR TITLE
Bug fix: MergeHiveSchemaWithAvro should retain avro properties for li…

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -157,11 +157,14 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
 
   private static void copySchemaProps(Schema from, Schema to) {
     if (from != null) {
+      Schema sanitizedFrom;
       if (AvroSchemaUtil.isOptionSchema(from)) {
         // extract the actual type from the nullable union
-        from = AvroSchemaUtil.fromOption(from);
+        sanitizedFrom = AvroSchemaUtil.fromOption(from);
+      } else {
+        sanitizedFrom = from;
       }
-      for (Map.Entry<String, Object> prop : from.getObjectProps().entrySet()) {
+      for (Map.Entry<String, Object> prop : sanitizedFrom.getObjectProps().entrySet()) {
         to.addProp(prop.getKey(), prop.getValue());
       }
     }

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -157,6 +157,10 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
 
   private static void copySchemaProps(Schema from, Schema to) {
     if (from != null) {
+      if (AvroSchemaUtil.isOptionSchema(from)) {
+        // extract the actual type from the nullable union
+        from = AvroSchemaUtil.fromOption(from);
+      }
       for (Map.Entry<String, Object> prop : from.getObjectProps().entrySet()) {
         to.addProp(prop.getKey(), prop.getValue());
       }

--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
@@ -302,11 +302,32 @@ public class TestMergeHiveSchemaWithAvro {
   }
 
   @Test
+  public void shouldRetainNullableMapProp() {
+    String hive = "struct<fa:map<string,int>>";
+    Schema fa = map(Schema.Type.INT);
+    fa.addProp("key-id", 1);
+    fa.addProp("value-id", 2);
+    Schema avro = struct("r1", optional("fa", fa));
+
+    assertSchema(avro, merge(hive, avro));
+  }
+
+  @Test
   public void shouldRetainListProp() {
     String hive = "struct<fa:array<int>>";
     Schema fa = array(Schema.Type.INT);
     fa.addProp("element-id", 1);
     Schema avro = struct("r1", required("fA", fa));
+
+    assertSchema(avro, merge(hive, avro));
+  }
+
+  @Test
+  public void shouldRetainNullableListProp() {
+    String hive = "struct<fa:array<int>>";
+    Schema fa = array(Schema.Type.INT);
+    fa.addProp("element-id", 1);
+    Schema avro = struct("r1", optional("fA", fa));
 
     assertSchema(avro, merge(hive, avro));
   }


### PR DESCRIPTION
…st and map when they are nullable.

We found a production issue when a ORC table with avro.schema contains a nullable array or map, the parallel tree walker `MergeHiveSchemaWithAvro` fails to copy over the persisted iceberg id properties in the schema literal, making the final output avro schema literal not have those properties, thus the final output avro schema conversion to Iceberg schema will fail.

This patch will fix this issue, and unblock production tables with such schema.