### PR TITLE
Support to field filtering of complex union type in ORC

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -415,7 +415,7 @@ public final class ORCSchemaUtil {
       TypeDescription childOrcType = orcField.type.getChildren().get(i);
       boolean typeProjectedInIcebergSchema = false;
       for (Types.NestedField nestedField : nestedFields) {
-        if (!nestedField.name().equals("tag") &&
+        if (!nestedField.name().equals(ICEBERG_UNION_TAG_FIELD_NAME) &&
                 Integer.parseInt(nestedField.name().substring(5)) == i) {
           // child type is projected in Iceberg schema
           TypeDescription childType = buildOrcProjection(nestedField.fieldId(), nestedField.type(),

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -20,13 +20,14 @@
 package org.apache.iceberg.orc;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 
-
 public abstract class OrcSchemaWithTypeVisitor<T> {
+
   public static <T> T visit(
       org.apache.iceberg.Schema iSchema, TypeDescription schema, OrcSchemaWithTypeVisitor<T> visitor) {
     return visit(iSchema.asStruct(), schema, visitor);
@@ -78,12 +79,71 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     if (types.size() == 1) { // single type union
       options.add(visit(type, types.get(0), visitor));
     } else { // complex union
-      for (int i = 0; i < types.size(); i += 1) {
-        options.add(visit(type.asStructType().fields().get(i + 1).type(), types.get(i), visitor));
-      }
+      visitComplexUnion(type, union, visitor, options);
     }
 
     return visitor.union(type, union, options);
+  }
+
+  /*
+  A complex union with multiple types of Avro schema is converted into a struct with multiple fields of Iceberg schema.
+  Also an extra tag field is added into the struct of Iceberg schema during the conversion.
+  Given an example of complex union in both Avro and Iceberg:
+  Avro schema: {"name":"unionCol","type":["int","string"]}
+  Iceberg schema:  struct<0: tag: required int, 1: field0: optional int, 2: field1: optional string>
+  The fields in the struct of Iceberg schema are expected to be stored in the same order
+  as the corresponding types in the union of Avro schema.
+  Except the tag field, the fields in the struct of Iceberg schema are the same as the types in the union of Avro schema
+  in the general case. In case of field projection, the fields in the struct of Iceberg schema only contains
+  the fields to be projected which equals to a subset of the types in the union of ORC schema.
+  Therefore, this function visits the complex union with the consideration of both cases.
+   */
+  private <T> void visitComplexUnion(Type type, TypeDescription union, OrcSchemaWithTypeVisitor<T> visitor,
+                                     List<T> options) {
+    int typeIndex = 0;
+    int fieldIndexInStruct = 0;
+    while (typeIndex < union.getChildren().size()) {
+      TypeDescription schema = union.getChildren().get(typeIndex);
+      boolean relatedFieldInStructFound = false;
+      Types.StructType struct = type.asStructType();
+      if (fieldIndexInStruct < struct.fields().size() &&
+              ORCSchemaUtil.ICEBERG_UNION_TAG_FIELD_NAME
+                      .equals(struct.fields().get(fieldIndexInStruct).name())) {
+        fieldIndexInStruct++;
+      }
+
+      if (fieldIndexInStruct < struct.fields().size()) {
+        String structFieldName = type.asStructType().fields().get(fieldIndexInStruct).name();
+        int indexFromStructFieldName = Integer.parseInt(structFieldName.substring(5));
+        if (typeIndex == indexFromStructFieldName) {
+          relatedFieldInStructFound = true;
+          T option = visit(type.asStructType().fields().get(fieldIndexInStruct).type(), schema, visitor);
+          options.add(option);
+          fieldIndexInStruct++;
+        }
+      }
+      if (!relatedFieldInStructFound) {
+        visitNotProjectedTypeInComplexUnion(schema, visitor, options, typeIndex);
+      }
+      typeIndex++;
+    }
+  }
+
+  // If a field is not projected, a corresponding field in the struct of Iceberg schema cannot be found
+  // for current type of union in Orc schema, a reader for current type still needs to be created and
+  // used to make the reading of Orc file successfully. In this case, a pseudo Iceberg type is converted from
+  // the Orc schema and is used to create the option for the reader of the current type which still can
+  // read the corresponding content in Orc file successfully.
+  private static <T> void visitNotProjectedTypeInComplexUnion(TypeDescription schema,
+                                                              OrcSchemaWithTypeVisitor<T> visitor,
+                                                              List<T> options,
+                                                              int typeIndex) {
+    OrcToIcebergVisitor schemaConverter = new OrcToIcebergVisitor();
+    schemaConverter.beforeField("field" + typeIndex, schema);
+    schema.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, "-1");
+    Optional<Types.NestedField> icebergSchema = OrcToIcebergVisitor.visit(schema, schemaConverter);
+    schemaConverter.afterField("field" + typeIndex, schema);
+    options.add(visit(icebergSchema.get().type(), schema, visitor));
   }
 
   public T record(Types.StructType iStruct, TypeDescription record, List<String> names, List<T> fields) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -86,14 +86,14 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
   }
 
   /*
-  A complex union with multiple types of Avro schema is converted into a struct with multiple fields of Iceberg schema.
+  A complex union with multiple types of Orc schema is converted into a struct with multiple fields of Iceberg schema.
   Also an extra tag field is added into the struct of Iceberg schema during the conversion.
-  Given an example of complex union in both Avro and Iceberg:
-  Avro schema: {"name":"unionCol","type":["int","string"]}
+  Given an example of complex union in both Orc and Iceberg:
+  Orc schema: {"name":"unionCol","type":["int","string"]}
   Iceberg schema:  struct<0: tag: required int, 1: field0: optional int, 2: field1: optional string>
   The fields in the struct of Iceberg schema are expected to be stored in the same order
-  as the corresponding types in the union of Avro schema.
-  Except the tag field, the fields in the struct of Iceberg schema are the same as the types in the union of Avro schema
+  as the corresponding types in the union of Orc schema.
+  Except the tag field, the fields in the struct of Iceberg schema are the same as the types in the union of Orc schema
   in the general case. In case of field projection, the fields in the struct of Iceberg schema only contains
   the fields to be projected which equals to a subset of the types in the union of ORC schema.
   Therefore, this function visits the complex union with the consideration of both cases.

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
 
     @Override
     public OrcValueReader<?> union(Type expected, TypeDescription union, List<OrcValueReader<?>> options) {
-      return SparkOrcValueReaders.union(options);
+      return SparkOrcValueReaders.union(options, expected);
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -20,12 +20,15 @@
 package org.apache.iceberg.spark.data;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
@@ -71,8 +74,8 @@ public class SparkOrcValueReaders {
     return new StructReader(readers, struct, idToConstant);
   }
 
-  static OrcValueReader<?> union(List<OrcValueReader<?>> readers) {
-    return new UnionReader(readers);
+  static OrcValueReader<?> union(List<OrcValueReader<?>> readers, Type expected) {
+    return new UnionReader(readers, expected);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -166,11 +169,38 @@ public class SparkOrcValueReaders {
 
   static class UnionReader implements OrcValueReader<Object> {
     private final OrcValueReader[] readers;
+    private final Type expected;
+    private int[] projectedFieldIdsToIdxInReturnedRow;
+    private boolean isTagFieldProjected;
+    private int numOfFieldsInReturnedRow;
 
-    private UnionReader(List<OrcValueReader<?>> readers) {
+    private UnionReader(List<OrcValueReader<?>> readers, Type expected) {
       this.readers = new OrcValueReader[readers.size()];
       for (int i = 0; i < this.readers.length; i += 1) {
         this.readers[i] = readers.get(i);
+      }
+      this.expected = expected;
+
+      if (this.readers.length > 1) {
+        // Creating an integer array to track the mapping between the index of fields to be projected
+        // and the index of the value for the field stored in the returned row,
+        // if the value for a field equals to -1, it means the value of this field should not be stored
+        // in the returned row
+        this.projectedFieldIdsToIdxInReturnedRow = new int[readers.size()];
+        Arrays.fill(this.projectedFieldIdsToIdxInReturnedRow, -1);
+        this.numOfFieldsInReturnedRow = 0;
+        this.isTagFieldProjected = false;
+
+        for (Types.NestedField expectedStructField : expected.asStructType().fields()) {
+          String fieldName = expectedStructField.name();
+          if (fieldName.equals(ORCSchemaUtil.ICEBERG_UNION_TAG_FIELD_NAME)) {
+            this.isTagFieldProjected = true;
+            this.numOfFieldsInReturnedRow++;
+            continue;
+          }
+          int projectedFieldIndex = Integer.valueOf(fieldName.substring(5));
+          this.projectedFieldIdsToIdxInReturnedRow[projectedFieldIndex] = this.numOfFieldsInReturnedRow++;
+        }
       }
     }
 
@@ -183,12 +213,17 @@ public class SparkOrcValueReaders {
       if (readers.length == 1) {
         return value;
       } else {
-        InternalRow struct = new GenericInternalRow(readers.length + 1);
-        for (int i = 0; i < readers.length; i += 1) {
-          struct.setNullAt(i + 1);
+        InternalRow struct = new GenericInternalRow(numOfFieldsInReturnedRow);
+        for (int i = 0; i < struct.numFields(); i += 1) {
+          struct.setNullAt(i);
         }
-        struct.update(0, fieldIndex);
-        struct.update(fieldIndex + 1, value);
+        if (this.isTagFieldProjected) {
+          struct.update(0, fieldIndex);
+        }
+
+        if (this.projectedFieldIdsToIdxInReturnedRow[fieldIndex] != -1) {
+          struct.update(this.projectedFieldIdsToIdxInReturnedRow[fieldIndex], value);
+        }
 
         return struct;
       }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcUnions.java
@@ -144,6 +144,82 @@ public class TestSparkOrcUnions {
   }
 
   @Test
+  public void testComplexUnionWithColumnProjection() throws IOException {
+    TypeDescription orcSchema =
+            TypeDescription.fromString("struct<unionCol:uniontype<int,string>>");
+
+    Schema expectedSchema = new Schema(
+            Types.NestedField.optional(0, "unionCol", Types.StructType.of(
+                    Types.NestedField.optional(1, "field0", Types.IntegerType.get())))
+    );
+
+    final InternalRow expectedFirstRow = new GenericInternalRow(1);
+    final InternalRow field1 = new GenericInternalRow(1);
+    field1.update(0, 0);
+    expectedFirstRow.update(0, field1);
+
+    final InternalRow expectedSecondRow = new GenericInternalRow(1);
+    final InternalRow field2 = new GenericInternalRow(1);
+    field2.update(0, null);
+    expectedSecondRow.update(0, field2);
+
+    Configuration conf = new Configuration();
+
+    File orcFile = temp.newFile();
+    Path orcFilePath = new Path(orcFile.getPath());
+
+    Writer writer = OrcFile.createWriter(orcFilePath,
+            OrcFile.writerOptions(conf)
+                    .setSchema(orcSchema).overwrite(true));
+
+    VectorizedRowBatch batch = orcSchema.createRowBatch();
+    LongColumnVector longColumnVector = new LongColumnVector(NUM_OF_ROWS);
+    BytesColumnVector bytesColumnVector = new BytesColumnVector(NUM_OF_ROWS);
+    UnionColumnVector complexUnion = new UnionColumnVector(NUM_OF_ROWS, longColumnVector, bytesColumnVector);
+
+    complexUnion.init();
+
+    for (int i = 0; i < NUM_OF_ROWS; i += 1) {
+      complexUnion.tags[i] = i % 2;
+      longColumnVector.vector[i] = i;
+      String stringValue = "foo-" + i;
+      bytesColumnVector.setVal(i, stringValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    batch.size = NUM_OF_ROWS;
+    batch.cols[0] = complexUnion;
+
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    // Test non-vectorized reader
+    List<InternalRow> actualRows = Lists.newArrayList();
+    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(orcFile))
+            .project(expectedSchema)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(expectedSchema, readOrcSchema))
+            .build()) {
+      reader.forEach(actualRows::add);
+
+      Assert.assertEquals(actualRows.size(), NUM_OF_ROWS);
+      assertEquals(expectedSchema, expectedFirstRow, actualRows.get(0));
+      assertEquals(expectedSchema, expectedSecondRow, actualRows.get(1));
+    }
+
+    // Test vectorized reader
+    try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+            .project(expectedSchema)
+            .createBatchedReaderFunc(readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(expectedSchema, readOrcSchema, ImmutableMap.of()))
+            .build()) {
+      final Iterator<InternalRow> actualRowsIt = batchesToRows(reader.iterator());
+
+      assertEquals(expectedSchema, expectedFirstRow, actualRowsIt.next());
+      assertEquals(expectedSchema, expectedSecondRow, actualRowsIt.next());
+    }
+  }
+
+  @Test
   public void testDeeplyNestedUnion() throws IOException {
     TypeDescription orcSchema =
         TypeDescription.fromString("struct<c1:uniontype<int,struct<c2:string,c3:uniontype<int,string>>>>");


### PR DESCRIPTION
**Problem**
Currently the query on the whole column of complex union type works in case that the data are stored in ORC file, (e.g. the query like `select c1 from tbl` where c1 is a type of complex union, however, field filtering on the column of complex union in the query does not work (e.g the query like `select c1.field0 from tbl` where field0 is one type in the complex union). The root cause of the problem is as follows:
Two types of schema are used in Iceberg to read the data from ORC file per the columns defined in the user query: one is table schema from table metastore and used by the user query which is defined in Iceberg format, namely Iceberg schema; the other is file schema which is defined in ORC file and data are stored complying with this schema, namely ORC schema.  As Iceberg does not support union type natively, complex union is defined as a struct type in Iceberg schema. The current code assumes that the types inside a union from ORC schema should match the type fields inside a union struct from Iceberg schema when ORC union reader is created.
In case of field filtering of union type, the current code only prune the schema of union in Iceberg schema with the projected fields, while the union of ORC schema still contains all the types. It results in the mismatch between ORC schema and Iceberg schema for the union in this case.
However, as all the contents of each data type in a union in Orc file should be read by Orc readers correctly no matter this data type is projected or not based on the decoding procedure of Orc file, all the types in a union from Orc schema are needed to create the corresponding type readers in `OrcUnionReader` even in case of column projection. Therefore the union in Orc schema cannot be pruned like what is done to the union struct in Iceberg schema.

**Solution**
Assuming there are N types in a union, there are N+1 fields including "tag" field in the struct corresponding to the union in Iceberg schema. The user can project any K fields (K>=1 and K<=N+1 and including the tag field) of the union in a query. The case of without column projection equals to full fields projection namely K=N+1. Therefore the solution does not differentiate the cases of with and without column projections.
In addition, the order of the types in a union in Iceberg schema can be identified from its field name like "field0".."fieldK". K is the index which can be used to match the order of the types in the union of Orc schema.

In the code of create the readers of all types in the union of Orc schema (namely `OrcSchemaWithTypeVisitor.visitUnion`), checking the fields of the struct corresponding union in Iceberg schema to create a map between the order index and the field type in Iceberg schema. When iterating through all the types in Orc schema, using the order index to check if the corresponding type exists in the map, if yes which means the field is projected, creating the option of creating the reader with the type in Iceberg schema, otherwise, creating the option with a pseudo Iceberg type converted from Orc schema.

In the code of `OrcUnionReader`, Iceberg schema needs to be passed into it. The fields of the returned row should be constructed based on the fields in Iceberg schema not the types in Orc schema. If tag field is projected, one more field is added in the beginning of the row and updated with the index of the field in Orc file.

**Test**
All the test cases in `TestSparkOrcUnions.java` with a new test case `testComplexUnionWithColumnProjection`

Manual test with Spark3 with all the following queries on a table with a union:

```
val df = spark.sql("select c1.field0 from u_yiqding.orc_union_table_test")

val df = spark.sql("select c1.field0,c1.field1 from u_yiqding.orc_union_table_test")

val df = spark.sql("select c1.tag,c1.field0 from u_yiqding.orc_union_table_test")

val df = spark.sql("select c1.tag,c1.field0,c1.field1 from u_yiqding.orc_union_table_test")

val df = spark.sql("select c1.field1,c1.field0,c1.tag from u_yiqding.orc_union_table_test")

val df = spark.sql("select c1.field1,c1.field0 from u_yiqding.orc_union_table_test")
```

The schema of the table `u_yiqding.orc_union_table_test` is as follows:
```
# col_name            	data_type           	comment

c1                  	uniontype<int,string>
```