### PR TITLE
Do not rewrite Spark views for Linkedin Spark 3.5

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -123,7 +123,9 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
     if (isIcebergCommand(sqlTextAfterSubstitution)) {
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }.asInstanceOf[LogicalPlan]
     } else {
-      RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
+      // Iceberg views are not supported in LinkedIn, do not rewrite views
+      // RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
+      delegate.parsePlan(sqlText)
     }
   }
 

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -59,6 +59,14 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
   private lazy val substitutor = substitutorCtor.newInstance(SQLConf.get)
   private lazy val astBuilder = new IcebergSqlExtensionsAstBuilder(delegate)
 
+  private def shouldRewriteViewCommands: Boolean = {
+    // default true to preserve existing behavior + tests
+    SQLConf.get.getConfString(
+      "spark.sql.iceberg.rewriteViewCommands.enabled",
+      "true"
+    ).toBoolean
+  }
+
   /**
    * Parse a string to a DataType.
    */
@@ -123,9 +131,11 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
     if (isIcebergCommand(sqlTextAfterSubstitution)) {
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }.asInstanceOf[LogicalPlan]
     } else {
-      // Iceberg views are not supported in LinkedIn, do not rewrite views
-      // RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
-      delegate.parsePlan(sqlText)
+      if (shouldRewriteViewCommands) {
+        RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
+      } else {
+        delegate.parsePlan(sqlText)
+      }
     }
   }
 


### PR DESCRIPTION
In Spark 3.5 along with `IcebergSparkSessionExtensions`, `CreateView` statements in Spark lead to the creation of [`CreateIcebergView` here](https://github.com/apache/iceberg/blob/main/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala#L65).

This leads to the creation of [`CreateV2ViewExec` here](https://github.com/apache/iceberg/blob/9ee4d023f85d70e0a0c14431f2561af479508640/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala#L120).

which in turn just calls [`createView` on the catalog](https://github.com/apache/iceberg/blob/9ee4d023f85d70e0a0c14431f2561af479508640/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala#L110).

`createView` in Linkedin's internal session catalog is not implemented and hence the view creation does not happen.

In Spark 3.1, we use HMS for handling views.

For Spark 3.5, we need a way to exclude this feature of rewriting views from taking place and let Spark handle it natively.

This PR, disables Iceberg from rewriting Spark view statements.