### PR TITLE
Adding SparkSQLProperty for split-size

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -191,6 +191,7 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
+        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -66,4 +66,7 @@ public class SparkSQLProperties {
 
   // Controls whether to report locality information to Spark while allocating input partitions
   public static final String LOCALITY = "spark.sql.iceberg.locality.enabled";
+
+  // Controls the spark input split size.
+  public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -201,6 +201,7 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
+        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -97,4 +97,7 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_LOCALITY_ENABLED =
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
+
+  // Controls the spark input split size.
+  public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -199,6 +199,7 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
+        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -90,4 +90,7 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_LOCALITY_ENABLED =
       "spark.sql.iceberg.executor-cache.locality.enabled";
   public static final boolean EXECUTOR_CACHE_LOCALITY_ENABLED_DEFAULT = false;
+
+  // Controls the spark input split size.
+  public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
 }


### PR DESCRIPTION
### Description

In Hive, we relied on the session-level config spark.sql.files.maxPartitionBytes to control file split sizes, and this was widely adopted across many flows at LinkedIn. As we transition to Iceberg, the equivalent setting is read.split.target-size, but it can't be set via session configs. This creates a gap—our current options are either to update thousands of jobs to pass this value through OPTIONS, or to set the table property spark.sql.iceberg.split-size directly on the tables and apply the config to all the jobs. Both of which is suboptimal.

Back-port PR: https://github.com/apache/iceberg/pull/13677
Same changes done in spark-3.1 for openhouse-1.2.0 branch https://github.com/linkedin/iceberg/pull/190 

### Testing
./gradlew clean && ./gradlew build