### PR TITLE
Bump gradle jvm memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ systemProp.knownSparkVersions=2.4,3.0,3.1,3.2,3.3
 systemProp.defaultScalaVersion=2.12
 systemProp.knownScalaVersions=2.12,2.13
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx768m
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
In the previous build, we are seeing a bunch of `Expiring Daemon because JVM heap space is exhausted` error messages, this bump will fix them.