### PR TITLE
Fix bug in hive shading and make fat jar thinner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -672,7 +672,12 @@ project(':iceberg-hive-metastore') {
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
 
-    fatJarPackagedDependencies("org.apache.hive:hive-metastore:" + shadedHiveVersion, commonExcludes)
+    fatJarPackagedDependencies("org.apache.hive:hive-common:" + shadedHiveVersion) {
+      transitive = false
+    }
+    fatJarPackagedDependencies("org.apache.hive:hive-serde:" + shadedHiveVersion) {
+      transitive = false
+    }
   }
 
   shadowJar {
@@ -686,19 +691,10 @@ project(':iceberg-hive-metastore') {
       include 'NOTICE'
     }
 
-    dependencies {
-      exclude("images/**")
-      exclude("javax/**")
-      exclude("webapps/**")
-      exclude("schema/**")
-    }
-
-    relocate('org', 'iceberghive.relocated.org') {
+    relocate('org.apache', 'iceberghive.relocated.org.apache') {
       exclude 'org.apache.iceberg.**'
-      exclude 'org.apache.hadoop.hive.metastore.**'
+      exclude 'org.apache.hadoop.hive.metastore.api.**'
     }
-    relocate('com', 'iceberghive.relocated.com')
-    relocate('javolution', 'iceberghive.relocated.javolution')
 
     minimize()
   }

--- a/build.gradle
+++ b/build.gradle
@@ -695,6 +695,7 @@ project(':iceberg-hive-metastore') {
 
     relocate('org', 'iceberghive.relocated.org') {
       exclude 'org.apache.iceberg.**'
+      exclude 'org.apache.hadoop.hive.metastore.**'
     }
     relocate('com', 'iceberghive.relocated.com')
     relocate('javolution', 'iceberghive.relocated.javolution')


### PR DESCRIPTION
## Changes
Last PR (https://github.com/linkedin/iceberg/pull/223) broke the build of `dali-data-sdk`. This PR excludes relocating the classes in `hive-metastore`, and make the fat jar thinner by only packaging `hive-serde` and `hive-common`.

## Tests
Tested build the module dali-data-sdk:sdk-dali-client.