### PR TITLE
Spark: Add application name to snapshot metadata to versions v3.3, v3.4 and v3.5

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -95,6 +95,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   private final IsolationLevel isolationLevel;
   private final Context context;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final String branch;
@@ -122,6 +123,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     this.isolationLevel = isolationLevel;
     this.context = new Context(dataSchema, writeConf, info);
     this.applicationId = spark.sparkContext().applicationId();
+    this.applicationName = spark.sparkContext().appName();
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -260,6 +262,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       LOG.info("Committing {} to table {}", description, table);
       if (applicationId != null) {
         operation.set("spark.app.id", applicationId);
+      }
+
+      if (applicationName != null) {
+        operation.set("spark.app.name", applicationName);
       }
 
       extraSnapshotMetadata.forEach(operation::set);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -375,6 +375,7 @@ public class SparkTable
         icebergTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
+            .set("spark.app.name", sparkSession().sparkContext().appName())
             .deleteFromRowFilter(deleteExpr);
 
     if (SparkTableUtil.wapEnabled(table())) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -89,6 +89,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final int outputSpecId;
@@ -109,6 +110,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema,
       Distribution requiredDistribution,
@@ -119,6 +121,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -190,6 +193,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -139,8 +139,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     Distribution distribution;
     SortOrder[] ordering;
@@ -162,7 +163,16 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     }
 
     return new SparkWrite(
-        spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema, distribution, ordering) {
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        appId,
+        appName,
+        writeSchema,
+        dsSchema,
+        distribution,
+        ordering) {
 
       @Override
       public BatchWrite toBatch() {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -97,6 +97,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   private final SparkBatchQueryScan scan;
   private final IsolationLevel isolationLevel;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final String branch;
@@ -122,6 +123,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     this.scan = scan;
     this.isolationLevel = isolationLevel;
     this.applicationId = spark.sparkContext().applicationId();
+    this.applicationName = spark.sparkContext().appName();
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -271,6 +273,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       LOG.info("Committing {} to table {}", description, table);
       if (applicationId != null) {
         operation.set("spark.app.id", applicationId);
+      }
+
+      if (applicationName != null) {
+        operation.set("spark.app.name", applicationName);
       }
 
       extraSnapshotMetadata.forEach(operation::set);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -375,6 +375,7 @@ public class SparkTable
         icebergTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
+            .set("spark.app.name", sparkSession().sparkContext().appName())
             .deleteFromRowFilter(deleteExpr);
 
     if (SparkTableUtil.wapEnabled(table())) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -90,6 +90,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final int outputSpecId;
@@ -110,6 +111,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema,
       SparkWriteRequirements writeRequirements) {
@@ -119,6 +121,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -196,6 +199,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -120,11 +120,20 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     return new SparkWrite(
-        spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema, writeRequirements()) {
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        appId,
+        appName,
+        writeSchema,
+        dsSchema,
+        writeRequirements()) {
 
       @Override
       public BatchWrite toBatch() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -97,6 +97,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   private final SparkBatchQueryScan scan;
   private final IsolationLevel isolationLevel;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final String branch;
@@ -122,6 +123,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     this.scan = scan;
     this.isolationLevel = isolationLevel;
     this.applicationId = spark.sparkContext().applicationId();
+    this.applicationName = spark.sparkContext().appName();
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -282,6 +284,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       LOG.info("Committing {} to table {}", description, table);
       if (applicationId != null) {
         operation.set("spark.app.id", applicationId);
+      }
+
+      if (applicationName != null) {
+        operation.set("spark.app.name", applicationName);
       }
 
       extraSnapshotMetadata.forEach(operation::set);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -375,6 +375,7 @@ public class SparkTable
         icebergTable
             .newDelete()
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
+            .set("spark.app.name", sparkSession().sparkContext().appName())
             .deleteFromRowFilter(deleteExpr);
 
     if (SparkTableUtil.wapEnabled(table())) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -90,6 +90,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String queryId;
   private final FileFormat format;
   private final String applicationId;
+  private final String applicationName;
   private final boolean wapEnabled;
   private final String wapId;
   private final int outputSpecId;
@@ -110,6 +111,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       SparkWriteConf writeConf,
       LogicalWriteInfo writeInfo,
       String applicationId,
+      String applicationName,
       Schema writeSchema,
       StructType dsSchema,
       SparkWriteRequirements writeRequirements) {
@@ -119,6 +121,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.queryId = writeInfo.queryId();
     this.format = writeConf.dataFileFormat();
     this.applicationId = applicationId;
+    this.applicationName = applicationName;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
     this.branch = writeConf.branch();
@@ -207,6 +210,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (applicationName != null) {
+      operation.set("spark.app.name", applicationName);
     }
 
     if (!extraSnapshotMetadata.isEmpty()) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -120,11 +120,20 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
-    // Get application id
+    // Get application id and name
     String appId = spark.sparkContext().applicationId();
+    String appName = spark.sparkContext().appName();
 
     return new SparkWrite(
-        spark, table, writeConf, writeInfo, appId, writeSchema, dsSchema, writeRequirements()) {
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        appId,
+        appName,
+        writeSchema,
+        dsSchema,
+        writeRequirements()) {
 
       @Override
       public BatchWrite toBatch() {


### PR DESCRIPTION
Add spark.app.name alongside the existing spark.app.id in snapshot summary metadata for all write operations. This provides better traceability by capturing the human-readable application name in addition to the Spark application ID.

Changes:

Capture app name from SparkContext.appName() in write builders
Thread app name through write operation constructors
Set spark.app.name in snapshot summary via operation.set()
Affected operations:

Append, overwrite, delete, and streaming writes

Spark versions: 3.1, 3.2, 3.3
The app name will be queryable via:
SELECT summary['spark.app.name'] FROM table.snapshots

Reference Pr - https://github.com/linkedin/iceberg/pull/212