### PR TITLE
Remove netty-common module from the spark-runtime fat jar

### DIFF
--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -124,6 +124,7 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
       exclude group: 'org.xerial.snappy'
       exclude group: 'javax.xml.bind'
       exclude group: 'javax.annotation'
+      exclude group: 'io.netty', module: 'netty-common'
     }
   }
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -188,6 +188,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'org.glassfish'
       exclude group: 'org.abego.treelayout'
       exclude group: 'org.antlr'
+      exclude group: 'io.netty', module: 'netty-common'
     }
   }
 


### PR DESCRIPTION
Iceberg doesn't need netty-common module as its implementation classes, so it shouldn't put those classes in the final shaded fat spark-runtime jar.

This will guarantee that, if spark runtime has some version of netty-common, it won't cause conflicts.