### PR TITLE
[LI] Bundle hivelink to iceberg-runtime jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1192,6 +1192,7 @@ project(':iceberg-runtime') {
     compile project(':iceberg-data')
     compile project(':iceberg-hive-metastore')
     compile project(':iceberg-orc')
+    compile project(':iceberg-hivelink-core')
   }
 
   shadowJar {


### PR DESCRIPTION
Hivelink module is needed by downstream LI consumers as a common dependency.

We should bundle it into `iceberg-runtime` so they can define a single runtime dependency from `iceberg-runtime` to get everything they need at runtime. `iceberg-runtime` automatically takes care of shading and dependency management related stuff so we don't need to additionally do that for hivelink.