### PR TITLE
[LI] Ignore field-ids from file schema in ORC read path via Hivelink

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -53,6 +53,16 @@ public class Schema implements Serializable {
   private transient Map<Integer, Accessor<StructLike>> idToAccessor = null;
   private transient Map<Integer, String> idToName = null;
 
+  private transient boolean isFromHiveTable = false;
+
+  public boolean isFromHiveTable() {
+    return isFromHiveTable;
+  }
+
+  public void setFromHiveTable(boolean fromHiveTable) {
+    isFromHiveTable = fromHiveTable;
+  }
+
   public Schema(List<NestedField> columns, Map<String, Integer> aliases) {
     this.struct = StructType.of(columns);
     this.aliasToId = aliases != null ? ImmutableBiMap.copyOf(aliases) : null;

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hivelink.core;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,6 @@ import org.apache.iceberg.hivelink.core.schema.MergeHiveSchemaWithAvro;
 import org.apache.iceberg.hivelink.core.utils.HiveTypeUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -90,8 +88,7 @@ class LegacyHiveTableUtils {
     Types.StructType dataStructType = schema.asStruct();
     List<Types.NestedField> fields = Lists.newArrayList(dataStructType.fields());
 
-    String partitionColumnIdMappingString = props.get("partition.column.ids");
-    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema, partitionColumnIdMappingString);
+    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema);
     Types.StructType partitionStructType = partitionSchema.asStruct();
     fields.addAll(partitionStructType.fields());
     return new Schema(fields);
@@ -110,8 +107,7 @@ class LegacyHiveTableUtils {
     return (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(fieldNames, fieldTypeInfos);
   }
 
-  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema, String idMapping) {
-    Map<String, Integer> nameToId = parsePartitionColId(idMapping);
+  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema) {
     AtomicInteger fieldId = new AtomicInteger(10000);
     List<Types.NestedField> partitionFields = Lists.newArrayList();
     partitionKeys.forEach(f -> {
@@ -121,37 +117,9 @@ class LegacyHiveTableUtils {
       }
       partitionFields.add(
           Types.NestedField.optional(
-              nameToId.containsKey(f.getName()) ? nameToId.get(f.getName()) : fieldId.incrementAndGet(),
-              f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
+              fieldId.incrementAndGet(), f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
     });
     return new Schema(partitionFields);
-  }
-
-  /**
-   *
-   * @param idMapping A comma separated string representation of column name
-   *                  and its id, e.g. partitionCol1:10,partitionCol2:11, no
-   *                  whitespace is allowed in the middle
-   * @return          The parsed in-mem Map representation of the name to
-   *                  id mapping
-   */
-  private static Map<String, Integer> parsePartitionColId(String idMapping) {
-    Map<String, Integer> nameToId = Maps.newHashMap();
-    if (idMapping != null) {
-      // parse idMapping string
-      Arrays.stream(idMapping.split(",")).forEach(kv -> {
-        String[] split = kv.split(":");
-        if (split.length != 2) {
-          throw new IllegalStateException(String.format(
-              "partition.column.ids property is invalid format: %s",
-              idMapping));
-        }
-        String name = split[0];
-        Integer id = Integer.parseInt(split[1]);
-        nameToId.put(name, id);
-      });
-    }
-    return nameToId;
   }
 
   private static Type primitiveIcebergType(String hiveTypeString) {

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
@@ -91,7 +91,9 @@ class LegacyHiveTableUtils {
     Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema);
     Types.StructType partitionStructType = partitionSchema.asStruct();
     fields.addAll(partitionStructType.fields());
-    return new Schema(fields);
+    Schema retSchema = new Schema(fields);
+    retSchema.setFromHiveTable(true);
+    return retSchema;
   }
 
   static StructTypeInfo structTypeInfoFromCols(List<FieldSchema> cols) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -88,7 +88,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;
     final TypeDescription fileSchemaWithIds;
-    if (ORCSchemaUtil.hasIds(fileSchema)) {
+    if (ORCSchemaUtil.hasIds(fileSchema) && !schema.isFromHiveTable()) {
       fileSchemaWithIds = fileSchema;
     } else {
       if (nameMapping == null) {


### PR DESCRIPTION
Gobblin uses spark iceberg writer to write files and reuse those files for a hive table. In order for Iceberg reader to be able to read the Hive table via hivelink, we implement a runtime custom property in Iceberg Schema called `isFromHiveTable` to signal that this table is runtime converted from a Hive table, thus when the ORC read path construct a reader, it will ignore honoring the field-ids in the file schema and directly use `nameMapping` to map fields, which is what we need for the read to succeed.

Unit test in this case will be hard to write because it will need to mimic the entire Gobblin workflow to derive a table that satisfy the testing condition, so test will be done via integration test on gateway spark.