### PR TITLE
Fix NPE excpetion when reading dataset with nested array

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -303,7 +303,7 @@ public class SchemaParser {
 
   private static String defaultValueToJsonString(Object value) {
     try {
-      return JsonUtil.mapper().writeValueAsString(value);
+      return JsonUtil.mapper().writeValueAsString(AvroSchemaUtil.convertToJavaDefaultValue(value));
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.avro;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +105,8 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       String fieldName =  isValidFieldName ? origFieldName : AvroSchemaUtil.sanitize(origFieldName);
       Object defaultValue = structField.hasDefaultValue() ? structField.getDefaultValue() :
           (structField.isOptional() ? JsonProperties.NULL_VALUE : null);
-      Schema.Field field = new Schema.Field(fieldName, fieldSchemas.get(i), structField.doc(), defaultValue);
+      Schema.Field field = new Schema.Field(fieldName, fieldSchemas.get(i), structField.doc(),
+          convertToJsonNull(defaultValue));
       if (!isValidFieldName) {
         field.addProp(AvroSchemaUtil.ICEBERG_FIELD_NAME_PROP, origFieldName);
       }
@@ -231,5 +234,33 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
     results.put(primitive, primitiveSchema);
 
     return primitiveSchema;
+  }
+
+  // This function ensures that all nested null are converted to JsonProperties.NULL_VALUE
+  // to make sure JacksonUtils.toJsonNode() converts them properly.
+  private Object convertToJsonNull(Object defaultValue) {
+    if (defaultValue instanceof Map) {
+      for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) defaultValue).entrySet()) {
+        if (entry.getValue() instanceof Map || entry.getValue() instanceof Collection) {
+          entry.setValue(convertToJsonNull(entry.getValue()));
+        } else {
+          entry.setValue(JsonProperties.NULL_VALUE);
+        }
+      }
+      return defaultValue;
+    } else if (defaultValue instanceof List) {
+      List<Object> originalList = (List<Object>) defaultValue;
+      List<Object> copiedList = new ArrayList<>();
+
+      for (Object element : originalList) {
+        if (element instanceof Map || element instanceof Collection) {
+          copiedList.add(convertToJsonNull(element));
+        } else {
+          copiedList.add(JsonProperties.NULL_VALUE);
+        }
+      }
+      return copiedList;
+    }
+    return defaultValue;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -584,4 +584,37 @@ public class TestSchemaConversions {
     String jSchema = SchemaParser.toJson(iSchema);
     org.apache.iceberg.Schema roundTripiSchema = SchemaParser.fromJson(jSchema);
   }
+  @Test
+  public void testConversionOfRecordWithNestedSubElementWithNotNullDefaultValue() {
+    String schemaString = "{\n" +
+        "  \"type\": \"record\",\n" +
+        "  \"name\": \"OuterRecord\",\n" +
+        "  \"fields\": [\n" +
+        "    {\n" +
+        "      \"name\": \"nestedRecord\",\n" +
+        "      \"type\": {\n" +
+        "        \"type\": \"record\",\n" +
+        "        \"name\": \"InnerRecord\",\n" +
+        "        \"fields\": [\n" +
+        "          {\n" +
+        "            \"name\": \"myArray\",\n" +
+        "            \"type\": {\n" +
+        "              \"type\": \"array\",\n" +
+        "              \"items\": \"int\"\n" +
+        "            },\n" +
+        "            \"default\": [1, 2, 3]\n" +
+        "          }\n" +
+        "        ],\n" +
+        "        \"default\": {\"myArray\": [1, 2, 3]}\n" +
+        "      },\n" +
+        "      \"default\": {\"myArray\": [1, 2, 3]}\n" +
+        "    }\n" +
+        "  ],\n" +
+        "  \"default\": {\"nestedRecord\": {\"myArray\": [1, 2, 3]}}\n" +
+        "}";
+    Schema schema = new Schema.Parser().parse(schemaString);
+    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(schema);
+    String jSchema = SchemaParser.toJson(iSchema);
+    org.apache.iceberg.Schema roundTripiSchema = SchemaParser.fromJson(jSchema);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -516,4 +516,72 @@ public class TestSchemaConversions {
     Assert.assertTrue(IntStream.range(0, roundTripiSchema.columns().size())
         .allMatch(i -> roundTripiSchema.columns().get(i).equals(iSchema.columns().get(i))));
   }
+
+  @Test
+  public void testConversionOfRecordWithNestedSubElement() {
+    String schemaString = "{\n" +
+        "    \"type\": \"record\",\n" +
+        "    \"name\": \"Root\",\n" +
+        "    \"fields\": [\n" +
+        "        {\n" +
+        "            \"name\": \"OuterRecord1\",\n" +
+        "            \"type\": [\n" +
+        "                \"null\",\n" +
+        "                {\n" +
+        "                    \"type\": \"record\",\n" +
+        "                    \"name\": \"InnerElement\",\n" +
+        "                    \"fields\": [\n" +
+        "                        {\n" +
+        "                            \"name\": \"InnerField\",\n" +
+        "                            \"type\": {\n" +
+        "                                \"type\": \"record\",\n" +
+        "                                \"name\": \"InnerField1\",\n" +
+        "                                \"fields\": [\n" +
+        "                                    {\n" +
+        "                                        \"name\": \"InnerField1Param\",\n" +
+        "                                        \"type\": [\n" +
+        "                                            \"null\",\n" +
+        "                                            \"string\"\n" +
+        "                                        ],\n" +
+        "                                        \"default\": null\n" +
+        "                                    }\n" +
+        "                                ]\n" +
+        "                            },\n" +
+        "                            \"default\": {\n" +
+        "                                \"InnerField1Param\": null\n" +
+        "                            }\n" +
+        "                        }\n" +
+        "                    ]\n" +
+        "                }\n" +
+        "            ],\n" +
+        "            \"default\": null\n" +
+        "        },\n" +
+        "        {\n" +
+        "            \"name\": \"InnerElementV2\",\n" +
+        "            \"type\": [\n" +
+        "                \"null\",\n" +
+        "                {\n" +
+        "                    \"type\": \"record\",\n" +
+        "                    \"name\": \"InnerElementV2\",\n" +
+        "                    \"fields\": [\n" +
+        "                        {\n" +
+        "                            \"name\": \"InnerField2\",\n" +
+        "                            \"type\": {\n" +
+        "                                \"type\": \"array\",\n" +
+        "                                \"items\": \"InnerElement\"\n" +
+        "                            },\n" +
+        "                            \"default\": []\n" +
+        "                        }\n" +
+        "                    ]\n" +
+        "                }\n" +
+        "            ],\n" +
+        "            \"default\": null\n" +
+        "        }\n" +
+        "    ]\n" +
+        "}";
+    Schema schema = new Schema.Parser().parse(schemaString);
+    org.apache.iceberg.Schema iSchema = AvroSchemaUtil.toIceberg(schema);
+    String jSchema = SchemaParser.toJson(iSchema);
+    org.apache.iceberg.Schema roundTripiSchema = SchemaParser.fromJson(jSchema);
+  }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReaderForFieldsWithDefaultValue.java
@@ -203,7 +203,7 @@ public class TestSparkAvroReaderForFieldsWithDefaultValue {
    * Test nested array with default null on complex types
    * if the table contains non-primitive Avro types (InnerElement in the test below)
    * as the first field and arrays of InnerElement as the second field,
-   * it leads to a NullPointerException when operating on the table.
+   * it previously leads to a NullPointerException when operating on the table.
    */
   @Test
   public void testNestedArrayWithDefaultNullOnComplexTypes() throws IOException {
@@ -270,15 +270,18 @@ public class TestSparkAvroReaderForFieldsWithDefaultValue {
         "}";
     org.apache.avro.Schema writeSchema = new org.apache.avro.Schema.Parser().parse(writeSchemaString);
     org.apache.iceberg.Schema icebergWriteSchema = AvroSchemaUtil.toIceberg(writeSchema);
-    Assert.assertThrows(
-        NullPointerException.class, () ->  RandomData.generateList(icebergWriteSchema, 2, 0L));
+
+    List<GenericData.Record> expected = RandomData.generateList(icebergWriteSchema, 2, 0L);
+
+
+    Assert.assertTrue("Delete should succeed", testFile.delete());
   }
 
 
   /*
    * Test nested array with default null on complex types.
    * This test differs from testNestedArrayWithDefaultNullOnComplexTypes on the type
-   * of InnerField1Param, when it is a primitive type, no NPE is thrown when operating on the table.
+   * of InnerField1Param, it is a primitive type in this test.
    */
   @Test
   public void testNestedArrayWithDefaultNullOnPrimitiveTypes() throws IOException {
@@ -344,16 +347,6 @@ public class TestSparkAvroReaderForFieldsWithDefaultValue {
 
 
     Assert.assertTrue("Delete should succeed", testFile.delete());
-
-    // write records with initial writeSchema
-    try (FileAppender<GenericData.Record> writer = Avro.write(Files.localOutput(testFile))
-        .schema(icebergWriteSchema)
-        .named("test")
-        .build()) {
-      for (GenericData.Record rec : expected) {
-        writer.add(rec);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Context:
We have identified a issue when reading the schema of Iceberg tables. Specifically, if the table contains non-primitive Avro types (referred to as `TypeA`) as the first field and arrays of `TypeA` as the second field, it leads to a NullPointerException during loading the table schema.

## Root Cause
The root cause lies in the absence of handling default null values within nested objects when two fields inside a record is cross referenced, it is causing a failure in the condition check in Jackson codebases below:

```java
if (datum == JsonProperties.NULL_VALUE) {
    generator.writeNull();
}
```
When datum is Java `null`, this predicate will miss and resulting in unidentified types when Jackson is parsing the schema.

Below is the detailed stacktracestacktrace of the issue
```
java.lang.NullPointerException
	at org.apache.avro.util.internal.JacksonUtils.toJson(JacksonUtils.java:96)
	at org.apache.avro.util.internal.JacksonUtils.toJson(JacksonUtils.java:68)
	at org.apache.avro.util.internal.JacksonUtils.toJsonNode(JacksonUtils.java:53)
	at org.apache.avro.Schema$Field.<init>(Schema.java:586)
	at org.apache.iceberg.avro.TypeToSchema.struct(TypeToSchema.java:108)
	at org.apache.iceberg.avro.TypeToSchema.struct(TypeToSchema.java:36)
	at org.apache.iceberg.types.TypeUtil.visit(TypeUtil.java:349)
	at org.apache.iceberg.types.TypeUtil.visit(TypeUtil.java:358)
```

## Resolution
This pull request addresses the issue by ensuring that default null values in nested objects are converted to `JsonProperties.NULL_VALUE` when iceberg is reading the schema object, and convert the  `JsonProperties.NULL_VALUE`  to java default null when serializing the schema object. This prevents the NPE and subsequent failures during reading and writing the table.

Below is the pseudo-code of the implementation of the fucntion.

```java
Object convertToJsonNull(defaultValue):
    if defaultValue is a Map:
        for each entry in defaultValue:
            if entry value is a Map or Collection:
                entry value = convertToJsonNull(entry value)
            else:
                entry value = JsonProperties.NULL_VALUE
        return defaultValue

    else if defaultValue is a List:
        originalList = copy of defaultValue
        copiedList = new ArrayList
        for each element in originalList:
            if element is a Map or Collection:
                copiedList.add(convertToJsonNull(element))
            else:
                copiedList.add(JsonProperties.NULL_VALUE)
        return copiedList

    else:
        return defaultValue
```


## Test
1. All unit test passed
2. Created a unit that reproduces the original issue and it was fixed with the newly introduced function.