### PR TITLE
Let shipkit automatically generate change log for github release

### DIFF
--- a/shipkit.gradle
+++ b/shipkit.gradle
@@ -22,7 +22,7 @@ apply plugin: "org.shipkit.shipkit-auto-version" //https://github.com/shipkit/sh
 
 apply plugin: "org.shipkit.shipkit-changelog" //https://github.com/shipkit/shipkit-changelog
 tasks.named("generateChangelog") {
-  previousRevision = 'li-0.11.x'
+  previousRevision = project.ext.'shipkit-auto-version.previous-tag'
   githubToken = System.getenv("GITHUB_TOKEN")
   repository = "linkedin/iceberg"
 }


### PR DESCRIPTION
Currently for every release in the 0.11 branch, we don't have a changelog pupulated, example: https://github.com/linkedin/iceberg/releases/tag/v0.11.1.17

After this change, it will enable the shipkit plugin to auto generate change log like it did for the 0.14 branch: https://github.com/linkedin/iceberg/releases/tag/v0.14.1.1