### PR TITLE
Suppress file deletion errors during Spark write abort

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -20,14 +20,6 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.IsolationLevel.SERIALIZABLE;
 import static org.apache.iceberg.IsolationLevel.SNAPSHOT;
-import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -69,7 +61,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
@@ -92,6 +83,11 @@ import org.slf4j.LoggerFactory;
 
 class SparkWrite {
   private static final Logger LOG = LoggerFactory.getLogger(SparkWrite.class);
+
+  private static final int DELETE_NUM_RETRIES = 3;
+  private static final int DELETE_MIN_RETRY_WAIT_MS = 100; // 100 ms
+  private static final int DELETE_MAX_RETRY_WAIT_MS = 30 * 1000; // 30 seconds
+  private static final int DELETE_TOTAL_RETRY_TIME_MS = 2 * 60 * 1000; // 2 minutes
 
   private final JavaSparkContext sparkContext;
   private final Table table;
@@ -244,18 +240,16 @@ class SparkWrite {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      Map<String, String> props = table.properties();
       Tasks.foreach(files(messages))
-          .retry(PropertyUtil.propertyAsInt(props, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .retry(DELETE_NUM_RETRIES)
           .exponentialBackoff(
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              DELETE_MIN_RETRY_WAIT_MS,
+              DELETE_MAX_RETRY_WAIT_MS,
+              DELETE_TOTAL_RETRY_TIME_MS,
               2.0 /* exponential */)
-          .throwFailureWhenFinished()
+          .suppressFailureWhenFinished()
+          .onFailure(
+              (file, exc) -> LOG.warn("Failed to delete {} during job abort", file.path(), exc))
           .run(
               file -> {
                 table.io().deleteFile(file.path().toString());
@@ -668,8 +662,15 @@ class SparkWrite {
 
   private static <T extends ContentFile<T>> void deleteFiles(FileIO io, List<T> files) {
     Tasks.foreach(files)
-        .throwFailureWhenFinished()
-        .noRetry()
+        .suppressFailureWhenFinished()
+        .retry(DELETE_NUM_RETRIES)
+        .exponentialBackoff(
+            DELETE_MIN_RETRY_WAIT_MS,
+            DELETE_MAX_RETRY_WAIT_MS,
+            DELETE_TOTAL_RETRY_TIME_MS,
+            2.0 /* exponential */)
+        .onFailure(
+            (file, exc) -> LOG.warn("Failed to delete {} during task abort", file.path(), exc))
         .run(file -> io.deleteFile(file.path().toString()));
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -670,9 +670,7 @@ public class TestSparkDataWrite {
     // so cleanupOnAbort stays true and abort will attempt file deletion)
     AppendFiles append = table.newAppend();
     AppendFiles spyAppend = spy(append);
-    doThrow(new RuntimeException("Simulated commit failure"))
-        .when(spyAppend)
-        .commit();
+    doThrow(new RuntimeException("Simulated commit failure")).when(spyAppend).commit();
 
     // Make file deletion also fail during abort to verify the delete failure
     // is suppressed and does not mask the original commit failure

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +42,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkWriteOptions;
@@ -646,6 +649,62 @@ public class TestSparkDataWrite {
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", records.size(), actual.size());
     Assert.assertEquals("Result rows should match", records, actual);
+  }
+
+  @Test
+  public void testAbortDeleteFailureDoesNotMaskCommitFailure() throws IOException {
+    File parent = temp.newFolder(format.toString());
+    File location = new File(parent, "abort_suppress");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+
+    // Make commit fail with a RuntimeException (not CommitStateUnknownException,
+    // so cleanupOnAbort stays true and abort will attempt file deletion)
+    AppendFiles append = table.newAppend();
+    AppendFiles spyAppend = spy(append);
+    doThrow(new RuntimeException("Simulated commit failure"))
+        .when(spyAppend)
+        .commit();
+
+    // Make file deletion also fail during abort to verify the delete failure
+    // is suppressed and does not mask the original commit failure
+    Table spyTable = spy(table);
+    when(spyTable.newAppend()).thenReturn(spyAppend);
+    FileIO spyIO = spy(table.io());
+    doThrow(new RuntimeException("Simulated HDFS delete failure"))
+        .when(spyIO)
+        .deleteFile(anyString());
+    when(spyTable.io()).thenReturn(spyIO);
+
+    SparkTable sparkTable = new SparkTable(spyTable, false);
+    String manualTableName = "abort_delete_suppress";
+    ManualSource.setTable(manualTableName, sparkTable);
+
+    // The write should fail with the original commit failure.
+    // With suppressFailureWhenFinished() in abort, delete failures are logged
+    // at WARN level but suppressed, allowing the original commit failure to surface.
+    AssertHelpers.assertThrowsWithCause(
+        "Should throw the original commit failure, not the delete failure from abort",
+        SparkException.class,
+        "Writing job aborted",
+        RuntimeException.class,
+        "Simulated commit failure",
+        () ->
+            df.select("id", "data")
+                .sort("data")
+                .write()
+                .format("org.apache.iceberg.spark.source.ManualSource")
+                .option(ManualSource.TABLE_NAME, manualTableName)
+                .mode(SaveMode.Append)
+                .save(location.toString()));
   }
 
   public enum IcebergOptionsType {


### PR DESCRIPTION
Suppress file deletion errors during abort to prevent masking original commit failure

Previously, both the driver-level and task-level abort paths used throwFailureWhenFinished(), causing HDFS delete errors (e.g. RemoteException) to propagate to the user and mask the original commit failure. This also meant task-level deletes had no retries, so transient failures left orphan files.

Now both paths suppress delete exceptions (logging each at WARN level) and the task-level path retries up to 3 times with exponential backoff, aligning with the Spark 3.5 implementation.

This change is impl of the same behavior from iceberg1.5.2 for spark3.5: https://github.com/linkedin/iceberg/blob/c9c41c46fbf5102b657e53981b1ec534010338a7/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java#L118