### PR TITLE
[LI] Fix SPARK ORC projection read for deeply nested union schema and…

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.orc.TypeDescription;
 
 public abstract class OrcSchemaWithTypeVisitor<T> {
-  private static final String PSEUDO_ICEBERG_FIELD_ID = "-1";
 
   public static <T> T visit(
       org.apache.iceberg.Schema iSchema, TypeDescription schema, OrcSchemaWithTypeVisitor<T> visitor) {
@@ -101,7 +100,8 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
   in the general case. In case of field projection, the fields in the struct of Iceberg schema only contains
   a subset of the types in the union of ORC schema, but all the readers for the union branch types must be constructed,
   it's up to the reader code logic to determine to return what value for the given projection schema.
-  Therefore, this function visits the complex union with the consideration of either whole projection or partially projected schema.
+  Therefore, this function visits the complex union with the consideration of either whole projection
+  or partially projected schema.
   Noted that null value and default value for complex union is not a consideration in case of ORC
    */
   private <T> void visitComplexUnion(Type type, TypeDescription union, OrcSchemaWithTypeVisitor<T> visitor,
@@ -124,8 +124,9 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
       if (idxInOrcUnionToIdxInType.containsKey(i)) {
         options.add(visit(structType.fields().get(idxInOrcUnionToIdxInType.get(i)).type(), unionTypes.get(i), visitor));
       } else {
-        // even if the type is not projected in the iceberg schema, a reader for the underlying orc type branch still needs to be created,
-        // we use a OrcToIcebergVisitorWithPseudoId to re-construct the iceberg type from the orc union branch type and add it to the options,
+        // even if the type is not projected in the iceberg schema, a reader for the underlying orc type branch
+        // still needs to be created, we use a OrcToIcebergVisitorWithPseudoId to re-construct the iceberg type
+        // from the orc union branch type and add it to the options,
         // with a pseudo iceberg-id "-1" to avoid failures with the remaining iceberg code infra
         visitNotProjectedTypeInComplexUnion(unionTypes.get(i), visitor, options, i);
       }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitorWithPseudoId.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitorWithPseudoId.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.orc.TypeDescription;
+
+public class OrcToIcebergVisitorWithPseudoId extends OrcToIcebergVisitor {
+
+  private static final String PSEUDO_ICEBERG_FIELD_ID = "-1";
+
+  @Override
+  public Optional<NestedField> union(TypeDescription union, List<Optional<NestedField>> options) {
+    union.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, PSEUDO_ICEBERG_FIELD_ID);
+    List<Optional<NestedField>> optionsCopy = new ArrayList<>(options);
+    optionsCopy.add(0, Optional.of(
+        Types.NestedField.of(Integer.parseInt(PSEUDO_ICEBERG_FIELD_ID), true,
+            ORCSchemaUtil.ICEBERG_UNION_TAG_FIELD_NAME, Types.IntegerType.get())));
+    return Optional.of(
+        Types.NestedField.of(Integer.parseInt(PSEUDO_ICEBERG_FIELD_ID), true, currentFieldName(), Types.StructType.of(
+            optionsCopy.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList()))));
+  }
+
+  @Override
+  public Optional<NestedField> record(TypeDescription record, List<String> names,
+      List<Optional<NestedField>> fields) {
+    record.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, PSEUDO_ICEBERG_FIELD_ID);
+    return super.record(record, names, fields);
+  }
+
+  @Override
+  public Optional<NestedField> list(TypeDescription array, Optional<NestedField> element) {
+    array.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, PSEUDO_ICEBERG_FIELD_ID);
+    return super.list(array, element);
+  }
+
+  @Override
+  public Optional<NestedField> map(TypeDescription map, Optional<NestedField> key,
+      Optional<NestedField> value) {
+    map.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, PSEUDO_ICEBERG_FIELD_ID);
+    return super.map(map, key, value);
+  }
+
+  @Override
+  public Optional<NestedField> primitive(TypeDescription primitive) {
+    primitive.setAttribute(org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, PSEUDO_ICEBERG_FIELD_ID);
+    return super.primitive(primitive);
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -173,10 +173,7 @@ public class SparkOrcValueReaders {
     private Map<Integer, Integer> idxInExpectedSchemaToIdxInReaders;
 
     private UnionReader(List<OrcValueReader<?>> readers, Type expected) {
-      this.readers = new OrcValueReader[readers.size()];
-      for (int i = 0; i < this.readers.length; i += 1) {
-        this.readers[i] = readers.get(i);
-      }
+      this.readers = readers.toArray(new OrcValueReader[readers.size()]);
       this.expectedType = expected;
 
       if (this.readers.length > 1) {


### PR DESCRIPTION
… out-of-order projection fields

This patch fixes multiple issues currently in the Spark ORC union type projection read code #150 

### Issue 1:
Given an ORC schema of `struct<unionCol:uniontype<int,string>>`, the converted iceberg schema is to be `struct<0: tag: required int, 1: field0: optional int, 2: field1: optional string>` (field id not important here).
So, for a fully-supported projection feature, user should be arbitrarily permutate and partially project a subset of the [tag, field0, field1].
e.g. users can project:

- [tag, field0, field1] fully projected, original/in-order schema
- [tag] single field
- [tag, field0] 2 fields
- [field1, field0] 2 fields, but out of order
- [field0, field1, tag] full projection, but out of order/fields-permutation

The current code exhibits multiple bugs when projecting a subset fields (e.g. projecting field0 works but field1 fails), projecting out-of-order fields (e.g. [field1, field0]).

### Issue 2:
Given a deeply nested ORC schema with at least 2 levels of `uniontype`, e.g. `struct<c1:uniontype<int,struct<c2:string,c3:uniontype<int,string>>>>` the current code completely fails with NPE.

We should expect the user to do full/partial/out-of-order projections on 2/arbitrary levels of unions without any issue.

### Solution
This PR holistically fixes the above 2 issues by changing the `OrcSchemaWithTypeVisitor` and `SparkOrcValueReaders`, to make the first one always return a fully projected reader options to the reader code, so that the reader can determine from the expected schema, which specific reader's value to return (by juding the `tag` value), the `OrcSchemaWithTypeVisitor` implements its magic via a new visitor `OrcToIcebergVisitorWithPseudoId`, which can convert a orc schema with uniontype to iceberg, without preexisting `iceberg-id` metadata in the orc schema.

