### PR TITLE
Support configuring delete file replication factor through spark-sql properties.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -371,4 +371,6 @@ public class TableProperties {
   public static final int ENCRYPTION_DEK_LENGTH_DEFAULT = 16;
 
   public static final int ENCRYPTION_AAD_LENGTH_DEFAULT = 16;
+
+  public static final String DELETE_FILE_REPLICATION = "write.delete-file-replication";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -69,4 +69,7 @@ public class SparkSQLProperties {
 
   // Controls the spark input split size.
   public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
+
+  // Controls the replication factor for delete files
+  public static final String DELETE_FILE_REPLICATION = "spark.sql.iceberg.delete-file-replication";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -133,6 +133,17 @@ public class SparkWriteConf {
     return sessionConf.get(SparkSQLProperties.WAP_ID, null);
   }
 
+  public short deleteFileReplication() {
+    return (short)
+        confParser
+            .intConf()
+            .option(SparkWriteOptions.DELETE_FILE_REPLICATION)
+            .sessionConf(SparkSQLProperties.DELETE_FILE_REPLICATION)
+            .tableProperty(TableProperties.DELETE_FILE_REPLICATION)
+            .defaultValue(SparkWriteOptions.DEFAULT_DELETE_FILE_REPLICATION)
+            .parse();
+  }
+
   public boolean mergeSchema() {
     return confParser
         .booleanConf()

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -23,6 +23,12 @@ public class SparkWriteOptions {
 
   private SparkWriteOptions() {}
 
+  // Configuration to tune the replication factor for delete files.
+  public static final String DELETE_FILE_REPLICATION = "delete-file-replication";
+
+  // Configuring the default replication factor.
+  public static final short DEFAULT_DELETE_FILE_REPLICATION = 3;
+
   // Fileformat for write operations(default: Table write.format.default )
   public static final String WRITE_FORMAT = "write-format";
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -100,4 +100,7 @@ public class SparkSQLProperties {
 
   // Controls the spark input split size.
   public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
+
+  // Controls the replication factor for delete files
+  public static final String DELETE_FILE_REPLICATION = "spark.sql.iceberg.delete-file-replication";
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -137,6 +137,8 @@ public class SparkWriteConf {
         confParser
             .intConf()
             .option(SparkWriteOptions.DELETE_FILE_REPLICATION)
+            .sessionConf(SparkSQLProperties.DELETE_FILE_REPLICATION)
+            .tableProperty(TableProperties.DELETE_FILE_REPLICATION)
             .defaultValue(SparkWriteOptions.DEFAULT_DELETE_FILE_REPLICATION)
             .parse();
   }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -23,8 +23,10 @@ public class SparkWriteOptions {
 
   private SparkWriteOptions() {}
 
+  // Configuration to tune the replication factor for delete files.
   public static final String DELETE_FILE_REPLICATION = "delete-file-replication";
 
+  // The default replication factor.
   public static final short DEFAULT_DELETE_FILE_REPLICATION = 3;
 
   // Fileformat for write operations(default: Table write.format.default )

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -93,4 +93,7 @@ public class SparkSQLProperties {
 
   // Controls the spark input split size.
   public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
+
+  // Controls the delete file replication
+  public static final String DELETE_FILE_REPLICATION = "spark.sql.iceberg.delete-file-replication";
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -136,6 +136,8 @@ public class SparkWriteConf {
     return (short)
         confParser
             .intConf()
+            .sessionConf(SparkSQLProperties.DELETE_FILE_REPLICATION)
+            .tableProperty(TableProperties.DELETE_FILE_REPLICATION)
             .option(SparkWriteOptions.DELETE_FILE_REPLICATION)
             .defaultValue(SparkWriteOptions.DEFAULT_DELETE_FILE_REPLICATION)
             .parse();


### PR DESCRIPTION
### Changes

PR #219 added support for delete file replication from spark applications. This PR  adds support to configures the delete file replication factor through spark-sql properties.

### Tests

./gradlew clean && ./gradlew build