### PR TITLE
[LI] Add feature for Spark ORC reader to ignore field ids in files by using a new table property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -184,4 +184,8 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String READ_ORC_IGNORE_FILE_FIELD_IDS = "read.orc.ignore.field-ids.enabled";
+
+  public static final boolean READ_ORC_IGNORE_FILE_FIELD_IDS_DEFAULT = false;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -186,6 +186,5 @@ public class TableProperties {
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
 
   public static final String READ_ORC_IGNORE_FILE_FIELD_IDS = "read.orc.ignore.field-ids.enabled";
-
   public static final boolean READ_ORC_IGNORE_FILE_FIELD_IDS_DEFAULT = false;
 }

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/LegacyHiveTableUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hivelink.core;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,6 @@ import org.apache.iceberg.hivelink.core.schema.MergeHiveSchemaWithAvro;
 import org.apache.iceberg.hivelink.core.utils.HiveTypeUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -90,8 +88,7 @@ class LegacyHiveTableUtils {
     Types.StructType dataStructType = schema.asStruct();
     List<Types.NestedField> fields = Lists.newArrayList(dataStructType.fields());
 
-    String partitionColumnIdMappingString = props.get("partition.column.ids");
-    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema, partitionColumnIdMappingString);
+    Schema partitionSchema = partitionSchema(table.getPartitionKeys(), schema);
     Types.StructType partitionStructType = partitionSchema.asStruct();
     fields.addAll(partitionStructType.fields());
     return new Schema(fields);
@@ -110,8 +107,7 @@ class LegacyHiveTableUtils {
     return (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(fieldNames, fieldTypeInfos);
   }
 
-  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema, String idMapping) {
-    Map<String, Integer> nameToId = parsePartitionColId(idMapping);
+  private static Schema partitionSchema(List<FieldSchema> partitionKeys, Schema dataSchema) {
     AtomicInteger fieldId = new AtomicInteger(10000);
     List<Types.NestedField> partitionFields = Lists.newArrayList();
     partitionKeys.forEach(f -> {
@@ -121,37 +117,9 @@ class LegacyHiveTableUtils {
       }
       partitionFields.add(
           Types.NestedField.optional(
-              nameToId.containsKey(f.getName()) ? nameToId.get(f.getName()) : fieldId.incrementAndGet(),
-              f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
+              fieldId.incrementAndGet(), f.getName(), primitiveIcebergType(f.getType()), f.getComment()));
     });
     return new Schema(partitionFields);
-  }
-
-  /**
-   *
-   * @param idMapping A comma separated string representation of column name
-   *                  and its id, e.g. partitionCol1:10,partitionCol2:11, no
-   *                  whitespace is allowed in the middle
-   * @return          The parsed in-mem Map representation of the name to
-   *                  id mapping
-   */
-  private static Map<String, Integer> parsePartitionColId(String idMapping) {
-    Map<String, Integer> nameToId = Maps.newHashMap();
-    if (idMapping != null) {
-      // parse idMapping string
-      Arrays.stream(idMapping.split(",")).forEach(kv -> {
-        String[] split = kv.split(":");
-        if (split.length != 2) {
-          throw new IllegalStateException(String.format(
-              "partition.column.ids property is invalid format: %s",
-              idMapping));
-        }
-        String name = split[0];
-        Integer id = Integer.parseInt(split[1]);
-        nameToId.put(name, id);
-      });
-    }
-    return nameToId;
   }
 
   private static Type primitiveIcebergType(String hiveTypeString) {

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -137,6 +137,8 @@ public class ORC {
     private NameMapping nameMapping = null;
     private OrcRowFilter rowFilter = null;
 
+    private boolean ignoreFileFieldIds = false;
+
     private Function<TypeDescription, OrcRowReader<?>> readerFunc;
     private Function<TypeDescription, OrcBatchReader<?>> batchedReaderFunc;
     private int recordsPerBatch = VectorizedRowBatch.DEFAULT_SIZE;
@@ -217,10 +219,15 @@ public class ORC {
       return this;
     }
 
+    public ReadBuilder setIgnoreFileFieldIds(boolean ignoreFileFieldIds) {
+      this.ignoreFileFieldIds = ignoreFileFieldIds;
+      return this;
+    }
+
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
       return new OrcIterable<>(file, conf, schema, nameMapping, start, length, readerFunc, caseSensitive, filter,
-          batchedReaderFunc, recordsPerBatch, rowFilter);
+          batchedReaderFunc, recordsPerBatch, rowFilter, ignoreFileFieldIds);
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -91,7 +91,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;
     final TypeDescription fileSchemaWithIds;
-    if (ORCSchemaUtil.hasIds(fileSchema) && !ignoreFileFieldIds) {
+    if (!ignoreFileFieldIds && ORCSchemaUtil.hasIds(fileSchema)) {
       fileSchemaWithIds = fileSchema;
     } else {
       if (nameMapping == null) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -60,11 +60,13 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
   private NameMapping nameMapping;
   private final OrcRowFilter rowFilter;
 
+  private final boolean ignoreFileFieldIds;
+
   OrcIterable(InputFile file, Configuration config, Schema schema,
               NameMapping nameMapping, Long start, Long length,
               Function<TypeDescription, OrcRowReader<?>> readerFunction, boolean caseSensitive, Expression filter,
               Function<TypeDescription, OrcBatchReader<?>> batchReaderFunction, int recordsPerBatch,
-              OrcRowFilter rowFilter) {
+              OrcRowFilter rowFilter, boolean ignoreFileFieldIds) {
     this.schema = schema;
     this.readerFunction = readerFunction;
     this.file = file;
@@ -77,6 +79,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     this.batchReaderFunction = batchReaderFunction;
     this.recordsPerBatch = recordsPerBatch;
     this.rowFilter = rowFilter;
+    this.ignoreFileFieldIds = ignoreFileFieldIds;
   }
 
   @SuppressWarnings("unchecked")
@@ -88,7 +91,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;
     final TypeDescription fileSchemaWithIds;
-    if (ORCSchemaUtil.hasIds(fileSchema)) {
+    if (ORCSchemaUtil.hasIds(fileSchema) && !ignoreFileFieldIds) {
       fileSchemaWithIds = fileSchema;
     } else {
       if (nameMapping == null) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -47,15 +47,17 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
   private final String nameMapping;
   private final boolean caseSensitive;
   private final int batchSize;
+  private final boolean ignoreFileFieldIds;
 
   BatchDataReader(
       CombinedScanTask task, Schema expectedSchema, String nameMapping, FileIO fileIo,
-      EncryptionManager encryptionManager, boolean caseSensitive, int size) {
+      EncryptionManager encryptionManager, boolean caseSensitive, int size, boolean ignoreFileFieldIds) {
     super(task, fileIo, encryptionManager);
     this.expectedSchema = expectedSchema;
     this.nameMapping = nameMapping;
     this.caseSensitive = caseSensitive;
     this.batchSize = size;
+    this.ignoreFileFieldIds = ignoreFileFieldIds;
   }
 
   @Override
@@ -98,7 +100,8 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
               idToConstant))
           .recordsPerBatch(batchSize)
           .filter(task.residual())
-          .caseSensitive(caseSensitive);
+          .caseSensitive(caseSensitive)
+          .setIgnoreFileFieldIds(ignoreFileFieldIds);
 
       if (nameMapping != null) {
         builder.withNameMapping(NameMappingParser.fromJson(nameMapping));

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -71,16 +71,18 @@ class RowDataReader extends BaseDataReader<InternalRow> {
   private final Schema expectedSchema;
   private final String nameMapping;
   private final boolean caseSensitive;
+  private final boolean ignoreFileFieldIds;
 
   RowDataReader(
       CombinedScanTask task, Schema tableSchema, Schema expectedSchema, String nameMapping, FileIO io,
-      EncryptionManager encryptionManager, boolean caseSensitive) {
+      EncryptionManager encryptionManager, boolean caseSensitive, boolean ignoreFileFieldIds) {
     super(task, io, encryptionManager);
     this.io = io;
     this.tableSchema = tableSchema;
     this.expectedSchema = expectedSchema;
     this.nameMapping = nameMapping;
     this.caseSensitive = caseSensitive;
+    this.ignoreFileFieldIds = ignoreFileFieldIds;
   }
 
   @Override
@@ -185,7 +187,8 @@ class RowDataReader extends BaseDataReader<InternalRow> {
         .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema, idToConstant))
         .filter(task.residual())
         .caseSensitive(caseSensitive)
-        .rowFilter(orcRowFilter);
+        .rowFilter(orcRowFilter)
+        .setIgnoreFileFieldIds(ignoreFileFieldIds);
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));


### PR DESCRIPTION
Adds a new table property `"read.orc.ignore.field-ids.enabled"` to control the Spark ORC reader behavior to ignore field-ids in file schema even if it contains it. This feature will be useful for LI-Iceberg to read Gobblin dual hive/Iceberg tables with shared iceberg written files.

Integration tested via spark-shell on the cluster, with setting the table property
```ALTER TABLE xxx.xxx SET TBLPROPERTIES ('read.orc.ignore.field-ids.enabled' = 'true');```
makes the table readable.