### PR TITLE
Partially shade iceberg-hive-metastore for HiveSchemaUtils usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -607,6 +607,18 @@ project(':iceberg-gcp') {
 }
 
 project(':iceberg-hive-metastore') {
+  apply plugin: 'com.github.johnrengelman.shadow'
+
+  tasks.shadowJar.dependsOn project(':iceberg-api').tasks.jar
+
+  configurations {
+    fatJarPackagedDependencies {}
+  }
+
+  ext {
+    hiveVersion = '2.3.8'
+  }
+
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     implementation project(':iceberg-core')
@@ -671,6 +683,38 @@ project(':iceberg-hive-metastore') {
     }
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+
+    fatJarPackagedDependencies ('org.apache.hive:hive-metastore:' + hiveVersion) {
+      transitive = false
+    }
+    fatJarPackagedDependencies ('org.apache.hive:hive-serde:' + hiveVersion) {
+      transitive = false
+    }
+    fatJarPackagedDependencies ('org.apache.hive:hive-common:' + hiveVersion) {
+      transitive = false
+    }
+    fatJarPackagedDependencies ('org.apache.hive:hive-storage-api:' + hiveVersion) {
+      transitive = false
+    }
+    fatJarPackagedDependencies ('org.apache.thrift:libthrift:0.9.3') {
+      transitive = false
+    }
+  }
+
+  shadowJar {
+    archiveClassifier.set('shaded4')
+    configurations = [project.configurations.fatJarPackagedDependencies]
+    zip64 true
+
+    // include the LICENSE and NOTICE files for the shaded Jar
+    from(projectDir) {
+      include 'LICENSE'
+      include 'NOTICE'
+    }
+
+    relocate('org.apache', 'iceberghive.relocated.org.apache')
+
+    minimize()
   }
 }
 
@@ -878,12 +922,12 @@ String getProjectVersion() {
       standardOutput = stdout
     }
     String version = stdout.toString().trim()
-    
+
     // Remove 'v' prefix if present
     if (version.startsWith('v')) {
       version = version.substring(1)
     }
-    
+
     println "Version from git tag: ${version.padRight(30)}"
 
     return version
@@ -895,7 +939,7 @@ String getProjectVersion() {
 
 /**
  * Get version string for Javadoc using the current branch name.
- * 
+ *
  * @return branch name for Javadoc version
  */
 String getJavadocVersion() {

--- a/build.gradle
+++ b/build.gradle
@@ -632,7 +632,7 @@ project(':iceberg-hive-metastore') {
   }
 
   ext {
-    shadedHiveVersion = '1.1.0'
+    shadedHiveVersion = '2.3.8'
   }
 
   dependencies {
@@ -673,16 +673,10 @@ project(':iceberg-hive-metastore') {
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
 
     fatJarPackagedDependencies("org.apache.hive:hive-metastore:" + shadedHiveVersion, commonExcludes)
-    fatJarPackagedDependencies(project(path: ':iceberg-bundled-guava', configuration: 'shadow'))
-    fatJarPackagedDependencies(project(':iceberg-core'))
-    fatJarPackagedDependencies(project(':iceberg-api'))
-    fatJarPackagedDependencies(project(':iceberg-common'))
-    fatJarPackagedDependencies("com.github.ben-manes.caffeine:caffeine")
-    fatJarPackagedDependencies("org.apache.hive:hive-storage-api:2.4.0")
   }
 
   shadowJar {
-    archiveClassifier.set('shaded-final')
+    archiveClassifier.set('shaded')
     configurations = [project.configurations.fatJarPackagedDependencies]
     zip64 true
 
@@ -699,8 +693,11 @@ project(':iceberg-hive-metastore') {
       exclude("schema/**")
     }
 
-    relocate('org', 'iceberghive.relocated.org')
+    relocate('org', 'iceberghive.relocated.org') {
+      exclude 'org.apache.iceberg.**'
+    }
     relocate('com', 'iceberghive.relocated.com')
+    relocate('javolution', 'iceberghive.relocated.javolution')
 
     minimize()
   }
@@ -897,6 +894,8 @@ project(':iceberg-snowflake') {
  * @return the project version (e.g., 1.2.0.4)
  */
 String getProjectVersion() {
+  return "1.2.0.4-alpha"
+
   if (project.hasProperty('ciVersion')) {
     String version = project.property('ciVersion')
     println "Version: ${version.padRight(27)}"

--- a/build.gradle
+++ b/build.gradle
@@ -693,7 +693,7 @@ project(':iceberg-hive-metastore') {
     fatJarPackagedDependencies ('org.apache.hive:hive-common:' + hiveVersion) {
       transitive = false
     }
-    fatJarPackagedDependencies ('org.apache.hive:hive-storage-api:' + hiveVersion) {
+    fatJarPackagedDependencies ('org.apache.hive:hive-storage-api:2.4.0') {
       transitive = false
     }
     fatJarPackagedDependencies ('org.apache.thrift:libthrift:0.9.3') {
@@ -702,7 +702,7 @@ project(':iceberg-hive-metastore') {
   }
 
   shadowJar {
-    archiveClassifier.set('shaded4')
+    archiveClassifier.set('shaded3')
     configurations = [project.configurations.fatJarPackagedDependencies]
     zip64 true
 

--- a/build.gradle
+++ b/build.gradle
@@ -894,8 +894,6 @@ project(':iceberg-snowflake') {
  * @return the project version (e.g., 1.2.0.4)
  */
 String getProjectVersion() {
-  return "1.2.0.4-alpha"
-
   if (project.hasProperty('ciVersion')) {
     String version = project.property('ciVersion')
     println "Version: ${version.padRight(27)}"

--- a/build.gradle
+++ b/build.gradle
@@ -615,8 +615,24 @@ project(':iceberg-hive-metastore') {
     fatJarPackagedDependencies {}
   }
 
+  def commonExcludes = {
+    exclude group: 'org.apache.avro', module: 'avro'
+    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    exclude group: 'org.pentaho' // missing dependency
+    exclude group: 'org.apache.hbase'
+    exclude group: 'org.apache.logging.log4j'
+    exclude group: 'co.cask.tephra'
+    exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
+    exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+    exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+    exclude group: 'com.tdunning', module: 'json'
+    exclude group: 'javax.transaction', module: 'transaction-api'
+    exclude group: 'com.zaxxer', module: 'HikariCP'
+  }
+
   ext {
-    hiveVersion = '2.3.8'
+    shadedHiveVersion = '1.1.0'
   }
 
   dependencies {
@@ -629,21 +645,7 @@ project(':iceberg-hive-metastore') {
 
     compileOnly "org.apache.avro:avro"
 
-    compileOnly("org.apache.hive:hive-metastore") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-      exclude group: 'org.pentaho' // missing dependency
-      exclude group: 'org.apache.hbase'
-      exclude group: 'org.apache.logging.log4j'
-      exclude group: 'co.cask.tephra'
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
-      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
-      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
-      exclude group: 'com.tdunning', module: 'json'
-      exclude group: 'javax.transaction', module: 'transaction-api'
-      exclude group: 'com.zaxxer', module: 'HikariCP'
-    }
+    compileOnly("org.apache.hive:hive-metastore", commonExcludes)
 
     // By default, hive-exec is a fat/uber jar and it exports a guava library
     // that's really old. We use the core classifier to be able to override our guava
@@ -661,21 +663,7 @@ project(':iceberg-hive-metastore') {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    testImplementation("org.apache.hive:hive-metastore") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-      exclude group: 'org.pentaho' // missing dependency
-      exclude group: 'org.apache.hbase'
-      exclude group: 'org.apache.logging.log4j'
-      exclude group: 'co.cask.tephra'
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
-      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
-      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
-      exclude group: 'com.tdunning', module: 'json'
-      exclude group: 'javax.transaction', module: 'transaction-api'
-      exclude group: 'com.zaxxer', module: 'HikariCP'
-    }
+    testImplementation("org.apache.hive:hive-metastore", commonExcludes)
 
     compileOnly("org.apache.hadoop:hadoop-client") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -684,25 +672,17 @@ project(':iceberg-hive-metastore') {
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
 
-    fatJarPackagedDependencies ('org.apache.hive:hive-metastore:' + hiveVersion) {
-      transitive = false
-    }
-    fatJarPackagedDependencies ('org.apache.hive:hive-serde:' + hiveVersion) {
-      transitive = false
-    }
-    fatJarPackagedDependencies ('org.apache.hive:hive-common:' + hiveVersion) {
-      transitive = false
-    }
-    fatJarPackagedDependencies ('org.apache.hive:hive-storage-api:2.4.0') {
-      transitive = false
-    }
-    fatJarPackagedDependencies ('org.apache.thrift:libthrift:0.9.3') {
-      transitive = false
-    }
+    fatJarPackagedDependencies("org.apache.hive:hive-metastore:" + shadedHiveVersion, commonExcludes)
+    fatJarPackagedDependencies(project(path: ':iceberg-bundled-guava', configuration: 'shadow'))
+    fatJarPackagedDependencies(project(':iceberg-core'))
+    fatJarPackagedDependencies(project(':iceberg-api'))
+    fatJarPackagedDependencies(project(':iceberg-common'))
+    fatJarPackagedDependencies("com.github.ben-manes.caffeine:caffeine")
+    fatJarPackagedDependencies("org.apache.hive:hive-storage-api:2.4.0")
   }
 
   shadowJar {
-    archiveClassifier.set('shaded3')
+    archiveClassifier.set('shaded-final')
     configurations = [project.configurations.fatJarPackagedDependencies]
     zip64 true
 
@@ -712,7 +692,15 @@ project(':iceberg-hive-metastore') {
       include 'NOTICE'
     }
 
-    relocate('org.apache', 'iceberghive.relocated.org.apache')
+    dependencies {
+      exclude("images/**")
+      exclude("javax/**")
+      exclude("webapps/**")
+      exclude("schema/**")
+    }
+
+    relocate('org', 'iceberghive.relocated.org')
+    relocate('com', 'iceberghive.relocated.com')
 
     minimize()
   }


### PR DESCRIPTION
## Changes
There are some usages of `HiveSchemaUtils` in the hive to iceberg migration, however the `iceberg-hive-metastore` module did not properly include the dependencies in RuntimeClasspath. This PR adds shading to the module and relocate hive related classes so it won't break the existing classes in the hive environment. Also since `HiveSchemaUtils` is the only use case, we should only partially shade the jars so that we don't need to deal with massive exclusions and relocations.

## Tests
**Integration tests**
Tested the snapshot shaded jar in `li-openhouse-java-runtime` with `HiveSchemaUtils` tests and worked.

**Shadow jar check**
The necessary classes exist and being relocated. The jar size is 18mb compared to 36mb for full shading.
<img width="460" height="765" alt="Screenshot 2025-12-12 at 1 59 41 AM" src="https://github.com/user-attachments/assets/8bc8c691-dd97-4476-9454-cb361b5b3911" />
