### PR TITLE
Fix release publishing process.

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-java@v4
       with:
         distribution: zulu


### PR DESCRIPTION
**Problem:** 

Publishing builds from the java-CI pipeline of openhouse-1.5.2 branch fails with the following exception: 

```
> Task :generateChangelog FAILED
Finding commits between master..HEAD in dir: /home/runner/work/iceberg/iceberg
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':generateChangelog'.
> Problems executing command (exit code: 128):
command: git log --pretty=format:%H@@info@@%ae@@info@@%an@@info@@%B%N@@commit@@ master..HEAD
working dir: /home/runner/work/iceberg/iceberg
output:
fatal: ambiguous argument 'master..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
* Get more help at https://help.gradle.org
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```

**Fix:** 
By default, actions/checkout fetches only the latest commit (fetch-depth: 1), so the runner lacks full branch history. When the :generateChangelog gradle task queries Git for commits between master and HEAD, it fails because master branch isn’t available in the clone. This patch sets fetch-depth: 0 to fetch the full history, allowing :generateChangelog task to find master and generate the changelog successfully.