### PR TITLE
Add spark.app.name to snapshot summary

### DIFF
--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -98,6 +98,7 @@ public class IcebergSource
         table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
     SparkUtil.validatePartitionTransforms(table.spec());
     String appId = lazySparkSession().sparkContext().applicationId();
+    String appName = lazySparkSession().sparkContext().appName();
     String wapId = writeConf.wapId();
     boolean replacePartitions = mode == SaveMode.Overwrite;
 
@@ -108,6 +109,7 @@ public class IcebergSource
             writeConf,
             replacePartitions,
             appId,
+            appName,
             wapId,
             writeSchema,
             dsStruct));
@@ -138,9 +140,10 @@ public class IcebergSource
     String queryId =
         lazySparkSession().sparkContext().getLocalProperty(StreamExecution.QUERY_ID_KEY());
     String appId = lazySparkSession().sparkContext().applicationId();
+    String appName = lazySparkSession().sparkContext().appName();
 
     return new StreamingWriter(
-        lazySparkSession(), table, writeConf, queryId, mode, appId, writeSchema, dsStruct);
+        lazySparkSession(), table, writeConf, queryId, mode, appId, appName, writeSchema, dsStruct);
   }
 
   protected Table findTable(DataSourceOptions options, Configuration conf) {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/StreamingWriter.java
@@ -52,9 +52,10 @@ public class StreamingWriter extends Writer implements StreamWriter {
       String queryId,
       OutputMode mode,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
-    super(spark, table, writeConf, false, applicationId, writeSchema, dsSchema);
+    super(spark, table, writeConf, false, applicationId, applicationName, null, writeSchema, dsSchema);
     this.queryId = queryId;
     this.mode = mode;
   }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -81,16 +81,6 @@ class Writer implements DataSourceWriter {
 
   private boolean cleanupOnAbort = true;
 
-  Writer(
-      SparkSession spark,
-      Table table,
-      SparkWriteConf writeConf,
-      boolean replacePartitions,
-      String applicationId,
-      Schema writeSchema,
-      StructType dsSchema) {
-    this(spark, table, writeConf, replacePartitions, applicationId, null, null, writeSchema, dsSchema);
-  }
 
   Writer(
       SparkSession spark,

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -87,9 +87,10 @@ class Writer implements DataSourceWriter {
       SparkWriteConf writeConf,
       boolean replacePartitions,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
-    this(spark, table, writeConf, replacePartitions, applicationId, null, writeSchema, dsSchema);
+    this(spark, table, writeConf, replacePartitions, applicationId, applicationName, writeSchema, dsSchema);
   }
 
   Writer(

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -71,6 +71,7 @@ class Writer implements DataSourceWriter {
   private final FileFormat format;
   private final boolean replacePartitions;
   private final String applicationId;
+  private final String applicationName;
   private final String wapId;
   private final long targetFileSize;
   private final Schema writeSchema;
@@ -88,7 +89,7 @@ class Writer implements DataSourceWriter {
       String applicationId,
       Schema writeSchema,
       StructType dsSchema) {
-    this(spark, table, writeConf, replacePartitions, applicationId, null, writeSchema, dsSchema);
+    this(spark, table, writeConf, replacePartitions, applicationId, null, null, writeSchema, dsSchema);
   }
 
   Writer(
@@ -97,6 +98,7 @@ class Writer implements DataSourceWriter {
       SparkWriteConf writeConf,
       boolean replacePartitions,
       String applicationId,
+      String applicationName,
       String wapId,
       Schema writeSchema,
       StructType dsSchema) {
@@ -105,6 +107,7 @@ class Writer implements DataSourceWriter {
     this.format = writeConf.dataFileFormat();
     this.replacePartitions = replacePartitions;
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapId = wapId;
     this.targetFileSize = writeConf.targetDataFileSize();
     this.writeSchema = writeSchema;
@@ -143,6 +146,10 @@ class Writer implements DataSourceWriter {
     LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -90,7 +90,7 @@ class Writer implements DataSourceWriter {
       String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
-    this(spark, table, writeConf, replacePartitions, applicationId, applicationName, writeSchema, dsSchema);
+    this(spark, table, writeConf, replacePartitions, applicationId, applicationName, null, writeSchema, dsSchema);
   }
 
   Writer(

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -81,6 +81,16 @@ class Writer implements DataSourceWriter {
 
   private boolean cleanupOnAbort = true;
 
+  Writer(
+      SparkSession spark,
+      Table table,
+      SparkWriteConf writeConf,
+      boolean replacePartitions,
+      String applicationId,
+      Schema writeSchema,
+      StructType dsSchema) {
+    this(spark, table, writeConf, replacePartitions, applicationId, null, writeSchema, dsSchema);
+  }
 
   Writer(
       SparkSession spark,

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/ManualSource.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/ManualSource.java
@@ -78,6 +78,7 @@ public class ManualSource implements WriteSupport, DataSourceRegister, DataSourc
         table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
     SparkUtil.validatePartitionTransforms(table.spec());
     String appId = lazySparkSession().sparkContext().applicationId();
+    String appName = lazySparkSession().sparkContext().appName();
     String wapId = writeConf.wapId();
     boolean replacePartitions = mode == SaveMode.Overwrite;
 
@@ -88,6 +89,7 @@ public class ManualSource implements WriteSupport, DataSourceRegister, DataSourc
             writeConf,
             replacePartitions,
             appId,
+            appName,
             wapId,
             writeSchema,
             dsStruct));

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRewriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRewriteBuilder.java
@@ -63,9 +63,10 @@ public class SparkRewriteBuilder implements WriteBuilder {
     SparkUtil.validatePartitionTransforms(table.spec());
 
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     SparkWrite write =
-        new SparkWrite(spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema);
+        new SparkWrite(spark, table, writeConf, writeInfo, appId, appName, writeSchema, dsSchema);
     return write.asRewrite(fileSetID);
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -292,6 +292,7 @@ public class SparkTable
     icebergTable
         .newDelete()
         .set("spark.app.id", sparkSession().sparkContext().applicationId())
+        .set("spark.app.name", sparkSession().sparkContext().appName())
         .deleteFromRowFilter(deleteExpr)
         .commit();
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -97,6 +97,7 @@ class SparkWrite {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final long targetFileSize;
@@ -113,6 +114,7 @@ class SparkWrite {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
@@ -120,6 +122,7 @@ class SparkWrite {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.targetFileSize = writeConf.targetDataFileSize();
@@ -170,6 +173,10 @@ class SparkWrite {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -114,11 +114,12 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     SparkWrite write =
-        new SparkWrite(spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema);
+        new SparkWrite(spark, table, writeConf, writeInfo, appId, appName, writeSchema, dsSchema);
     if (overwriteByFilter) {
       return write.asOverwriteByFilter(overwriteExpr);
     } else if (overwriteDynamic) {
@@ -150,11 +151,12 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         "Unsupported streaming operation: overwrite by filter: %s",
         overwriteExpr);
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     SparkWrite write =
-        new SparkWrite(spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema);
+        new SparkWrite(spark, table, writeConf, writeInfo, appId, appName, writeSchema, dsSchema);
     if (overwriteByFilter) {
       return write.asStreamingOverwrite();
     } else {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -95,6 +95,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   private final IsolationLevel isolationLevel;
   private final Context context;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final Map<String, String> extraSnapshotMetadata;
@@ -121,6 +122,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     this.isolationLevel = isolationLevel;
     this.context = new Context(dataSchema, writeConf, info);
     this.applicationId = spark.sparkContext().applicationId();
+    this.applicationName = spark.sparkContext().appName();
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
@@ -260,6 +262,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       LOG.info("Committing {} to table {}", description, table);
       if (applicationId != null) {
         operation.set("spark.app.id", applicationId);
+      }
+
+      if (applicationName != null) {
+        operation.set("spark.app.name", applicationName);
       }
 
       extraSnapshotMetadata.forEach(operation::set);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -329,6 +329,7 @@ public class SparkTable
     icebergTable
         .newDelete()
         .set("spark.app.id", sparkSession().sparkContext().applicationId())
+        .set("spark.app.name", sparkSession().sparkContext().appName())
         .deleteFromRowFilter(deleteExpr)
         .commit();
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -88,6 +88,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final long targetFileSize;
@@ -106,6 +107,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema,
       Distribution requiredDistribution,
@@ -116,6 +118,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.targetFileSize = writeConf.targetDataFileSize();
@@ -184,6 +187,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -141,8 +141,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     Distribution distribution;
     SortOrder[] ordering;
@@ -164,7 +165,16 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     }
 
     return new SparkWrite(
-        spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema, distribution, ordering) {
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        appId,
+        appName,
+        writeSchema,
+        dsSchema,
+        distribution,
+        ordering) {
 
       @Override
       public BatchWrite toBatch() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -95,6 +95,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   private final IsolationLevel isolationLevel;
   private final Context context;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final String branch;
@@ -122,6 +123,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     this.isolationLevel = isolationLevel;
     this.context = new Context(dataSchema, writeConf, info);
     this.applicationId = spark.sparkContext().applicationId();
+    this.applicationName = spark.sparkContext().appName();
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -260,6 +262,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       LOG.info("Committing {} to table {}", description, table);
       if (applicationId != null) {
         operation.set("spark.app.id", applicationId);
+      }
+
+      if (applicationName != null) {
+        operation.set("spark.app.name", applicationName);
       }
 
       extraSnapshotMetadata.forEach(operation::set);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -369,6 +369,7 @@ public class SparkTable
         icebergTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
+            .set("spark.app.name", sparkSession().sparkContext().appName())
             .deleteFromRowFilter(deleteExpr);
 
     if (branch != null) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -89,6 +89,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final String branch;
@@ -108,6 +109,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema,
       Distribution requiredDistribution,
@@ -118,6 +120,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -187,6 +190,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -139,8 +139,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     Distribution distribution;
     SortOrder[] ordering;
@@ -162,7 +163,16 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     }
 
     return new SparkWrite(
-        spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema, distribution, ordering) {
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        appId,
+        appName,
+        writeSchema,
+        dsSchema,
+        distribution,
+        ordering) {
 
       @Override
       public BatchWrite toBatch() {


### PR DESCRIPTION
Add spark.app.name alongside the existing spark.app.id in snapshot summary metadata for all write operations. This provides better traceability by capturing the human-readable application name in addition to the Spark application ID.

Changes:
- Capture app name from SparkContext.appName() in write builders
- Thread app name through write operation constructors
- Set spark.app.name in snapshot summary via operation.set()

Affected operations:
- Append, overwrite, delete, and streaming writes
- Row-level operations (UPDATE/MERGE/DELETE in Spark 3.2+)
- All Spark versions: 2.4, 3.1, 3.2, 3.3

The app name will be queryable via:
  SELECT summary['spark.app.name'] FROM table.snapshots
  
Testing and Validation:
1.  Published this project JAR to local maevn
2. Used the Snapshot version of Iceberg in Openhouse repo and tested in Docker.
Sample Output for snapshots table:"
`spark.sql("SELECT * FROM openhouse.test_db.sample.snapshots").show(false)
+----------------------+-------------------+---------+---------+--------------------------------------------------------
|committed_at          |snapshot_id        |parent_id|operation|manifest_list                                                                                                              |summary                                                                                                                                                                                                                                                                                                                        |
+----------------------+-------------------+---------+---------+--------------------------------------------------------
|2025-11-05 17:31:33.07|2345330373939359967|null     |append   |hdfs://namenode:9000/warehouse/test_db/sample/metadata/snap-2345330373939359967-1-c91ec09b-7eeb-4fc1-b6bd-11b683b477d9.avro|{spark.app.id -> local-1762363791420, spark.app.name -> Spark shell, added-data-files -> 3, added-records -> 3, added-files-size -> 2913, changed-partition-count -> 3, total-records -> 3, total-files-size -> 2913, total-data-files -> 3, total-delete-files -> 0, total-position-deletes -> 0, total-equality-deletes -> 0}|
+----------------------+-------------------+---------+---------+--------------------------------------------------------