### PR TITLE
Backport mergeSchema changes to Spark3.1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -125,17 +125,16 @@ if (flinkVersions.contains("1.16")) {
   project(":iceberg-flink:flink-runtime-1.16").name = "iceberg-flink-runtime-1.16"
 }
 
-if (sparkVersions.contains("3.1")) {
-  include ':iceberg-spark:spark-3.1_2.12'
-  include ':iceberg-spark:spark-extensions-3.1_2.12'
-  include ':iceberg-spark:spark-runtime-3.1_2.12'
-  project(':iceberg-spark:spark-3.1_2.12').projectDir = file('spark/v3.1/spark')
-  project(':iceberg-spark:spark-3.1_2.12').name = 'iceberg-spark-3.1_2.12'
-  project(':iceberg-spark:spark-extensions-3.1_2.12').projectDir = file('spark/v3.1/spark-extensions')
-  project(':iceberg-spark:spark-extensions-3.1_2.12').name = 'iceberg-spark-extensions-3.1_2.12'
-  project(':iceberg-spark:spark-runtime-3.1_2.12').projectDir = file('spark/v3.1/spark-runtime')
-  project(':iceberg-spark:spark-runtime-3.1_2.12').name = 'iceberg-spark-runtime-3.1_2.12'
-}
+// Spark 3.1: always include for backport branch (spotless/build). Revert to "if (sparkVersions.contains(\"3.1\"))" for upstream.
+include ':iceberg-spark:spark-3.1_2.12'
+include ':iceberg-spark:spark-extensions-3.1_2.12'
+include ':iceberg-spark:spark-runtime-3.1_2.12'
+project(':iceberg-spark:spark-3.1_2.12').projectDir = file('spark/v3.1/spark')
+project(':iceberg-spark:spark-3.1_2.12').name = 'iceberg-spark-3.1_2.12'
+project(':iceberg-spark:spark-extensions-3.1_2.12').projectDir = file('spark/v3.1/spark-extensions')
+project(':iceberg-spark:spark-extensions-3.1_2.12').name = 'iceberg-spark-extensions-3.1_2.12'
+project(':iceberg-spark:spark-runtime-3.1_2.12').projectDir = file('spark/v3.1/spark-runtime')
+project(':iceberg-spark:spark-runtime-3.1_2.12').name = 'iceberg-spark-runtime-3.1_2.12'
 
 if (sparkVersions.contains("3.2")) {
   include ":iceberg-spark:spark-3.2_${scalaVersion}"

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.spark;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 
@@ -148,14 +150,14 @@ class SparkConfParser {
   }
 
   abstract class ConfParser<ThisT, T> {
-    private String optionName;
+    private final List<String> optionNames = Lists.newArrayList();
     private String sessionConfName;
     private String tablePropertyName;
 
     protected abstract ThisT self();
 
     public ThisT option(String name) {
-      this.optionName = name;
+      this.optionNames.add(name);
       return self();
     }
 
@@ -170,12 +172,14 @@ class SparkConfParser {
     }
 
     protected T parse(Function<String, T> conversion, T defaultValue) {
-      if (optionName != null) {
-        // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case
-        // map
-        String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
-        if (optionValue != null) {
-          return conversion.apply(optionValue);
+      if (!optionNames.isEmpty()) {
+        for (String optionName : optionNames) {
+          // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case
+          // map
+          String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
+          if (optionValue != null) {
+            return conversion.apply(optionValue);
+          }
         }
       }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -48,4 +48,8 @@ public class SparkSQLProperties {
 
   // Controls the spark input split size.
   public static final String SPLIT_SIZE = "spark.sql.iceberg.split-size";
+
+  // Controls whether to merge the DataFrame schema with the table schema on write
+  public static final String MERGE_SCHEMA = "spark.sql.iceberg.merge-schema";
+  public static final boolean MERGE_SCHEMA_DEFAULT = false;
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -195,6 +195,29 @@ public class SparkSchemaUtil {
   }
 
   /**
+   * Convert a Spark {@link StructType struct} to a {@link Schema} based on the given schema.
+   *
+   * <p>This conversion will assign new ids for fields that are not found in the base schema.
+   *
+   * <p>Data types, field order, and nullability will match the spark type. This conversion may
+   * return a schema that is not compatible with base schema.
+   *
+   * @param baseSchema a Schema on which conversion is based
+   * @param sparkType a Spark StructType
+   * @return the equivalent Schema
+   * @throws IllegalArgumentException if the type cannot be converted or there are missing ids
+   */
+  public static Schema convertWithFreshIds(Schema baseSchema, StructType sparkType) {
+    // convert to a type with fresh ids
+    Types.StructType struct =
+        SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType)).asStructType();
+    // reassign ids to match the base schema
+    Schema schema = TypeUtil.reassignOrRefreshIds(new Schema(struct.fields()), baseSchema);
+    // fix types that can't be represented in Spark (UUID and Fixed)
+    return SparkFixupTypes.fixup(schema, baseSchema);
+  }
+
+  /**
    * Prune columns from a {@link Schema} using a {@link StructType Spark type} projection.
    *
    * <p>This requires that the Spark type is a projection of the Schema. Nullability and types must

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -115,6 +115,15 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
+  public boolean mergeSchema() {
+    return confParser
+        .booleanConf()
+        .option(SparkWriteOptions.MERGE_SCHEMA)
+        .option(SparkWriteOptions.SPARK_MERGE_SCHEMA)
+        .defaultValue(SparkWriteOptions.MERGE_SCHEMA_DEFAULT)
+        .parse();
+  }
+
   public FileFormat dataFileFormat() {
     String valueAsString =
         confParser

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -120,6 +120,7 @@ public class SparkWriteConf {
         .booleanConf()
         .option(SparkWriteOptions.MERGE_SCHEMA)
         .option(SparkWriteOptions.SPARK_MERGE_SCHEMA)
+        .sessionConf(SparkSQLProperties.MERGE_SCHEMA)
         .defaultValue(SparkWriteOptions.MERGE_SCHEMA_DEFAULT)
         .parse();
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -52,4 +52,8 @@ public class SparkWriteOptions {
       "handle-timestamp-without-timezone";
 
   public static final String OVERWRITE_MODE = "overwrite-mode";
+
+  public static final String MERGE_SCHEMA = "merge-schema";
+  public static final String SPARK_MERGE_SCHEMA = "mergeSchema";
+  public static final boolean MERGE_SCHEMA_DEFAULT = false;
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.MetadataColumn;
@@ -90,10 +91,16 @@ public class SparkTable
           TableCapability.STREAMING_WRITE,
           TableCapability.OVERWRITE_BY_FILTER,
           TableCapability.OVERWRITE_DYNAMIC);
+  private static final Set<TableCapability> CAPABILITIES_WITH_ACCEPT_ANY_SCHEMA =
+      ImmutableSet.<TableCapability>builder()
+          .addAll(CAPABILITIES)
+          .add(TableCapability.ACCEPT_ANY_SCHEMA)
+          .build();
 
   private final Table icebergTable;
   private final Long snapshotId;
   private final boolean refreshEagerly;
+  private final Set<TableCapability> capabilities;
   private StructType lazyTableSchema = null;
   private SparkSession lazySpark = null;
 
@@ -105,6 +112,13 @@ public class SparkTable
     this.icebergTable = icebergTable;
     this.snapshotId = snapshotId;
     this.refreshEagerly = refreshEagerly;
+
+    boolean acceptAnySchema =
+        PropertyUtil.propertyAsBoolean(
+            icebergTable.properties(),
+            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA,
+            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
+    this.capabilities = acceptAnySchema ? CAPABILITIES_WITH_ACCEPT_ANY_SCHEMA : CAPABILITIES;
   }
 
   private SparkSession sparkSession() {
@@ -177,7 +191,7 @@ public class SparkTable
 
   @Override
   public Set<TableCapability> capabilities() {
-    return CAPABILITIES;
+    return capabilities;
   }
 
   @Override

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -105,6 +106,9 @@ class SparkWrite {
   private final StructType dsSchema;
   private final Map<String, String> extraSnapshotMetadata;
   private final boolean partitionedFanoutEnabled;
+  /** Pending schema update when mergeSchema was used; committed in commit() before data commit. */
+  private final UpdateSchema pendingSchemaUpdate;
+  private volatile boolean schemaUpdateCommitted = false;
 
   private boolean cleanupOnAbort = true;
 
@@ -117,6 +121,19 @@ class SparkWrite {
       String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
+    this(spark, table, writeConf, writeInfo, applicationId, applicationName, writeSchema, dsSchema, null);
+  }
+
+  SparkWrite(
+      SparkSession spark,
+      Table table,
+      SparkWriteConf writeConf,
+      LogicalWriteInfo writeInfo,
+      String applicationId,
+      String applicationName,
+      Schema writeSchema,
+      StructType dsSchema,
+      UpdateSchema pendingSchemaUpdate) {
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     this.table = table;
     this.queryId = writeInfo.queryId();
@@ -130,6 +147,16 @@ class SparkWrite {
     this.dsSchema = dsSchema;
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
+    this.pendingSchemaUpdate = pendingSchemaUpdate;
+  }
+
+  /** Commits the pending schema update (mergeSchema) if present. Called before data commit. */
+  private void commitPendingSchemaUpdate() {
+    if (pendingSchemaUpdate != null && !schemaUpdateCommitted) {
+      LOG.info("Committing schema update (mergeSchema) to table {}", table.name());
+      pendingSchemaUpdate.commit();
+      schemaUpdateCommitted = true;
+    }
   }
 
   BatchWrite asBatchAppend() {
@@ -262,6 +289,7 @@ class SparkWrite {
   private class BatchAppend extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       AppendFiles append = table.newAppend();
 
       int numFiles = 0;
@@ -277,6 +305,7 @@ class SparkWrite {
   private class DynamicOverwrite extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       Iterable<DataFile> files = files(messages);
 
       if (!files.iterator().hasNext()) {
@@ -307,6 +336,7 @@ class SparkWrite {
 
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       OverwriteFiles overwriteFiles = table.newOverwrite();
       overwriteFiles.overwriteByRowFilter(overwriteExpr);
 
@@ -350,6 +380,7 @@ class SparkWrite {
 
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       OverwriteFiles overwriteFiles = table.newOverwrite();
 
       List<DataFile> overwrittenFiles = overwrittenFiles();
@@ -420,6 +451,7 @@ class SparkWrite {
 
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
 
       Set<DataFile> newDataFiles = Sets.newHashSetWithExpectedSize(messages.length);
@@ -500,6 +532,7 @@ class SparkWrite {
 
     @Override
     protected void doCommit(long epochId, WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       AppendFiles append = table.newFastAppend();
       int numFiles = 0;
       for (DataFile file : files(messages)) {
@@ -518,6 +551,7 @@ class SparkWrite {
 
     @Override
     public void doCommit(long epochId, WriterCommitMessage[] messages) {
+      commitPendingSchemaUpdate();
       OverwriteFiles overwriteFiles = table.newOverwrite();
       overwriteFiles.overwriteByRowFilter(Expressions.alwaysTrue());
       int numFiles = 0;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -108,6 +108,7 @@ class SparkWrite {
   private final boolean partitionedFanoutEnabled;
   /** Pending schema update when mergeSchema was used; committed in commit() before data commit. */
   private final UpdateSchema pendingSchemaUpdate;
+
   private volatile boolean schemaUpdateCommitted = false;
 
   private boolean cleanupOnAbort = true;
@@ -121,7 +122,16 @@ class SparkWrite {
       String applicationName,
       Schema writeSchema,
       StructType dsSchema) {
-    this(spark, table, writeConf, writeInfo, applicationId, applicationName, writeSchema, dsSchema, null);
+    this(
+        spark,
+        table,
+        writeConf,
+        writeInfo,
+        applicationId,
+        applicationName,
+        writeSchema,
+        dsSchema,
+        null);
   }
 
   SparkWrite(

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -110,7 +110,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         handleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
         SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
 
-    Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
+    WriteSchemaResult schemaResult = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
     // Get application id and name
@@ -118,7 +118,16 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     String appName = spark.sparkContext().appName();
 
     SparkWrite write =
-        new SparkWrite(spark, table, writeConf, writeInfo, appId, appName, writeSchema, dsSchema);
+        new SparkWrite(
+            spark,
+            table,
+            writeConf,
+            writeInfo,
+            appId,
+            appName,
+            schemaResult.writeSchema,
+            dsSchema,
+            schemaResult.pendingSchemaUpdate);
     if (overwriteByFilter) {
       return write.asOverwriteByFilter(overwriteExpr);
     } else if (overwriteDynamic) {
@@ -137,7 +146,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         handleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
         SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
 
-    Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
+    WriteSchemaResult schemaResult = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
     // Change to streaming write if it is just append
@@ -153,7 +162,16 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     String appName = spark.sparkContext().appName();
 
     SparkWrite write =
-        new SparkWrite(spark, table, writeConf, writeInfo, appId, appName, writeSchema, dsSchema);
+        new SparkWrite(
+            spark,
+            table,
+            writeConf,
+            writeInfo,
+            appId,
+            appName,
+            schemaResult.writeSchema,
+            dsSchema,
+            schemaResult.pendingSchemaUpdate);
     if (overwriteByFilter) {
       return write.asStreamingOverwrite();
     } else {
@@ -161,31 +179,47 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     }
   }
 
-  private static Schema validateOrMergeWriteSchema(
+  /**
+   * Result of schema validation/merge: the write schema to use and an optional pending schema
+   * update. When mergeSchema is used, the update is not committed during planning; it is committed
+   * in the write's commit() phase so that schema and data are committed only after data files are
+   * written. This avoids leaving the table with an advanced schema but no new data if the job fails
+   * after planning (e.g. OOM in executors).
+   */
+  private static class WriteSchemaResult {
+    final Schema writeSchema;
+    final UpdateSchema pendingSchemaUpdate;
+
+    WriteSchemaResult(Schema writeSchema, UpdateSchema pendingSchemaUpdate) {
+      this.writeSchema = writeSchema;
+      this.pendingSchemaUpdate = pendingSchemaUpdate;
+    }
+  }
+
+  private static WriteSchemaResult validateOrMergeWriteSchema(
       Table table, StructType dsSchema, SparkWriteConf writeConf) {
-    Schema writeSchema;
     if (writeConf.mergeSchema()) {
       // convert the dataset schema and assign fresh ids for new fields
       Schema newSchema = SparkSchemaUtil.convertWithFreshIds(table.schema(), dsSchema);
 
-      // update the table to get final id assignments and validate the changes
+      // prepare schema update and get final id assignments and merged schema (do NOT commit yet)
       UpdateSchema update = table.updateSchema().unionByNameWith(newSchema);
       Schema mergedSchema = update.apply();
 
       // reconvert the dsSchema without assignment to use the ids assigned by UpdateSchema
-      writeSchema = SparkSchemaUtil.convert(mergedSchema, dsSchema);
+      Schema writeSchema = SparkSchemaUtil.convert(mergedSchema, dsSchema);
 
       TypeUtil.validateWriteSchema(
           mergedSchema, writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
 
-      // if the validation passed, update the table schema
-      update.commit();
+      // Defer commit to write commit phase so schema and data are only committed after data
+      // files are written. If the job fails after planning (e.g. OOM), the table schema is unchanged.
+      return new WriteSchemaResult(writeSchema, update);
     } else {
-      writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
+      Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
       TypeUtil.validateWriteSchema(
           table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
+      return new WriteSchemaResult(writeSchema, null);
     }
-
-    return writeSchema;
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -213,7 +213,8 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
           mergedSchema, writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
 
       // Defer commit to write commit phase so schema and data are only committed after data
-      // files are written. If the job fails after planning (e.g. OOM), the table schema is unchanged.
+      // files are written. If the job fails after planning (e.g. OOM), the table schema is
+      // unchanged.
       return new WriteSchemaResult(writeSchema, update);
     } else {
       Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -125,9 +125,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
             writeInfo,
             appId,
             appName,
-            schemaResult.writeSchema,
+            schemaResult.writeSchema(),
             dsSchema,
-            schemaResult.pendingSchemaUpdate);
+            schemaResult.pendingSchemaUpdate());
     if (overwriteByFilter) {
       return write.asOverwriteByFilter(overwriteExpr);
     } else if (overwriteDynamic) {
@@ -169,9 +169,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
             writeInfo,
             appId,
             appName,
-            schemaResult.writeSchema,
+            schemaResult.writeSchema(),
             dsSchema,
-            schemaResult.pendingSchemaUpdate);
+            schemaResult.pendingSchemaUpdate());
     if (overwriteByFilter) {
       return write.asStreamingOverwrite();
     } else {
@@ -187,12 +187,20 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
    * after planning (e.g. OOM in executors).
    */
   private static class WriteSchemaResult {
-    final Schema writeSchema;
-    final UpdateSchema pendingSchemaUpdate;
+    private final Schema writeSchema;
+    private final UpdateSchema pendingSchemaUpdate;
 
     WriteSchemaResult(Schema writeSchema, UpdateSchema pendingSchemaUpdate) {
       this.writeSchema = writeSchema;
       this.pendingSchemaUpdate = pendingSchemaUpdate;
+    }
+
+    Schema writeSchema() {
+      return this.writeSchema;
+    }
+
+    UpdateSchema pendingSchemaUpdate() {
+      return this.pendingSchemaUpdate;
     }
   }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -109,9 +110,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         handleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
         SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
 
-    Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
-    TypeUtil.validateWriteSchema(
-        table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
+    Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
     // Get application id and name
@@ -138,9 +137,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         handleTimestampWithoutZone || !SparkUtil.hasTimestampWithoutZone(table.schema()),
         SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
 
-    Schema writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
-    TypeUtil.validateWriteSchema(
-        table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
+    Schema writeSchema = validateOrMergeWriteSchema(table, dsSchema, writeConf);
     SparkUtil.validatePartitionTransforms(table.spec());
 
     // Change to streaming write if it is just append
@@ -162,5 +159,33 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     } else {
       return write.asStreamingAppend();
     }
+  }
+
+  private static Schema validateOrMergeWriteSchema(
+      Table table, StructType dsSchema, SparkWriteConf writeConf) {
+    Schema writeSchema;
+    if (writeConf.mergeSchema()) {
+      // convert the dataset schema and assign fresh ids for new fields
+      Schema newSchema = SparkSchemaUtil.convertWithFreshIds(table.schema(), dsSchema);
+
+      // update the table to get final id assignments and validate the changes
+      UpdateSchema update = table.updateSchema().unionByNameWith(newSchema);
+      Schema mergedSchema = update.apply();
+
+      // reconvert the dsSchema without assignment to use the ids assigned by UpdateSchema
+      writeSchema = SparkSchemaUtil.convert(mergedSchema, dsSchema);
+
+      TypeUtil.validateWriteSchema(
+          mergedSchema, writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
+
+      // if the validation passed, update the table schema
+      update.commit();
+    } else {
+      writeSchema = SparkSchemaUtil.convert(table.schema(), dsSchema);
+      TypeUtil.validateWriteSchema(
+          table.schema(), writeSchema, writeConf.checkNullability(), writeConf.checkOrdering());
+    }
+
+    return writeSchema;
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ui.SQLExecutionUIData;
@@ -255,6 +257,11 @@ public abstract class SparkTestBase {
             .filter(x -> metricsIds.containsKey(x.getKey()))
             .collect(Collectors.toMap(x -> metricsIds.get(x.getKey()), x -> x.getValue()));
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
+  }
+
+  protected Dataset<Row> jsonToDF(String schema, String... records) {
+    Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
+    return spark.read().schema(schema).json(jsonDF);
   }
 
   @FunctionalInterface

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
@@ -183,5 +184,97 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
         ImmutableList.of(
             row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
         sql("select * from %s order by id", tableName));
+  }
+
+  @Test
+  public void testMergeSchemaSessionConf() throws Exception {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
+        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    try {
+      spark.conf().set(SparkSQLProperties.MERGE_SCHEMA, "true");
+
+      Dataset<Row> threeColDF =
+          jsonToDF(
+              "id bigint, data string, new_col float",
+              "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+              "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+      // Append without passing merge-schema option; session conf should enable it
+      threeColDF.writeTo(tableName).append();
+
+      assertEquals(
+          "Should have 3-column rows when merge-schema is set via session conf",
+          ImmutableList.of(
+              row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
+          sql("select * from %s order by id", tableName));
+    } finally {
+      spark.conf().unset(SparkSQLProperties.MERGE_SCHEMA);
+    }
+  }
+
+  /**
+   * Validates that when a column exists in both the table and the DataFrame but with incompatible
+   * types, the write fails both with and without mergeSchema. mergeSchema only adds new columns or
+   * widens nullability; it does not allow changing an existing column to an incompatible type.
+   */
+  @Test
+  public void testMergeSchemaIncompatibleTypeExistingColumn() throws Exception {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
+        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    // Table has: id bigint, data string
+    Dataset<Row> initialDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+    initialDF.writeTo(tableName).append();
+
+    // DataFrame has same column name "data" but incompatible type (int instead of string)
+    Dataset<Row> incompatibleTypeDF =
+        jsonToDF(
+            "id bigint, data int",
+            "{ \"id\": 3, \"data\": 10 }",
+            "{ \"id\": 4, \"data\": 20 }");
+
+    AssertHelpers.assertThrows(
+        "Write with incompatible type for existing column should fail when mergeSchema is disabled",
+        Exception.class,
+        null, // message may vary (e.g. type mismatch, schema, incompatible)
+        () -> {
+          try {
+            incompatibleTypeDF.writeTo(tableName).append();
+          } catch (NoSuchTableException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    AssertHelpers.assertThrows(
+        "Write with incompatible type for existing column should fail when mergeSchema is enabled",
+        Exception.class,
+        null,
+        () -> {
+          try {
+            incompatibleTypeDF.writeTo(tableName).option("merge-schema", "true").append();
+          } catch (NoSuchTableException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
+  @Before
+  public void createTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
+        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF =
+        jsonToDF(
+            "id bigint, data string, new_col float",
+            "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+            "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    // this has a different error message than the case without accept-any-schema because it uses
+    // Iceberg checks
+    AssertHelpers.assertThrows(
+        "Should fail when merge-schema is not enabled on the writer",
+        IllegalArgumentException.class,
+        "Field new_col not found in source schema",
+        () -> {
+          try {
+            threeColDF.writeTo(tableName).append();
+          } catch (NoSuchTableException e) {
+            // needed because append has checked exceptions
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  public void testMergeSchemaWithoutAcceptAnySchema() throws Exception {
+    Dataset<Row> twoColDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF =
+        jsonToDF(
+            "id bigint, data string, new_col float",
+            "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+            "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    AssertHelpers.assertThrows(
+        "Should fail when accept-any-schema is not enabled on the table",
+        AnalysisException.class,
+        "too many data columns",
+        () -> {
+          try {
+            threeColDF.writeTo(tableName).option("merge-schema", "true").append();
+          } catch (NoSuchTableException e) {
+            // needed because append has checked exceptions
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  public void testMergeSchemaSparkProperty() throws Exception {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
+        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF =
+        jsonToDF(
+            "id bigint, data string, new_col float",
+            "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+            "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    threeColDF.writeTo(tableName).option("mergeSchema", "true").append();
+
+    assertEquals(
+        "Should have 3-column rows",
+        ImmutableList.of(
+            row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
+        sql("select * from %s order by id", tableName));
+  }
+
+  @Test
+  public void testMergeSchemaIcebergProperty() throws Exception {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
+        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF =
+        jsonToDF(
+            "id bigint, data string",
+            "{ \"id\": 1, \"data\": \"a\" }",
+            "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals(
+        "Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF =
+        jsonToDF(
+            "id bigint, data string, new_col float",
+            "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+            "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    threeColDF.writeTo(tableName).option("merge-schema", "true").append();
+
+    assertEquals(
+        "Should have 3-column rows",
+        ImmutableList.of(
+            row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
+        sql("select * from %s order by id", tableName));
+  }
+}
+

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -249,9 +249,7 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
     // DataFrame has same column name "data" but incompatible type (int instead of string)
     Dataset<Row> incompatibleTypeDF =
         jsonToDF(
-            "id bigint, data int",
-            "{ \"id\": 3, \"data\": 10 }",
-            "{ \"id\": 4, \"data\": 20 }");
+            "id bigint, data int", "{ \"id\": 3, \"data\": 10 }", "{ \"id\": 4, \"data\": 20 }");
 
     AssertHelpers.assertThrows(
         "Write with incompatible type for existing column should fail when mergeSchema is disabled",

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -185,4 +185,3 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
         sql("select * from %s order by id", tableName));
   }
 }
-


### PR DESCRIPTION
Implement MergeSchema Feature in Spark v3.1. This helps us in the following way using DaliSpark:

Writing a DF with binary field to an Iceberg table with Fixed field
Writing a DF with nullable field (with non-null data) to an Iceberg table with Required field
Writing a DF with Required field to an Iceberg table with Nullable field

E2E Testing done - https://docs.google.com/document/d/1dLaALEgS0N9BPDzuhOae9dXRNrYK_Ktdec6nwceoUWQ

Ticket - https://linkedin.atlassian.net/browse/BDP-70583