### PR TITLE
Flink: Configuration to plan single file per task

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -286,6 +286,11 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       return this;
     }
 
+    public Builder planSingleWholeFilePerTask(boolean singleWholeFilePerTask) {
+      this.contextBuilder.planSingleWholeFilePerTask(singleWholeFilePerTask);
+      return this;
+    }
+
     public Builder properties(Map<String, String> properties) {
       contextBuilder.fromProperties(properties);
       return this;

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkPlanner.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkPlanner.java
@@ -1,0 +1,82 @@
+package org.apache.iceberg.flink.source;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.util.ThreadPools;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+public class TestFlinkPlanner  {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  protected HadoopCatalog catalog;
+  protected String warehouse;
+  protected String location;
+  FileFormat fileFormat = FileFormat.valueOf(FileFormat.ORC.toString());
+
+  @Before
+  public void before() throws IOException {
+    File warehouseFile = TEMPORARY_FOLDER.newFolder();
+    Assert.assertTrue(warehouseFile.delete());
+    // before variables
+    warehouse = "file:" + warehouseFile;
+    Configuration conf = new Configuration();
+    catalog = new HadoopCatalog(conf, warehouse);
+    location = String.format("%s/%s/%s", warehouse, TestFixtures.DATABASE, TestFixtures.TABLE);
+  }
+
+  @After
+  public void after() throws IOException {}
+
+  /** Test PLAN_SINGLE_WHOLE_FILE_PER_TASK configuration */
+  @Test
+  public void testFlinkPlannerSingleFilePerTask() throws Exception {
+    Table table =
+        catalog.createTable(TestFixtures.TABLE_IDENTIFIER, TestFixtures.SCHEMA, TestFixtures.SPEC);
+    List<Record> expectedRecords = RandomGenericData.generate(TestFixtures.SCHEMA, 1, 0L);
+    expectedRecords.get(0).set(2, "2020-03-20");
+    new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER)
+        .appendToTable(org.apache.iceberg.TestHelpers.Row.of("2020-03-20", 0), expectedRecords);
+    new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER)
+        .appendToTable(org.apache.iceberg.TestHelpers.Row.of("2020-03-20", 0), expectedRecords);
+
+    ScanContext scanContext = ScanContext.builder().planParallelism(2).build();
+    ExecutorService workerPool = ThreadPools.newWorkerPool("test", scanContext.planParallelism());
+    List<IcebergSourceSplit> splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
+    Assert.assertEquals("Expected 1 split but scan returned %d splits", 1 , splits.size());
+    Assert.assertEquals("Expected 2 FileScanTask in the split but has %d instead",
+        2 , splits.get(0).task().tasks().size());
+
+    // Enable planning single file per task
+    scanContext = ScanContext.builder().planParallelism(2).planSingleWholeFilePerTask(true).build();
+    splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
+    // There should be 2 splits with 1 FileScanTask each
+    Assert.assertEquals("Expected 2 splits but scan returned %d splits", 2 , splits.size());
+    splits.forEach(split
+        -> Assert.assertEquals("Expected a single file task in the split but task has %d tasks",
+            1 , split.task().tasks().size()));
+  }
+}

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkPlanner.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkPlanner.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.iceberg.flink.source;
 
 import java.io.File;
@@ -23,8 +41,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-
-public class TestFlinkPlanner  {
+public class TestFlinkPlanner {
 
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
@@ -65,18 +82,22 @@ public class TestFlinkPlanner  {
 
     ScanContext scanContext = ScanContext.builder().planParallelism(2).build();
     ExecutorService workerPool = ThreadPools.newWorkerPool("test", scanContext.planParallelism());
-    List<IcebergSourceSplit> splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
-    Assert.assertEquals("Expected 1 split but scan returned %d splits", 1 , splits.size());
-    Assert.assertEquals("Expected 2 FileScanTask in the split but has %d instead",
-        2 , splits.get(0).task().tasks().size());
+    List<IcebergSourceSplit> splits =
+        FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
+    Assert.assertEquals("Expected 1 split but scan returned %d splits", 1, splits.size());
+    Assert.assertEquals(
+        "Expected 2 FileScanTask in the split but has %d instead",
+        2, splits.get(0).task().tasks().size());
 
     // Enable planning single file per task
     scanContext = ScanContext.builder().planParallelism(2).planSingleWholeFilePerTask(true).build();
     splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
     // There should be 2 splits with 1 FileScanTask each
-    Assert.assertEquals("Expected 2 splits but scan returned %d splits", 2 , splits.size());
-    splits.forEach(split
-        -> Assert.assertEquals("Expected a single file task in the split but task has %d tasks",
-            1 , split.task().tasks().size()));
+    Assert.assertEquals("Expected 2 splits but scan returned %d splits", 2, splits.size());
+    splits.forEach(
+        split ->
+            Assert.assertEquals(
+                "Expected a single file task in the split but task has %d tasks",
+                1, split.task().tasks().size()));
   }
 }


### PR DESCRIPTION
Having a single whole file per task allows to extract column metadata stats that can be used by the iceberg connector.
Added `PLAN_SINGLE_WHOLE_FILE_PER_TASK` configuration to ScanContext to specify that.
More context https://docs.google.com/document/d/1QgogtL1NhGCNpci6rbMlxJgnEp8lY5XNDOitKbAAyuk/edit#heading=h.ms1hwzaxm9te

In this PR we only make changes needed in flink-iceberg connector to allow for custom assigner to work. The actual implementation of the custom event-ordered assigner based on Netflix's design is not merged to li-iceberg as it lacks necessary testing required to make it available to the company. The assigner will be maintained by CODA team until required level of testing is added.
