### PR TITLE
Found unsupported Spark versions exception in the java-ci.

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -72,7 +72,7 @@ jobs:
         && github.ref == 'refs/heads/openhouse-1.5.2'
         && github.repository == 'linkedin/iceberg'
         && !contains(toJSON(github.event.commits.*.message), '[skip release]') }}
-      run: ./gradlew -DsparkVersions=3.5.2 githubRelease publishToSonatype closeAndReleaseStagingRepository -x test -x integrationTest
+      run: ./gradlew -DsparkVersions=3.5 githubRelease publishToSonatype closeAndReleaseStagingRepository -x test -x integrationTest
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         SONATYPE_USER: ${{secrets.SONATYPE_USERNAME}}


### PR DESCRIPTION
**Problem:**

Currently the java-ci build is failing with the following exception: 

```FAILURE: Build failed with an exception.

* Where:
Settings file '/home/runner/work/iceberg/iceberg/settings.gradle' line: 100

* What went wrong:
A problem occurred evaluating settings 'iceberg'.
> Found unsupported Spark versions: [3.5.2]
```

**Fix:**
This patch addresses this problem by updating the spark version to valid value in the gradle-build.