### PR TITLE
Offload ResolveView operations to Spark 

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -410,7 +410,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     Assertions.assertThat(tasks).as("Should scan 1 files").hasSize(1);
   }
 
-  //@Test
+  // @Test
   public void testConcurrentFastAppends(@TempDir File dir) throws Exception {
     Assertions.assertThat(version(1)).as("Should create v1 metadata").exists().isFile();
     int threadsCount = 5;

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -36,7 +36,9 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // analyzer extensions
     extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
-    extensions.injectResolutionRule { spark => ResolveViews(spark) }
+    // Disable Iceberg's custom view resolution to use Spark's native implementation.
+    // This is a temporary fix until `createView` is supported in `CoralSparkViewCatalog`.
+    // extensions.injectResolutionRule { spark => ResolveViews(spark) }
     extensions.injectResolutionRule { _ => ProcedureArgumentCoercion }
     extensions.injectCheckRule(_ => CheckViews)
 


### PR DESCRIPTION
## Summary 
This change disables Iceberg's custom view management by commenting out the ResolveViews in IcebergSparkSessionExtensions

By doing this, we delegate all view-related operations back to Spark's native implementation. This is because of a feature gap in CoralSparkViewCatalog which has not yet implemented create view related logic, causing the view creation to fail and resulting in a NoSuchTableException upon subsequent access.


## How to reproduce? 

```

spark.sql("CREATE VIEW shreyesh.fooview AS SELECT * from shreyesh.footable").show();


25/11/22 00:10:14 ERROR catalog.LiOpenHouseMetastoreClient: Failed to load table  shreyesh.fooview
liopenhouse.relocated.org.apache.iceberg.exceptions.NoSuchTableException: Table does not exist: shreyesh.fooview
        at liopenhouse.relocated.org.apache.iceberg.BaseMetastoreCatalog.loadTable(BaseMetastoreCatalog.java:53)
        at com.linkedin.coral.spark.catalog.LiOpenHouseMetastoreClient.getTable(LiOpenHouseMetastoreClient.java:120)
        at com.linkedin.coral.spark.catalog.MultiCatalogMetastoreClient.getTable(MultiCatalogMetastoreClient.java:81)
        at com.linkedin.coral.spark.catalog.BaseCoralSparkViewCatalog.loadView(BaseCoralSparkViewCatalog.java:256)
        at org.apache.spark.sql.connector.catalog.ViewCatalog.viewExists(ViewCatalog.java:110)

```


## Testing Done 
WIP