### PR TITLE
[LI] Make MergeHiveSchemaWithAvro not reordering avro optional union …

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -192,6 +192,18 @@ public class AvroSchemaUtil {
     return false;
   }
 
+  public static int getNullIndexInUnion(Schema schema) {
+    Preconditions.checkArgument(schema.getType() == UNION,
+        "Expected union schema but was passed: %s", schema);
+    for (int i = 0; i < schema.getTypes().size(); i++) {
+      if (schema.getTypes().get(i).getType() == Schema.Type.NULL) {
+        return i;
+      }
+    }
+    // which means null is not present in the union
+    return -1;
+  }
+
   public static Schema toOption(Schema schema) {
     return toOption(schema, false);
   }

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -147,8 +147,10 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
         shouldResultBeOptional && AvroSchemaUtil.getNullIndexInUnion(partner) == 1;
     Schema hivePrimitive = hivePrimitiveToAvro(primitive);
     // if there was no matching Avro primitive, use the Hive primitive
-    Schema result = partner == null ? hivePrimitive : checkCompatibilityAndPromote(hivePrimitive, partner);
-    return shouldResultBeOptional ? AvroSchemaUtil.toOption(result, nullShouldBeSecondElementInOptionalUnionSchema) : result;
+    Schema result =
+        partner == null ? hivePrimitive : checkCompatibilityAndPromote(hivePrimitive, partner);
+    return shouldResultBeOptional ? AvroSchemaUtil.toOption(result,
+        nullShouldBeSecondElementInOptionalUnionSchema) : result;
   }
 
   private Schema checkCompatibilityAndPromote(Schema schema, Schema partner) {

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -143,10 +143,12 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
   @Override
   public Schema primitive(PrimitiveTypeInfo primitive, Schema partner) {
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
+    boolean nullShouldBeSecondElementInOptionalUnionSchema =
+        shouldResultBeOptional && AvroSchemaUtil.getNullIndexInUnion(partner) == 1;
     Schema hivePrimitive = hivePrimitiveToAvro(primitive);
     // if there was no matching Avro primitive, use the Hive primitive
     Schema result = partner == null ? hivePrimitive : checkCompatibilityAndPromote(hivePrimitive, partner);
-    return shouldResultBeOptional ? AvroSchemaUtil.toOption(result) : result;
+    return shouldResultBeOptional ? AvroSchemaUtil.toOption(result, nullShouldBeSecondElementInOptionalUnionSchema) : result;
   }
 
   private Schema checkCompatibilityAndPromote(Schema schema, Schema partner) {

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/schema/MergeHiveSchemaWithAvro.java
@@ -101,6 +101,8 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
       boolean isNullFirstOption = schema.getTypes().get(0).getType() == Schema.Type.NULL;
       if (isNullFirstOption && defaultValue.equals(JsonProperties.NULL_VALUE)) {
         return schema;
+      } else if (!isNullFirstOption && !defaultValue.equals(JsonProperties.NULL_VALUE)) {
+        return schema;
       } else {
         return Schema.createUnion(schema.getTypes().get(1), schema.getTypes().get(0));
       }
@@ -143,7 +145,7 @@ public class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema
   @Override
   public Schema primitive(PrimitiveTypeInfo primitive, Schema partner) {
     boolean shouldResultBeOptional = partner == null || AvroSchemaUtil.isOptionSchema(partner);
-    boolean nullShouldBeSecondElementInOptionalUnionSchema =
+    boolean nullShouldBeSecondElementInOptionalUnionSchema = partner != null &&
         shouldResultBeOptional && AvroSchemaUtil.getNullIndexInUnion(partner) == 1;
     Schema hivePrimitive = hivePrimitiveToAvro(primitive);
     // if there was no matching Avro primitive, use the Hive primitive


### PR DESCRIPTION
…field when it's it's merging a hive primitive with an avro optional union

This patch fixes a issue when a table's avro schema exhibit this pattern: it has a record field which has a inner optional field with null as the second element, and it has a default value at the record level with a key-value pair for that inner optional field, then the current `MergeHiveSchemaWithAvro` will reorder the null to be the first element of the optional field schema, making the record-level default validation fail. This patch will retain the positional of the `null` element in the avro optional field its original position, thus fixing the bug.