### PR TITLE
Add logging for HiveMetadataPreservingTableOperations

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -278,7 +278,7 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
           e);
     } catch (DynamoDbException e) {
       LOG.error(
-          "Failed to release lock {} by for entity: {}, owner: {}, encountered unexpected DynamoDB exception",
+          "Failed to release lock for entity: {}, owner: {}, encountered unexpected DynamoDB exception",
           entityId,
           ownerId,
           e);

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
   }
   dependencies {
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
-    classpath 'com.palantir.baseline:gradle-baseline-java:4.0.0'
+    classpath 'com.palantir.baseline:gradle-baseline-java:4.40.0'
     classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.8.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'

--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -55,6 +55,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 // inspired in part by
 // https://github.com/apache/avro/blob/release-1.8.2/lang/java/guava/src/main/java/org/apache/avro/GuavaClasses.java
+@SuppressWarnings("ReturnValueIgnored")
 public class GuavaClasses {
 
   /*

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -162,7 +162,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
       return false;
     } catch (IOException e) {
       if (shouldSuppressPermissionError(e)) {
-        LOG.warn("Unable to list metadata directory {}: {}", metadataPath, e);
+        LOG.warn("Unable to list metadata directory {}", metadataPath, e);
         return false;
       } else {
         throw new UncheckedIOException(e);
@@ -177,7 +177,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
       return false;
     } catch (IOException e) {
       if (shouldSuppressPermissionError(e)) {
-        LOG.warn("Unable to list directory {}: {}", path, e);
+        LOG.warn("Unable to list directory {}", path, e);
         return false;
       } else {
         throw new UncheckedIOException(e);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
-import jline.internal.Log;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -569,12 +568,20 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             Lists.newArrayList(lockComponent),
             System.getProperty("user.name"),
             InetAddress.getLocalHost().getHostName());
-    LOG.warn("In thread {}, trying to call hmsclient.lock() on table {}", Thread.currentThread(), fullName);
+    LOG.warn(
+        "In thread {}, trying to call hmsclient.lock() on table {}",
+        Thread.currentThread(),
+        fullName);
     LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
-    LOG.warn("In thread {}, hmsclient.lock() finished on table {}", Thread.currentThread(), fullName);
+    LOG.warn(
+        "In thread {}, hmsclient.lock() finished on table {}", Thread.currentThread(), fullName);
     AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
     long lockId = lockResponse.getLockid();
-    LOG.warn("In thread {}, lockId returned from hmsclient.lock() on table {} is {}", Thread.currentThread(), fullName, lockId);
+    LOG.warn(
+        "In thread {}, lockId returned from hmsclient.lock() on table {} is {}",
+        Thread.currentThread(),
+        fullName,
+        lockId);
 
     final long start = System.currentTimeMillis();
     long duration = 0;
@@ -600,9 +607,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             .run(
                 id -> {
                   try {
-                    LOG.warn("In thread {}, trying to call hmsclient.checkLock() on table {}", Thread.currentThread(), fullName);
+                    LOG.warn(
+                        "In thread {}, trying to call hmsclient.checkLock() on table {}",
+                        Thread.currentThread(),
+                        fullName);
                     LockResponse response = metaClients.run(client -> client.checkLock(id));
-                    LOG.warn("In thread {}, hmsclient.checkLock() finished on table {}", Thread.currentThread(), fullName);
+                    LOG.warn(
+                        "In thread {}, hmsclient.checkLock() finished on table {}",
+                        Thread.currentThread(),
+                        fullName);
                     LockState newState = response.getState();
                     state.set(newState);
                     if (newState.equals(LockState.WAITING)) {
@@ -668,8 +681,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       } catch (Exception e) {
         LOG.warn("Failed to unlock {}.{}", database, tableName, e);
       }
-    }
-    else {
+    } else {
       LOG.warn("No lockId to unlock for {}.{}", database, tableName);
     }
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+import jline.internal.Log;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -568,9 +569,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             Lists.newArrayList(lockComponent),
             System.getProperty("user.name"),
             InetAddress.getLocalHost().getHostName());
+    LOG.warn("In thread {}, trying to call hmsclient.lock() on table {}", Thread.currentThread(), fullName);
     LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
+    LOG.warn("In thread {}, hmsclient.lock() finished on table {}", Thread.currentThread(), fullName);
     AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
     long lockId = lockResponse.getLockid();
+    LOG.warn("In thread {}, lockId returned from hmsclient.lock() on table {} is {}", Thread.currentThread(), fullName, lockId);
 
     final long start = System.currentTimeMillis();
     long duration = 0;
@@ -662,6 +666,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       } catch (Exception e) {
         LOG.warn("Failed to unlock {}.{}", database, tableName, e);
       }
+    }
+    else {
+      LOG.warn("No lockId to unlock for {}.{}", database, tableName);
     }
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -617,6 +617,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
                         Thread.currentThread(),
                         fullName);
                     LockState newState = response.getState();
+                    LOG.warn(
+                        "In thread {}, lock state returned from hmsclient.checkLock() on table {} is {}",
+                        Thread.currentThread(),
+                        fullName,
+                        newState);
                     state.set(newState);
                     if (newState.equals(LockState.WAITING)) {
                       throw new WaitingForLockException(

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -600,7 +600,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             .run(
                 id -> {
                   try {
+                    LOG.warn("In thread {}, trying to call hmsclient.checkLock() on table {}", Thread.currentThread(), fullName);
                     LockResponse response = metaClients.run(client -> client.checkLock(id));
+                    LOG.warn("In thread {}, hmsclient.checkLock() finished on table {}", Thread.currentThread(), fullName);
                     LockState newState = response.getState();
                     state.set(newState);
                     if (newState.equals(LockState.WAITING)) {

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingCatalog.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingCatalog.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
  */
 public class HiveMetadataPreservingCatalog extends HiveCatalog {
 
-  private static final String DEFAULT_NAME = "hive_meta_preserving";
+  private static final String DEFAULT_NAME = "hive_meta_preserving_catalog";
 
   public HiveMetadataPreservingCatalog() {}
 

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
@@ -195,7 +195,7 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
     ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
     tableLevelMutex.lock();
     try {
-      LOG.warn("In thread {}, starting to create a lock for table {}", Thread.currentThread(), fullName);
+      LOG.warn("In thread {}, starting to acquire a lock for table {}", Thread.currentThread(), fullName);
       lockId = Optional.of(acquireLock());
       LOG.warn("In thread {}, acquired lock id: {} for table {}", Thread.currentThread(), lockId.get(), fullName);
       // TODO add lock heart beating for cases where default lock timeout is too low.
@@ -209,9 +209,9 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       boolean tableExists = metaClients.run(client -> client.tableExists(database, tableName));
       LOG.warn("In thread {}, checking table exists finishes with result: {}", Thread.currentThread(), tableExists);
       if (tableExists) {
-        LOG.warn("In thread {}, starting to get table {} from HMS", Thread.currentThread(), fullName);
+        LOG.warn("In thread {}, starting to call getTable: {} from HMS", Thread.currentThread(), fullName);
         tbl = metaClients.run(client -> client.getTable(database, tableName));
-        LOG.warn("In thread {}, got table {} from HMS", Thread.currentThread(), fullName);
+        LOG.warn("In thread {}, getTable: {} from HMS finished", Thread.currentThread(), fullName);
         fixMismatchedSchema(tbl);
       } else {
         final long currentTimeMillis = System.currentTimeMillis();

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
@@ -195,9 +195,16 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
     ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
     tableLevelMutex.lock();
     try {
-      LOG.warn("In thread {}, starting to acquire a lock for table {}", Thread.currentThread(), fullName);
+      LOG.warn(
+          "In thread {}, starting to acquire a lock for table {}",
+          Thread.currentThread(),
+          fullName);
       lockId = Optional.of(acquireLock());
-      LOG.warn("In thread {}, acquired lock id: {} for table {}", Thread.currentThread(), lockId.get(), fullName);
+      LOG.warn(
+          "In thread {}, acquired lock id: {} for table {}",
+          Thread.currentThread(),
+          lockId.get(),
+          fullName);
       // TODO add lock heart beating for cases where default lock timeout is too low.
       Table tbl;
       // [LINKEDIN] Instead of checking if base != null to check for table existence, we query
@@ -207,9 +214,15 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       // definition and not create a new definition
       LOG.warn("In thread {}, checking if table exists {}", Thread.currentThread(), fullName);
       boolean tableExists = metaClients.run(client -> client.tableExists(database, tableName));
-      LOG.warn("In thread {}, checking table exists finishes with result: {}", Thread.currentThread(), tableExists);
+      LOG.warn(
+          "In thread {}, checking table exists finishes with result: {}",
+          Thread.currentThread(),
+          tableExists);
       if (tableExists) {
-        LOG.warn("In thread {}, starting to call getTable: {} from HMS", Thread.currentThread(), fullName);
+        LOG.warn(
+            "In thread {}, starting to call getTable: {} from HMS",
+            Thread.currentThread(),
+            fullName);
         tbl = metaClients.run(client -> client.getTable(database, tableName));
         LOG.warn("In thread {}, getTable: {} from HMS finished", Thread.currentThread(), fullName);
         fixMismatchedSchema(tbl);
@@ -288,9 +301,16 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       throw new RuntimeException("Interrupted during commit", e);
 
     } finally {
-      LOG.warn("In thread {}, trying to cleanupMetadataAndUnlock of lock id: {} for table: {}", Thread.currentThread(), lockId, fullName);
+      LOG.warn(
+          "In thread {}, trying to cleanupMetadataAndUnlock of lock id: {} for table: {}",
+          Thread.currentThread(),
+          lockId,
+          fullName);
       cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
-      LOG.warn("In thread {}, cleanupMetadataAndUnlock finishes for table: {}", Thread.currentThread(), fullName);
+      LOG.warn(
+          "In thread {}, cleanupMetadataAndUnlock finishes for table: {}",
+          Thread.currentThread(),
+          fullName);
     }
   }
 

--- a/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
+++ b/hivelink-core/src/main/java/org/apache/iceberg/hivelink/core/HiveMetadataPreservingTableOperations.java
@@ -195,7 +195,9 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
     ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
     tableLevelMutex.lock();
     try {
+      LOG.warn("In thread {}, starting to create a lock for table {}", Thread.currentThread(), fullName);
       lockId = Optional.of(acquireLock());
+      LOG.warn("In thread {}, acquired lock id: {} for table {}", Thread.currentThread(), lockId.get(), fullName);
       // TODO add lock heart beating for cases where default lock timeout is too low.
       Table tbl;
       // [LINKEDIN] Instead of checking if base != null to check for table existence, we query
@@ -203,9 +205,13 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       // base can be null if not Iceberg metadata exists, but Hive table exists, so we want to get
       // the current table
       // definition and not create a new definition
+      LOG.warn("In thread {}, checking if table exists {}", Thread.currentThread(), fullName);
       boolean tableExists = metaClients.run(client -> client.tableExists(database, tableName));
+      LOG.warn("In thread {}, checking table exists finishes with result: {}", Thread.currentThread(), tableExists);
       if (tableExists) {
+        LOG.warn("In thread {}, starting to get table {} from HMS", Thread.currentThread(), fullName);
         tbl = metaClients.run(client -> client.getTable(database, tableName));
+        LOG.warn("In thread {}, got table {} from HMS", Thread.currentThread(), fullName);
         fixMismatchedSchema(tbl);
       } else {
         final long currentTimeMillis = System.currentTimeMillis();
@@ -243,7 +249,9 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       updateMetadataLocationInHms(newMetadataLocation, tbl);
 
       try {
+        LOG.warn("In thread {}, starting to persist table {}", Thread.currentThread(), fullName);
         persistTable(tbl, tableExists);
+        LOG.warn("In thread {}, persisted table {}", Thread.currentThread(), fullName);
         commitStatus = CommitStatus.SUCCESS;
       } catch (Throwable persistFailure) {
         LOG.error(
@@ -280,7 +288,9 @@ public class HiveMetadataPreservingTableOperations extends HiveTableOperations {
       throw new RuntimeException("Interrupted during commit", e);
 
     } finally {
+      LOG.warn("In thread {}, trying to cleanupMetadataAndUnlock of lock id: {} for table: {}", Thread.currentThread(), lockId, fullName);
       cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
+      LOG.warn("In thread {}, cleanupMetadataAndUnlock finishes for table: {}", Thread.currentThread(), fullName);
     }
   }
 


### PR DESCRIPTION
This PR adds comprehensive logging to the `HiveMetadataPreservingTableOperations` so that we get the timestamps of all the critical HMS client calls at their starting and end time, so that it can help us reason about what are the sequence of calls the actual code runtime does when running in the gobblin job, and their respective time taken.

