### PR TITLE
Back-port spark sql data-locality patch into 1.2.0 branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -884,7 +884,7 @@ String getProjectVersion() {
 
   try {
     String version = gitVersion()
-    Pattern pattern = Pattern.compile("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:\\..*)?")
+    Pattern pattern = Pattern.compile("([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:\\..*)?")
     Matcher matcher = pattern.matcher(version)
     if (matcher.matches()) {
       return matcher.group(1) + "." + matcher.group(2) + "." + matcher.group(3) + "."  + matcher.group(4)

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.Util;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 
 /**
@@ -63,7 +62,12 @@ public class SparkReadConf {
 
   public boolean localityEnabled() {
     boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.LOCALITY)
+        .sessionConf(SparkSQLProperties.LOCALITY)
+        .defaultValue(defaultValue)
+        .parse();
   }
 
   public Long snapshotId() {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -42,4 +42,7 @@ public class SparkSQLProperties {
   // Controls whether to check the order of fields during writes
   public static final String CHECK_ORDERING = "spark.sql.iceberg.check-ordering";
   public static final boolean CHECK_ORDERING_DEFAULT = true;
+
+  // Controls whether to report locality information to Spark while allocating input partitions
+  public static final String LOCALITY = "spark.sql.iceberg.locality.enabled";
 }


### PR DESCRIPTION
**Description**

Back-port spark sql locality configuration change from the 1.5.2 branch into 1.2.0 branch. This change is back-porting the PR from apache iceberg into spark-3.1 https://github.com/apache/iceberg/pull/9101/files 

**Testing**

./gradlew clean && ./gradlew build