### PR TITLE
Fix reordering avro nullable types in MergeHiveSchemaWithAvro

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -138,6 +138,15 @@ public class AvroSchemaUtil {
     return false;
   }
 
+  public static int getNullIndex(Schema schema) {
+    Preconditions.checkArgument(isOptionSchema(schema));
+    if (schema.getTypes().get(0).getType() == Schema.Type.NULL) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+
   /**
    * This method decides whether a schema represents a single type union, i.e., a union that contains only one option
    *

--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestMergeHiveSchemaWithAvro.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -353,6 +354,25 @@ public class TestMergeHiveSchemaWithAvro {
             AvroSchemaUtil.fromOption(merged.getField("fa").schema()).getLogicalType().getName());
     // This last line should not throw any exception.
     AvroSchemaUtil.toIceberg(merged);
+  }
+
+  @Test
+  public void shouldNotReorderListElementType() {
+    String hive = "struct<fa:array<int>>";
+    Schema avro =
+        SchemaBuilder.record("r1")
+            .fields()
+            .name("fa")
+            .type()
+            .nullable()
+            .array()
+            .items()
+            .nullable()
+            .intType()
+            .arrayDefault(Arrays.asList(1, 2, 3))
+            .endRecord();
+
+    assertSchema(avro, merge(hive, avro));
   }
 
   // TODO: tests to retain schema props


### PR DESCRIPTION
This patch fixes a bug where the avro nullable type orders (the order of null and the other type's order) is wrongly flipped, resulting in read failure.

The fix is demonstrated by the new unit test `shouldNotReorderListElementType`