### PR TITLE
Revert 7dd301f04f8ec930e24e5fb831658550cc9ff5e7 and add unit test

### DIFF
--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveMetadataPreservingTableOperations.java
@@ -79,7 +79,7 @@ public class TestHiveMetadataPreservingTableOperations {
   }
 
   @Test
-  public void testFixMismatchedSchemaWithUnionType() {
+  public void testFixMismatchedSchemaWithSingleUnionType() {
     // Schema literal with 2 fields (name, uniontest)
     String testSchemaLiteral =
         "{\"name\":\"testSchema\",\"type\":\"record\",\"namespace\":\"com.linkedin.test\","


### PR DESCRIPTION
As in #142, reverting this bad commit in 1.0.x branch as well. In this one also added a unit test which verifies that uniontype info is not lost.