### PR TITLE
[LI] Bug fix: Remove ids from fileSchema before feeding it into apply…

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -97,7 +97,9 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
       if (nameMapping == null) {
         nameMapping = MappingUtil.create(schema);
       }
-      fileSchemaWithIds = ORCSchemaUtil.applyNameMapping(fileSchema, nameMapping);
+      // Since in the above branch, if the ignoreFileFieldIds is true, fileSchema can still have ids,
+      // here we should first sanitize it by removing the existing ids.
+      fileSchemaWithIds = ORCSchemaUtil.applyNameMapping(ORCSchemaUtil.removeIds(fileSchema), nameMapping);
     }
     readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, fileSchemaWithIds);
     // If the projected ORC schema is an empty struct, it means we are only projecting columns

--- a/orc/src/main/java/org/apache/iceberg/orc/RemoveIds.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/RemoveIds.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.orc;
 
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
 import org.apache.orc.TypeDescription;
 
 class RemoveIds extends OrcSchemaVisitor<TypeDescription> {

--- a/orc/src/main/java/org/apache/iceberg/orc/RemoveIds.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/RemoveIds.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.orc;
 
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
 import org.apache.orc.TypeDescription;
 
 class RemoveIds extends OrcSchemaVisitor<TypeDescription> {
@@ -44,6 +45,13 @@ class RemoveIds extends OrcSchemaVisitor<TypeDescription> {
   @Override
   public TypeDescription map(TypeDescription map, TypeDescription key, TypeDescription value) {
     return TypeDescription.createMap(key, value);
+  }
+
+  @Override
+  public TypeDescription union(TypeDescription union, List<TypeDescription> options) {
+    TypeDescription ret = TypeDescription.createUnion();
+    options.forEach(ret::addUnionChild);
+    return ret;
   }
 
   @Override


### PR DESCRIPTION
…NameMapping

In #134 , we added a config to let ORC read path ignore file schema ids and only use ids from namemapping, but in the code where the runtime `fileSchemaWithIds` is generated:

```fileSchemaWithIds = ORCSchemaUtil.applyNameMapping(fileSchema, nameMapping);```

Previously, we have assumed the `fileSchema` and `nameMapping` contains exact same columns, so that the `nameMapping` can guarantee to override all ids (if exist) in the fileSchema, thus serving as the single id provider for the `fileSchemaWithIds`.

but for the case when they don't contain exact same columns, for example, when the underlying files contains more columns than the hive schema columns, then `nameMapping` will not completely override the `fileSchema`'s all ids, there could be some uncleaned ids left. The way to fix it is we first do a cleanup by removing the ids first:

```fileSchemaWithIds = ORCSchemaUtil.applyNameMapping(ORCSchemaUtil.removeIds(fileSchema), nameMapping);```

This fix will make li-iceberg read hive tables whose table schema is a subset of its underlying file schema.

