### PR TITLE
Support to field filtering of complex union type in Avro

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -385,10 +385,16 @@ public class Avro {
     };
     private Long start = null;
     private Long length = null;
+    private Schema fileSchema = null;
 
     private ReadBuilder(InputFile file) {
       Preconditions.checkNotNull(file, "Input file cannot be null");
       this.file = file;
+    }
+
+    public ReadBuilder setFileSchema(Schema fileSchema) {
+      this.fileSchema = fileSchema;
+      return this;
     }
 
     public ReadBuilder createReaderFunc(Function<Schema, DatumReader<?>> readerFunction) {
@@ -458,7 +464,7 @@ public class Avro {
       }
 
       return new AvroIterable<>(file,
-          new ProjectionDatumReader<>(readerFunc, schema, renames, nameMapping),
+          new ProjectionDatumReader<>(readerFunc, schema, renames, nameMapping, fileSchema),
           start, length, reuseContainers);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -498,4 +498,20 @@ public class AvroSchemaUtil {
     // don't touch any other primitive values
     return defaultValue;
   }
+
+  public static boolean isPrimitiveType(Schema schema) {
+    switch (schema.getType()) {
+      case STRING:
+      case BYTES:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case NULL:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -498,20 +498,4 @@ public class AvroSchemaUtil {
     // don't touch any other primitive values
     return defaultValue;
   }
-
-  public static boolean isPrimitiveType(Schema schema) {
-    switch (schema.getType()) {
-      case STRING:
-      case BYTES:
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-      case BOOLEAN:
-      case NULL:
-        return true;
-      default:
-        return false;
-    }
-  }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -108,6 +108,9 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
   /*
   A complex union with multiple types of Avro schema is converted into a struct with multiple fields of Iceberg schema.
   Also an extra tag field is added into the struct of Iceberg schema during the conversion.
+  Given an example of complex union in both Avro and Iceberg:
+  Avro schema: {"name":"unionCol","type":["int","string"]}
+  Iceberg schema:  struct<0: tag: required int, 1: field0: optional int, 2: field1: optional string>
   The fields in the struct of Iceberg schema are expected to be stored in the same order
   as the corresponding types in the union of Avro schema.
   Except the tag field, the fields in the struct of Iceberg schema are the same as the types in the union of Avro schema

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -22,12 +22,15 @@ package org.apache.iceberg.avro;
 import java.util.Deque;
 import java.util.List;
 import org.apache.avro.Schema;
+import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 public abstract class AvroSchemaWithTypeVisitor<T> {
+  private static final String UNION_TAG_FIELD_NAME = "tag";
+
   public static <T> T visit(org.apache.iceberg.Schema iSchema, Schema schema, AvroSchemaWithTypeVisitor<T> visitor) {
     return visit(iSchema.asStruct(), schema, visitor);
   }
@@ -97,17 +100,89 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
         options.add(visit(type, branch, visitor));
       }
     } else { // complex union case
-      int index = 1;
-      for (Schema branch : types) {
-        if (branch.getType() == Schema.Type.NULL) {
-          options.add(visit((Type) null, branch, visitor));
-        } else {
-          options.add(visit(type.asStructType().fields().get(index).type(), branch, visitor));
-          index += 1;
+      visitComplexUnion(type, union, visitor, options);
+    }
+    return visitor.union(type, union, options);
+  }
+
+  /*
+  A complex union with multiple types of Avro schema is converted into a struct with multiple fields of Iceberg schema.
+  Also an extra tag field is added into the struct of Iceberg schema during the conversion.
+  The fields in the struct of Iceberg schema are expected to be stored in the same order
+  as the corresponding types in the union of Avro schema.
+  Except the tag field, the fields in the struct of Iceberg schema are the same as the types in the union of Avro schema
+  in the general case. In case of field projection, the fields in the struct of Iceberg schema only contains
+  the fields to be projected which equals to a subset of the types in the union of Avro schema.
+  Therefore, this function visits the complex union with the consideration of both cases.
+   */
+  private static <T> void visitComplexUnion(Type type, Schema union,
+                                            AvroSchemaWithTypeVisitor<T> visitor, List<T> options) {
+    boolean nullTypeFound = false;
+    int typeIndex = 0;
+    int fieldIndexInStruct = 0;
+    while (typeIndex < union.getTypes().size()) {
+      Schema schema = union.getTypes().get(typeIndex);
+      // in some cases, a NULL type exists in the union of Avro schema besides the actual types,
+      // and it affects the index of the actual types of the order in the union
+      if (schema.getType() == Schema.Type.NULL) {
+        nullTypeFound = true;
+        options.add(visit((Type) null, schema, visitor));
+      } else {
+        boolean relatedFieldInStructFound = false;
+        Types.StructType struct = type.asStructType();
+        if (fieldIndexInStruct < struct.fields().size() &&
+                UNION_TAG_FIELD_NAME.equals(struct.fields().get(fieldIndexInStruct).name())) {
+          fieldIndexInStruct++;
+        }
+
+        if (fieldIndexInStruct < struct.fields().size()) {
+          // If a NULL type is found before current type, the type index is one larger than the actual type index which
+          // can be used to track the corresponding field in the struct of Iceberg schema.
+          int actualTypeIndex = nullTypeFound ? typeIndex - 1 : typeIndex;
+          String structFieldName = type.asStructType().fields().get(fieldIndexInStruct).name();
+          int indexFromStructFieldName = Integer.valueOf(structFieldName.substring(5));
+          if (actualTypeIndex == indexFromStructFieldName) {
+            relatedFieldInStructFound = true;
+            options.add(visit(type.asStructType().fields().get(fieldIndexInStruct).type(), schema, visitor));
+            fieldIndexInStruct++;
+          }
+        }
+
+        if (!relatedFieldInStructFound) {
+          visitNotProjectedTypeInComplexUnion(schema, visitor, options);
+        }
+      }
+      typeIndex++;
+    }
+  }
+
+  // If a field is not projected, a corresponding field in the struct of Iceberg schema cannot be found
+  // for current type of union in Avro schema, a reader for current type still needs to be created and
+  // used to make the reading of Avro file successfully. In this case, an pseudo Iceberg type is converted from
+  // the Avro schema and is used to create the option for the reader of the current type which still can
+  // read the corresponding content in Avro file successfully.
+  private static <T> void visitNotProjectedTypeInComplexUnion(Schema schema,
+                                                                            AvroSchemaWithTypeVisitor<T> visitor,
+                                                                            List<T> options) {
+    Type iType = AvroSchemaUtil.convert(schema);
+    if (schema.getType().equals(Schema.Type.RECORD)) {
+      // When the type of Avro schema is RECORD, the fields under it must have the property of "field-id".
+      // However, the "field-id" is not set in previous steps as the corresponding Iceberg type is not projected
+      // and no field id can be found for this field in Iceberg schema.
+      // Therefore, a name mapping is created based on the Avro schema and its corresponding Iceberg type.
+      // The field-id from the resulted name mapping is assigned as the property of "field-id" of each
+      // field under the Avro schema.
+      NameMappingWithAvroSchema nameMappingWithAvroSchema = new NameMappingWithAvroSchema();
+      MappedFields nameMapping = AvroWithPartnerByStructureVisitor.visit(
+              iType, schema, nameMappingWithAvroSchema);
+      for (Schema.Field field : schema.getFields()) {
+        if (!AvroSchemaUtil.hasFieldId(field)) {
+          int fieldId = nameMapping.id(field.name());
+          field.addProp(AvroSchemaUtil.FIELD_ID_PROP, fieldId);
         }
       }
     }
-    return visitor.union(type, union, options);
+    options.add(visit(iType, schema, visitor));
   }
 
   private static <T> T visitArray(Type type, Schema array, AvroSchemaWithTypeVisitor<T> visitor) {

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithTypeByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithTypeByStructureVisitor.java
@@ -23,6 +23,12 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 
+/**
+ * This class extends {@link AvroWithPartnerByStructureVisitor} to override some functions
+ * related to some nested data types which help the generation of name mapping from Iceberg schema.
+ *
+ *  @param <T> Return T.
+ */
 public class AvroWithTypeByStructureVisitor<T> extends AvroWithPartnerByStructureVisitor<Type, T> {
   @Override
   protected boolean isMapType(Type type) {

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithTypeByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithTypeByStructureVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+
+public class AvroWithTypeByStructureVisitor<T> extends AvroWithPartnerByStructureVisitor<Type, T> {
+  @Override
+  protected boolean isMapType(Type type) {
+    return type.isMapType();
+  }
+
+  @Override
+  protected boolean isStringType(Type type) {
+    return type.isPrimitiveType() && type.asPrimitiveType().typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  protected Type arrayElementType(Type arrayType) {
+    return arrayType.asListType().elementType();
+  }
+
+  @Override
+  protected Type mapKeyType(Type mapType) {
+    return mapType.asMapType().keyType();
+  }
+
+  @Override
+  protected Type mapValueType(Type mapType) {
+    return mapType.asMapType().valueType();
+  }
+
+  @Override
+  protected Pair<String, Type> fieldNameAndType(Type structType, int pos) {
+    Types.NestedField field = structType.asStructType().fields().get(pos);
+    return Pair.of(field.name(), field.type());
+  }
+
+  @Override
+  protected Type nullType() {
+    return null;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/NameMappingWithAvroSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/NameMappingWithAvroSchema.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.iceberg.mapping.MappedField;
+import org.apache.iceberg.mapping.MappedFields;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+public class NameMappingWithAvroSchema extends AvroWithTypeByStructureVisitor<MappedFields> {
+  @Override
+  public MappedFields record(
+      Type struct, Schema record, List<String> names, List<MappedFields> fieldResults) {
+    List<MappedField> fields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+
+    for (int i = 0; i < fieldResults.size(); i += 1) {
+      Types.NestedField field = struct.asStructType().fields().get(i);
+      MappedFields result = fieldResults.get(i);
+      fields.add(MappedField.of(field.fieldId(), field.name(), result));
+    }
+
+    return MappedFields.of(fields);
+  }
+
+  @Override
+  public MappedFields union(Type type, Schema union, List<MappedFields> optionResults) {
+    if (AvroSchemaUtil.isOptionSchema(union)) {
+      for (int i = 0; i < optionResults.size(); i += 1) {
+        if (union.getTypes().get(i).getType() != Schema.Type.NULL) {
+          return optionResults.get(i);
+        }
+      }
+    } else { // Complex union
+      Preconditions.checkArgument(
+          type instanceof Types.StructType,
+          "Cannot visit invalid Iceberg type: %s for Avro complex union type: %s",
+          type,
+          union);
+      Types.StructType struct = (Types.StructType) type;
+      List<MappedField> fields = Lists.newArrayListWithExpectedSize(optionResults.size());
+      int index = 0;
+      // Avro spec for union types states that unions may not contain more than one schema with the
+      // same type, except for the named types record, fixed and enum. For example, unions
+      // containing two array types or two map types are not permitted, but two types with different
+      // names are permitted.
+      // Therefore, for non-named types, use the Avro type toString() as the field mapping key. For
+      // named types, use the record name of the Avro type as the field mapping key.
+      for (Schema option : union.getTypes()) {
+        if (option.getType() != Schema.Type.NULL) {
+          // Check if current option is a named type, i.e., a RECORD, ENUM, or FIXED type. If so,
+          // use the record name of the Avro type as the field name. Otherwise, use the Avro
+          // type toString().
+          if (option.getType() == Schema.Type.RECORD ||
+              option.getType() == Schema.Type.ENUM ||
+              option.getType() == Schema.Type.FIXED) {
+            fields.add(
+                MappedField.of(
+                    struct.fields().get(index).fieldId(),
+                    option.getName(),
+                    optionResults.get(index)));
+          } else {
+            fields.add(
+                MappedField.of(
+                    struct.fields().get(index).fieldId(),
+                    option.toString(),
+                    optionResults.get(index)));
+          }
+
+          // Both iStruct and optionResults do not contain an entry for the NULL type, so we need to
+          // increment i only
+          // when we encounter a non-NULL type.
+          index++;
+        }
+      }
+      return MappedFields.of(fields);
+    }
+    return null;
+  }
+
+  @Override
+  public MappedFields array(Type list, Schema array, MappedFields elementResult) {
+    return MappedFields.of(MappedField.of(list.asListType().elementId(), "element", elementResult));
+  }
+
+  @Override
+  public MappedFields map(Type sMap, Schema map, MappedFields keyResult, MappedFields valueResult) {
+    return MappedFields.of(
+        MappedField.of(sMap.asMapType().keyId(), "key", keyResult),
+        MappedField.of(sMap.asMapType().valueId(), "value", valueResult));
+  }
+
+  @Override
+  public MappedFields map(Type sMap, Schema map, MappedFields valueResult) {
+    return MappedFields.of(
+        MappedField.of(sMap.asMapType().keyId(), "key", null),
+        MappedField.of(sMap.asMapType().valueId(), "value", valueResult));
+  }
+
+  @Override
+  public MappedFields primitive(Type type, Schema primitive) {
+    return null; // no mapping because primitives have no nested fields
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/NameMappingWithAvroSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/NameMappingWithAvroSchema.java
@@ -28,6 +28,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+/**
+ * This class extends {@link AvroWithTypeByStructureVisitor} to generate the name mapping from
+ * Iceberg schema and the corresponding Avro schema.
+ *
+ *  param Return MappedFields
+ */
 public class NameMappingWithAvroSchema extends AvroWithTypeByStructureVisitor<MappedFields> {
   @Override
   public MappedFields record(

--- a/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
@@ -50,6 +50,18 @@ public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosi
     this.nameMapping = nameMapping;
   }
 
+  public ProjectionDatumReader(Function<Schema, DatumReader<?>> getReader,
+                               org.apache.iceberg.Schema expectedSchema,
+                               Map<String, String> renames,
+                               NameMapping nameMapping,
+                               Schema fileSchema) {
+    this.getReader = getReader;
+    this.expectedSchema = expectedSchema;
+    this.renames = renames;
+    this.nameMapping = nameMapping;
+    this.fileSchema = fileSchema;
+  }
+
   @Override
   public void setRowPositionSupplier(Supplier<Long> posSupplier) {
     if (wrapped instanceof SupportsRowPosition) {
@@ -59,7 +71,10 @@ public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosi
 
   @Override
   public void setSchema(Schema newFileSchema) {
-    this.fileSchema = newFileSchema;
+    if (this.fileSchema == null) {
+      this.fileSchema = newFileSchema;
+    }
+
     if (nameMapping == null && !AvroSchemaUtil.hasIds(fileSchema)) {
       nameMapping = MappingUtil.create(expectedSchema);
     }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
@@ -121,7 +120,8 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       return options.get(0);
     } else {
       // Complex union
-      List<Types.NestedField> newFields = new ArrayList<>();
+      // List<Types.NestedField> newFields = new ArrayList<>();
+      List<Types.NestedField> newFields  = Lists.newArrayListWithExpectedSize(options.size());
       newFields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
 
       int tagIndex = 0;

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -120,7 +120,6 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       return options.get(0);
     } else {
       // Complex union
-      // List<Types.NestedField> newFields = new ArrayList<>();
       List<Types.NestedField> newFields  = Lists.newArrayListWithExpectedSize(options.size());
       newFields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestNameMappingWithAvroSchema.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestNameMappingWithAvroSchema.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import org.apache.avro.Schema;
+import org.apache.iceberg.mapping.MappedField;
+import org.apache.iceberg.mapping.MappedFields;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestNameMappingWithAvroSchema {
+  @Test
+  public void testNameMappingWithAvroSchema() {
+
+    // Create an example Avro schema with a nested record but not using the SchemaBuilder
+    Schema schema =
+        Schema.createRecord(
+            "test",
+            null,
+            null,
+            false,
+            Lists.newArrayList(
+                new Schema.Field("id", Schema.create(Schema.Type.INT)),
+                new Schema.Field("data", Schema.create(Schema.Type.STRING)),
+                new Schema.Field(
+                    "location",
+                    Schema.createRecord(
+                        "location",
+                        null,
+                        null,
+                        false,
+                        Lists.newArrayList(
+                            new Schema.Field("lat", Schema.create(Schema.Type.DOUBLE)),
+                            new Schema.Field("long", Schema.create(Schema.Type.DOUBLE))))),
+                new Schema.Field("friends", Schema.createArray(Schema.create(Schema.Type.STRING))),
+                new Schema.Field(
+                    "simpleUnion",
+                    Schema.createUnion(
+                        Lists.newArrayList(
+                            Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)))),
+                new Schema.Field(
+                    "complexUnion",
+                    Schema.createUnion(
+                        new Schema[] {
+                            Schema.create(Schema.Type.NULL),
+                            Schema.create(Schema.Type.STRING),
+                            Schema.createRecord(
+                                "innerRecord1",
+                                null,
+                                null,
+                                false,
+                                Lists.newArrayList(
+                                    new Schema.Field("lat", Schema.create(Schema.Type.DOUBLE)),
+                                    new Schema.Field("long", Schema.create(Schema.Type.DOUBLE)))),
+                            Schema.createRecord(
+                                "innerRecord2",
+                                null,
+                                null,
+                                false,
+                                Lists.newArrayList(
+                                    new Schema.Field("lat", Schema.create(Schema.Type.DOUBLE)),
+                                    new Schema.Field("long", Schema.create(Schema.Type.DOUBLE)))),
+                            Schema.createRecord(
+                                "innerRecord3",
+                                null,
+                                null,
+                                false,
+                                Lists.newArrayList(
+                                    new Schema.Field(
+                                        "innerUnion",
+                                        Schema.createUnion(
+                                            Lists.newArrayList(
+                                                Schema.create(Schema.Type.STRING),
+                                                Schema.create(Schema.Type.INT)))))),
+                            Schema.createEnum(
+                                "timezone", null, null, Lists.newArrayList("UTC", "PST", "EST")),
+                            Schema.createFixed("bitmap", null, null, 1)
+                        }))));
+
+    NameMappingWithAvroSchema nameMappingWithAvroSchema = new NameMappingWithAvroSchema();
+
+    // Convert Avro schema to Iceberg schema
+    org.apache.iceberg.Schema icebergSchema = AvroSchemaUtil.toIceberg(schema);
+    MappedFields expected =
+        MappedFields.of(
+            MappedField.of(0, "id"),
+            MappedField.of(1, "data"),
+            MappedField.of(
+                2,
+                "location",
+                MappedFields.of(MappedField.of(6, "lat"), MappedField.of(7, "long"))),
+            MappedField.of(3, "friends", MappedFields.of(MappedField.of(8, "element"))),
+            MappedField.of(4, "simpleUnion"),
+            MappedField.of(
+                5,
+                "complexUnion",
+                MappedFields.of(
+                    MappedField.of(17, "\"string\""),
+                    MappedField.of(
+                        18,
+                        "innerRecord1",
+                        MappedFields.of(MappedField.of(9, "lat"), MappedField.of(10, "long"))),
+                    MappedField.of(
+                        19,
+                        "innerRecord2",
+                        MappedFields.of(MappedField.of(11, "lat"), MappedField.of(12, "long"))),
+                    MappedField.of(
+                        20,
+                        "innerRecord3",
+                        MappedFields.of(
+                            MappedField.of(
+                                16,
+                                "innerUnion",
+                                MappedFields.of(
+                                    MappedField.of(13, "\"string\""),
+                                    MappedField.of(14, "\"int\""))))),
+                    MappedField.of(21, "timezone"),
+                    MappedField.of(22, "bitmap"))));
+    MappedFields actual = AvroWithPartnerByStructureVisitor.visit(
+            icebergSchema.asStruct(), schema, nameMappingWithAvroSchema);
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroReader.java
@@ -83,7 +83,7 @@ public class SparkAvroReader implements DatumReader<InternalRow> {
       if (AvroSchemaUtil.isOptionSchema(union) || AvroSchemaUtil.isSingleTypeUnion(union)) {
         return ValueReaders.union(options);
       } else {
-        return SparkValueReaders.union(union, options);
+        return SparkValueReaders.union(union, options, expected);
       }
     }
 


### PR DESCRIPTION
**Problem**
Currently field filtering does not work for complex union type in Avro. The root cause of the problem is as follows:

The current code assumes that the types inside a union from Avro schema should match the type fields inside a union struct from Iceberg schema when Avro union reader is created.
In case of column projection of union type, the current code only prune the schema of union in Iceberg schema with the projected fields, while the union of Avro schema still contains all the types. It results in the mismatch between Avro schema and Iceberg schema for the union in this case.
However, as all the contents of each data type in a union in Avro file should be read by Avro readers correctly no matter this data type is projected or not based on the decoding procedure of Avro file, all the types in a union from Avro schema are needed to create the corresponding type readers in AvroUnionReader even in case of column projection. Therefore the union in Avro schema cannot be pruned like what is done to the union struct in Iceberg schema.

**Solution**
Assuming there are N types in a union, there are N+1 fields including "tag" field in the struct corresponding to the union in Iceberg schema. The user can project any K fields (K>=1 and K<=N+1 and including the tag field) of the union in a query. The case of without column projection equals to full fields projection namely K=N+1. Therefore the solution does not differentiate the cases of with and without column projections.
In addition, the order of the types in a union in Iceberg schema can be identified from its field name like "field0".."fieldK". K is the index which can be used to match the order of the types in the union of Avro schema.

In the code of create the readers of all types in the union of Avro schema (namely AvroSchemaWithTypeVisitor.visitUnion), checking the fields of the struct corresponding union in Iceberg schema to create a map between the order index and the field type in Iceberg schema. When iterating through all the types in Avro schema, using the order index to check if the corresponding type exists in the map, if yes which means the field is projected, creating the option of creating the reader with the type in Iceberg schema, otherwise, creating the option with a pseudo Iceberg type converted from Avro schema. 
There is a special case when the Avro schema is RECORD, the property of `field-id` should be set in each field under the RECORD Avro schema. Therefore, a `NameMapping` is created based on both Avro schema and the converted Iceberg type by the code of  `AvroWithPartnerByStructureVisitor` and `NameMappingWithAvroSchema` from PR [Add Avro-assisted name mapping](https://github.com/apache/iceberg/pull/7392)

In the code of AvroUnionReader, Iceberg schema needs to be passed into it. The fields of the returned row should be constructed based on the fields in Iceberg schema not the types in Avro schema. If tag field is projected, one more field is added in the beginning of the row and updated with the index of the field in Avro file.

**Test**
All the test cases in TestSparkAvroUnions.java with a new test case writeAndValidateRequiredComplexUnionWithProjection

Manual test with Spark3 with all the following queries on a table with a union:
```
val df = spark.sql("select c1.field0 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field0,c1.field1 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.tag,c1.field0 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.tag,c1.field0,c1.field1 from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field1,c1.field0,c1.tag from u_yiqding.avro_union_table_test")

val df = spark.sql("select c1.field1,c1.field0 from u_yiqding.avro_union_table_test")
```