### PR TITLE
Fix netty dependency and row level fitler issue in spark2

### DIFF
--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -124,7 +124,6 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
       exclude group: 'org.xerial.snappy'
       exclude group: 'javax.xml.bind'
       exclude group: 'javax.annotation'
-      exclude group: 'io.netty', module: 'netty-common'
     }
   }
 
@@ -167,6 +166,7 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     // relocate Arrow and related deps to shade Iceberg specific version
     relocate 'io.netty.buffer', 'org.apache.iceberg.shaded.io.netty.buffer'
+    relocate 'io.netty.util', 'org.apache.iceberg.shaded.io.netty.util'
     relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataTask;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
@@ -36,6 +37,8 @@ import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.orc.OrcRowFilter;
+import org.apache.iceberg.orc.OrcRowFilterUtils;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -44,6 +47,7 @@ import org.apache.iceberg.spark.data.SparkAvroReader;
 import org.apache.iceberg.spark.data.SparkOrcReader;
 import org.apache.iceberg.spark.data.SparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
@@ -154,6 +158,10 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       FileScanTask task,
       Schema readSchema,
       Map<Integer, ?> idToConstant) {
+    OrcRowFilter orcRowFilter = OrcRowFilterUtils.rowFilterFromTask(task);
+    if (orcRowFilter != null) {
+      validateRowFilterRequirements(task, orcRowFilter);
+    }
     Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(readSchema,
         Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
 
@@ -162,7 +170,8 @@ class RowDataReader extends BaseDataReader<InternalRow> {
         .split(task.start(), task.length())
         .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema, idToConstant))
         .filter(task.residual())
-        .caseSensitive(caseSensitive);
+        .caseSensitive(caseSensitive)
+        .rowFilter(orcRowFilter);
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
@@ -194,6 +203,18 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     @Override
     protected InputFile getInputFile(String location) {
       return RowDataReader.this.getInputFile(location);
+    }
+  }
+
+  private void validateRowFilterRequirements(FileScanTask task, OrcRowFilter filter) {
+    Preconditions.checkArgument(task.file().format() == FileFormat.ORC, "Row filter can only be applied to ORC files");
+    Preconditions.checkArgument(task.spec().fields().size() == 0,
+        "Row filter can only be applied to unpartitioned tables");
+    for (Types.NestedField column : filter.requiredSchema().columns()) {
+      Preconditions.checkArgument(tableSchema.findField(column.name()) != null,
+          "Row filter can only be applied to top level fields. %s is not a top level field", column.name());
+      Preconditions.checkArgument(column.type().isPrimitiveType(),
+          "Row filter can only be applied to primitive fields. %s is of type %s", column.name(), column.type());
     }
   }
 }


### PR DESCRIPTION
- spark2 uses netty 2, and in netty 2, netty-buffer depends on netty-common so we also need to include and shade netty-common for iceberg-arrow to correctly work.
- Fix a issue during rebase where the row level filtering logic is patched to spark 3.1 but not spark 2.4 's `RowDataReader`