### PR TITLE
Remove hive-serde dependency from HiveMetadataPreservingTableOperations

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -38,17 +37,15 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.hadoop.hive.serde2.avro.AvroObjectInspectorGenerator;
-import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hive.HiveClientPool;
+import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -86,6 +83,8 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       .build();
   public static final String ORC_COLUMNS = "columns";
   public static final String ORC_COLUMNS_TYPES = "columns.types";
+  // Redefine avro.schema.literal to avoid dependency on hive-serde
+  public static final String AVRO_SCHEMA_LITERAL_KEY = "avro.schema.literal";
 
   protected HiveMetadataPreservingTableOperations(Configuration conf, HiveClientPool metaClients, FileIO fileIO,
       String catalogName, String database, String table) {
@@ -236,13 +235,7 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       return false;
     }
     Schema schema = new Schema.Parser().parse(avroSchemaLiteral);
-    List<FieldSchema> hiveCols;
-    try {
-      hiveCols = getColsFromAvroSchema(schema);
-    } catch (SerDeException e) {
-      LOG.error("Failed to get get columns from avro schema when checking schema", e);
-      return false;
-    }
+    List<FieldSchema> hiveCols = HiveSchemaUtil.convert(AvroSchemaUtil.toIceberg(schema));
 
     boolean schemaMismatched;
     if (table.getSd().getCols().size() != hiveCols.size()) {
@@ -270,25 +263,10 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
     return schemaMismatched;
   }
 
-  private static List<FieldSchema> getColsFromAvroSchema(Schema schema)
-      throws SerDeException {
-    AvroObjectInspectorGenerator avroOI = new AvroObjectInspectorGenerator(schema);
-    List<String> columnNames = avroOI.getColumnNames();
-    List<TypeInfo> columnTypes = avroOI.getColumnTypes();
-    if (columnNames.size() != columnTypes.size()) {
-      throw new IllegalStateException();
-    }
-
-    return IntStream.range(0, columnNames.size())
-        .mapToObj(i -> new FieldSchema(columnNames.get(i), columnTypes.get(i).getTypeName(), ""))
-        .collect(Collectors.toList());
-  }
-
   private static String getAvroSchemaLiteral(Table table) {
-    String schemaStr = table.getParameters().get(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
+    String schemaStr = table.getParameters().get(AVRO_SCHEMA_LITERAL_KEY);
     if (Strings.isNullOrEmpty(schemaStr)) {
-      schemaStr = table.getSd().getSerdeInfo().getParameters()
-          .get(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
+      schemaStr = table.getSd().getSerdeInfo().getParameters().get(AVRO_SCHEMA_LITERAL_KEY);
     }
     return schemaStr;
   }

--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
@@ -47,9 +47,9 @@ public class TestHiveMetadataPreservingTableOperations {
 
     long currentTimeMillis = System.currentTimeMillis();
     StorageDescriptor storageDescriptor = new StorageDescriptor();
-    FieldSchema field1 = new FieldSchema("name", "string", "");
-    FieldSchema field2 = new FieldSchema("id", "int", "");
-    FieldSchema field3 = new FieldSchema("nested", "struct<field1:string,field2:string>", "");
+    FieldSchema field1 = new FieldSchema("name", "string", null);
+    FieldSchema field2 = new FieldSchema("id", "int", null);
+    FieldSchema field3 = new FieldSchema("nested", "struct<field1:string,field2:string>", null);
     // Set cols with incorrect nested type
     storageDescriptor.setCols(ImmutableList.of(field1, field2, new FieldSchema("nested", "struct<field1:int," +
         "field2:string>", "")));


### PR DESCRIPTION
Because spark runtime jars do not include hive-serde, we should avoid using hive-serde imports in `HiveMetadataPreservingTableOperations`. This PR removes the dependency by using `HiveSchemaUtil.convert` instead of `AvroObjectInspectorGenerator`, and redefining the `avro.schema.literal` constant.

Tested through unit test and successfully ran an ExpireSnapshots action through spark with the change.