### PR TITLE
Add single union schema conversion logic for hive to iceberg

### DIFF
--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveTypeToIcebergType.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveTypeToIcebergType.java
@@ -58,6 +58,11 @@ public class HiveTypeToIcebergType extends HiveTypeUtil.HiveSchemaVisitor<Type> 
   // Mimic the struct call behavior to construct a union converted struct type
   @Override
   public Type union(UnionTypeInfo union, List<Type> unionResults) {
+    // if the union is single-typed, return the type directly
+    if (union.getAllUnionObjectTypeInfos().size() == 1) {
+      return unionResults.get(0);
+    }
+    // else, it's a complex union
     List<Types.NestedField> fields = Lists.newArrayListWithExpectedSize(unionResults.size() + 1);
     fields.add(Types.NestedField.required(allocateId(), "tag", Types.IntegerType.get()));
     for (int i = 0; i < unionResults.size(); i++) {

--- a/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveSchemaConversions.java
+++ b/hivelink-core/src/test/java/org/apache/iceberg/hivelink/core/TestHiveSchemaConversions.java
@@ -82,6 +82,8 @@ public class TestHiveSchemaConversions {
               "length:int,count:int,list:array<struct<lastword:string,lastwordlength:int>>," +
               "wordcounts:map<string,int>>");
     check("struct<1: tag: required int, 2: field0: optional int, 3: field1: optional string>", "uniontype<int,string>");
+    // single type union
+    check("int", "uniontype<int>");
   }
 
   private static void check(String icebergTypeStr, String hiveTypeStr) {


### PR DESCRIPTION
This patch adds the parity conversion logic that already exists in avro/orc -> iceberg schema conversion where it treats the single type union as the unwrapped single type itself, instead of returning a struct of tag and field0.