### PR TITLE
Add app-name to EnvironmentContext for audit event metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -140,6 +140,7 @@ public class CatalogProperties {
   public static final String LOCK_TABLE = "lock.table";
 
   public static final String APP_ID = "app-id";
+  public static final String APP_NAME = "app-name";
   public static final String USER = "user";
 
   /**

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -491,6 +491,7 @@ public class SparkCatalog extends BaseCatalog {
     EnvironmentContext.put(
         EnvironmentContext.ENGINE_VERSION, sparkSession.sparkContext().version());
     EnvironmentContext.put(CatalogProperties.APP_ID, sparkSession.sparkContext().applicationId());
+    EnvironmentContext.put(CatalogProperties.APP_NAME, sparkSession.sparkContext().appName());
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -490,6 +490,7 @@ public class SparkCatalog extends BaseCatalog {
     EnvironmentContext.put(
         EnvironmentContext.ENGINE_VERSION, sparkSession.sparkContext().version());
     EnvironmentContext.put(CatalogProperties.APP_ID, sparkSession.sparkContext().applicationId());
+    EnvironmentContext.put(CatalogProperties.APP_NAME, sparkSession.sparkContext().appName());
   }
 
   @Override

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -654,6 +656,22 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Data after compaction should not change", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testEnvironmentContextContainsAppName() {
+    // Trigger catalog initialization by creating a table
+    createTable();
+
+    Map<String, String> env = EnvironmentContext.get();
+    assertThat(env)
+        .containsKey(CatalogProperties.APP_ID)
+        .containsKey(CatalogProperties.APP_NAME)
+        .containsEntry(EnvironmentContext.ENGINE_NAME, "spark")
+        .hasEntrySatisfying(
+            EnvironmentContext.ENGINE_VERSION, v -> assertThat(v).startsWith("3.3"));
+
+    assertThat(env.get(CatalogProperties.APP_NAME)).isNotEmpty();
   }
 
   private void createTable() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -556,6 +556,7 @@ public class SparkCatalog extends BaseCatalog {
     EnvironmentContext.put(
         EnvironmentContext.ENGINE_VERSION, sparkSession.sparkContext().version());
     EnvironmentContext.put(CatalogProperties.APP_ID, sparkSession.sparkContext().applicationId());
+    EnvironmentContext.put(CatalogProperties.APP_NAME, sparkSession.sparkContext().appName());
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Adds `APP_NAME` constant (`"app-name"`) to `CatalogProperties`, following the existing `APP_ID` pattern
- Sets `app-name` from `sparkSession.sparkContext().appName()` in `EnvironmentContext` during `SparkCatalog.initialize()` for Spark v3.1, v3.2, and v3.3
- Enables downstream audit events (`service.openhouseauditeventcommit`) to include the human-readable application name in their metadata map, allowing easy filtering of maintenance operations (compaction, purging, retention) from user commits without expensive multi-table joins
- **No changes needed in li-openhouse** — the existing code already copies the full `CommitReport.metadata()` map into the audit event

### Data Flow
```
SparkCatalog.initialize()
  → EnvironmentContext.put("app-name", sparkSession.sparkContext().appName())  ← NEW
  → SnapshotProducer → CommitReport.metadata()
    → LiOpenHouseMetricsReporter.report()
      → OpenHouseReportKafkaPublish.toCommitAuditEvent()
        → copies commitReport.metadata() into event.setMetadata()  ← ALREADY EXISTS
          → Kafka → service.openhouseauditeventcommit
```

### Design Decision
Uses `app-name` (not `spark.app.name`) to follow the existing kebab-case, engine-agnostic convention (`app-id`, `engine-name`, `engine-version`).

## Testing Done
- [x] Build verification: `./gradlew :iceberg-spark:iceberg-spark-3.1:compileJava :iceberg-spark:iceberg-spark-3.2:compileJava :iceberg-spark:iceberg-spark-3.3:compileJava :iceberg-core:compileJava` — passes
- [ ] Post-deploy Trino verification query against `service.openhouseauditeventcommit`