### PR TITLE
Revert "Remove hive-serde dependency from HiveMetadataPreservingTableOperations (#138)"

### DIFF
--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
@@ -47,9 +47,9 @@ public class TestHiveMetadataPreservingTableOperations {
 
     long currentTimeMillis = System.currentTimeMillis();
     StorageDescriptor storageDescriptor = new StorageDescriptor();
-    FieldSchema field1 = new FieldSchema("name", "string", null);
-    FieldSchema field2 = new FieldSchema("id", "int", null);
-    FieldSchema field3 = new FieldSchema("nested", "struct<field1:string,field2:string>", null);
+    FieldSchema field1 = new FieldSchema("name", "string", "");
+    FieldSchema field2 = new FieldSchema("id", "int", "");
+    FieldSchema field3 = new FieldSchema("nested", "struct<field1:string,field2:string>", "");
     // Set cols with incorrect nested type
     storageDescriptor.setCols(ImmutableList.of(field1, field2, new FieldSchema("nested", "struct<field1:int," +
         "field2:string>", "")));


### PR DESCRIPTION
This reverts commit 5bfe975d3fcf5517416cef0aab4971e2943824e2.

Reverting #138 since converting the schema to iceberg and back causes it to lose unionType info, causing schema issues for some datasets.