### PR TITLE
Suppress file deletion errors during Spark write abort

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -296,6 +296,10 @@ public class TableProperties {
   public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
   public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
+  public static final String WRITE_ABORT_SUPPRESS_DELETE_FAILURES =
+      "write.abort.suppress-delete-failures";
+  public static final boolean WRITE_ABORT_SUPPRESS_DELETE_FAILURES_DEFAULT = true;
+
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED =
       "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -20,14 +20,6 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.IsolationLevel.SERIALIZABLE;
 import static org.apache.iceberg.IsolationLevel.SNAPSHOT;
-import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
-import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -69,7 +61,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
@@ -92,6 +83,11 @@ import org.slf4j.LoggerFactory;
 
 class SparkWrite {
   private static final Logger LOG = LoggerFactory.getLogger(SparkWrite.class);
+
+  private static final int DELETE_NUM_RETRIES = 3;
+  private static final int DELETE_MIN_RETRY_WAIT_MS = 100; // 100 ms
+  private static final int DELETE_MAX_RETRY_WAIT_MS = 30 * 1000; // 30 seconds
+  private static final int DELETE_TOTAL_RETRY_TIME_MS = 2 * 60 * 1000; // 2 minutes
 
   private final JavaSparkContext sparkContext;
   private final Table table;
@@ -244,18 +240,16 @@ class SparkWrite {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      Map<String, String> props = table.properties();
       Tasks.foreach(files(messages))
-          .retry(PropertyUtil.propertyAsInt(props, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .retry(DELETE_NUM_RETRIES)
           .exponentialBackoff(
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              DELETE_MIN_RETRY_WAIT_MS,
+              DELETE_MAX_RETRY_WAIT_MS,
+              DELETE_TOTAL_RETRY_TIME_MS,
               2.0 /* exponential */)
-          .throwFailureWhenFinished()
+          .suppressFailureWhenFinished()
+          .onFailure(
+              (file, exc) -> LOG.warn("Failed to delete {} during job abort", file.path(), exc))
           .run(
               file -> {
                 table.io().deleteFile(file.path().toString());
@@ -668,8 +662,15 @@ class SparkWrite {
 
   private static <T extends ContentFile<T>> void deleteFiles(FileIO io, List<T> files) {
     Tasks.foreach(files)
-        .throwFailureWhenFinished()
-        .noRetry()
+        .suppressFailureWhenFinished()
+        .retry(DELETE_NUM_RETRIES)
+        .exponentialBackoff(
+            DELETE_MIN_RETRY_WAIT_MS,
+            DELETE_MAX_RETRY_WAIT_MS,
+            DELETE_TOTAL_RETRY_TIME_MS,
+            2.0 /* exponential */)
+        .onFailure(
+            (file, exc) -> LOG.warn("Failed to delete {} during task abort", file.path(), exc))
         .run(file -> io.deleteFile(file.path().toString()));
   }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.IsolationLevel.SERIALIZABLE;
 import static org.apache.iceberg.IsolationLevel.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.WRITE_ABORT_SUPPRESS_DELETE_FAILURES;
+import static org.apache.iceberg.TableProperties.WRITE_ABORT_SUPPRESS_DELETE_FAILURES_DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -61,6 +63,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
@@ -240,20 +243,27 @@ class SparkWrite {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      Tasks.foreach(files(messages))
-          .retry(DELETE_NUM_RETRIES)
-          .exponentialBackoff(
-              DELETE_MIN_RETRY_WAIT_MS,
-              DELETE_MAX_RETRY_WAIT_MS,
-              DELETE_TOTAL_RETRY_TIME_MS,
-              2.0 /* exponential */)
-          .suppressFailureWhenFinished()
-          .onFailure(
-              (file, exc) -> LOG.warn("Failed to delete {} during job abort", file.path(), exc))
-          .run(
-              file -> {
-                table.io().deleteFile(file.path().toString());
-              });
+      boolean suppressFailures =
+          PropertyUtil.propertyAsBoolean(
+              table.properties(),
+              WRITE_ABORT_SUPPRESS_DELETE_FAILURES,
+              WRITE_ABORT_SUPPRESS_DELETE_FAILURES_DEFAULT);
+      Tasks.Builder<DataFile> builder =
+          Tasks.foreach(files(messages))
+              .retry(DELETE_NUM_RETRIES)
+              .exponentialBackoff(
+                  DELETE_MIN_RETRY_WAIT_MS,
+                  DELETE_MAX_RETRY_WAIT_MS,
+                  DELETE_TOTAL_RETRY_TIME_MS,
+                  2.0 /* exponential */)
+              .onFailure(
+                  (file, exc) -> LOG.warn("Failed to delete {} during job abort", file.path(), exc));
+      if (suppressFailures) {
+        builder.suppressFailureWhenFinished();
+      } else {
+        builder.throwFailureWhenFinished();
+      }
+      builder.run(file -> table.io().deleteFile(file.path().toString()));
     } else {
       LOG.warn(
           "Skipping cleaning up of data files because Iceberg was unable to determine the final commit state");
@@ -633,6 +643,11 @@ class SparkWrite {
       Table table = tableBroadcast.value();
       PartitionSpec spec = table.spec();
       FileIO io = table.io();
+      boolean suppressAbortDeleteFailures =
+          PropertyUtil.propertyAsBoolean(
+              table.properties(),
+              WRITE_ABORT_SUPPRESS_DELETE_FAILURES,
+              WRITE_ABORT_SUPPRESS_DELETE_FAILURES_DEFAULT);
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId).format(format).build();
@@ -644,7 +659,8 @@ class SparkWrite {
               .build();
 
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
+        return new UnpartitionedDataWriter(
+            writerFactory, fileFactory, io, spec, targetFileSize, suppressAbortDeleteFailures);
 
       } else {
         return new PartitionedDataWriter(
@@ -655,38 +671,43 @@ class SparkWrite {
             writeSchema,
             dsSchema,
             targetFileSize,
-            partitionedFanoutEnabled);
+            partitionedFanoutEnabled,
+            suppressAbortDeleteFailures);
       }
     }
   }
 
-  private static <T extends ContentFile<T>> void deleteFiles(FileIO io, List<T> files) {
-    Tasks.foreach(files)
-        .suppressFailureWhenFinished()
-        .retry(DELETE_NUM_RETRIES)
-        .exponentialBackoff(
-            DELETE_MIN_RETRY_WAIT_MS,
-            DELETE_MAX_RETRY_WAIT_MS,
-            DELETE_TOTAL_RETRY_TIME_MS,
-            2.0 /* exponential */)
-        .onFailure(
-            (file, exc) -> LOG.warn("Failed to delete {} during task abort", file.path(), exc))
-        .run(file -> io.deleteFile(file.path().toString()));
+  private static <T extends ContentFile<T>> void deleteFiles(
+      FileIO io, List<T> files, boolean suppressFailures) {
+    Tasks.Builder<T> builder =
+        Tasks.foreach(files)
+            .noRetry()
+            .onFailure(
+                (file, exc) -> LOG.warn("Failed to delete {} during task abort", file.path(), exc));
+    if (suppressFailures) {
+      builder.suppressFailureWhenFinished();
+    } else {
+      builder.throwFailureWhenFinished();
+    }
+    builder.run(file -> io.deleteFile(file.path().toString()));
   }
 
   private static class UnpartitionedDataWriter implements DataWriter<InternalRow> {
     private final FileWriter<InternalRow, DataWriteResult> delegate;
     private final FileIO io;
+    private final boolean suppressAbortDeleteFailures;
 
     private UnpartitionedDataWriter(
         SparkFileWriterFactory writerFactory,
         OutputFileFactory fileFactory,
         FileIO io,
         PartitionSpec spec,
-        long targetFileSize) {
+        long targetFileSize,
+        boolean suppressAbortDeleteFailures) {
       this.delegate =
           new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
+      this.suppressAbortDeleteFailures = suppressAbortDeleteFailures;
     }
 
     @Override
@@ -709,7 +730,7 @@ class SparkWrite {
       close();
 
       DataWriteResult result = delegate.result();
-      deleteFiles(io, result.dataFiles());
+      deleteFiles(io, result.dataFiles(), suppressAbortDeleteFailures);
     }
 
     @Override
@@ -724,6 +745,7 @@ class SparkWrite {
     private final PartitionSpec spec;
     private final PartitionKey partitionKey;
     private final InternalRowWrapper internalRowWrapper;
+    private final boolean suppressAbortDeleteFailures;
 
     private PartitionedDataWriter(
         SparkFileWriterFactory writerFactory,
@@ -733,7 +755,8 @@ class SparkWrite {
         Schema dataSchema,
         StructType dataSparkType,
         long targetFileSize,
-        boolean fanoutEnabled) {
+        boolean fanoutEnabled,
+        boolean suppressAbortDeleteFailures) {
       if (fanoutEnabled) {
         this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       } else {
@@ -743,6 +766,7 @@ class SparkWrite {
       this.spec = spec;
       this.partitionKey = new PartitionKey(spec, dataSchema);
       this.internalRowWrapper = new InternalRowWrapper(dataSparkType);
+      this.suppressAbortDeleteFailures = suppressAbortDeleteFailures;
     }
 
     @Override
@@ -766,7 +790,7 @@ class SparkWrite {
       close();
 
       DataWriteResult result = delegate.result();
-      deleteFiles(io, result.dataFiles());
+      deleteFiles(io, result.dataFiles(), suppressAbortDeleteFailures);
     }
 
     @Override

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -257,7 +257,8 @@ class SparkWrite {
                   DELETE_TOTAL_RETRY_TIME_MS,
                   2.0 /* exponential */)
               .onFailure(
-                  (file, exc) -> LOG.warn("Failed to delete {} during job abort", file.path(), exc));
+                  (file, exc) ->
+                      LOG.warn("Failed to delete {} during job abort", file.path(), exc));
       if (suppressFailures) {
         builder.suppressFailureWhenFinished();
       } else {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -686,22 +688,39 @@ public class TestSparkDataWrite {
     String manualTableName = "abort_delete_propagate";
     ManualSource.setTable(manualTableName, sparkTable);
 
-    // With suppression disabled, the delete failure during abort surfaces as the cause
-    // instead of the original commit failure.
-    AssertHelpers.assertThrowsWithCause(
-        "Should throw the delete failure when suppression is disabled",
-        SparkException.class,
-        "Writing job aborted",
-        RuntimeException.class,
-        "Simulated HDFS delete failure",
-        () ->
-            df.select("id", "data")
-                .sort("data")
-                .write()
-                .format("org.apache.iceberg.spark.source.ManualSource")
-                .option(ManualSource.TABLE_NAME, manualTableName)
-                .mode(SaveMode.Append)
-                .save(location.toString()));
+    // With suppression disabled, the abort itself throws the delete failure. Spark wraps the
+    // original commit failure as the cause and adds the abort exception to the cause's
+    // suppressed list, then throws SparkException("Writing job failed.", commitFailure).
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                df.select("id", "data")
+                    .sort("data")
+                    .write()
+                    .format("org.apache.iceberg.spark.source.ManualSource")
+                    .option(ManualSource.TABLE_NAME, manualTableName)
+                    .mode(SaveMode.Append)
+                    .save(location.toString()));
+
+    assertThat(thrown)
+        .isInstanceOf(SparkException.class)
+        .hasMessageContaining("Writing job failed")
+        .hasCauseInstanceOf(RuntimeException.class);
+    assertThat(thrown.getCause())
+        .as("SparkException cause should be the original commit failure")
+        .hasMessageContaining("Simulated commit failure");
+    assertThat(thrown.getCause().getSuppressed())
+        .as("Delete failure should be attached to the commit cause as a suppressed exception")
+        .anyMatch(s -> containsMessage(s, "Simulated HDFS delete failure"));
+  }
+
+  private static boolean containsMessage(Throwable t, String fragment) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (cur.getMessage() != null && cur.getMessage().contains(fragment)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -714,8 +714,8 @@ public class TestSparkDataWrite {
         .anyMatch(s -> containsMessage(s, "Simulated HDFS delete failure"));
   }
 
-  private static boolean containsMessage(Throwable t, String fragment) {
-    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+  private static boolean containsMessage(Throwable throwable, String fragment) {
+    for (Throwable cur = throwable; cur != null; cur = cur.getCause()) {
       if (cur.getMessage() != null && cur.getMessage().contains(fragment)) {
         return true;
       }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +42,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkWriteOptions;
@@ -646,6 +649,60 @@ public class TestSparkDataWrite {
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", records.size(), actual.size());
     Assert.assertEquals("Result rows should match", records, actual);
+  }
+
+  @Test
+  public void testAbortDeleteFailureDoesNotMaskCommitFailure() throws IOException {
+    File parent = temp.newFolder(format.toString());
+    File location = new File(parent, "abort_suppress");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+
+    // Make commit fail with a RuntimeException (not CommitStateUnknownException,
+    // so cleanupOnAbort stays true and abort will attempt file deletion)
+    AppendFiles append = table.newAppend();
+    AppendFiles spyAppend = spy(append);
+    doThrow(new RuntimeException("Simulated commit failure")).when(spyAppend).commit();
+
+    // Make file deletion also fail during abort to verify the delete failure
+    // is suppressed and does not mask the original commit failure
+    Table spyTable = spy(table);
+    when(spyTable.newAppend()).thenReturn(spyAppend);
+    FileIO spyIO = spy(table.io());
+    doThrow(new RuntimeException("Simulated HDFS delete failure"))
+        .when(spyIO)
+        .deleteFile(anyString());
+    when(spyTable.io()).thenReturn(spyIO);
+
+    SparkTable sparkTable = new SparkTable(spyTable, false);
+    String manualTableName = "abort_delete_suppress";
+    ManualSource.setTable(manualTableName, sparkTable);
+
+    // The write should fail with the original commit failure.
+    // With suppressFailureWhenFinished() in abort, delete failures are logged
+    // at WARN level but suppressed, allowing the original commit failure to surface.
+    AssertHelpers.assertThrowsWithCause(
+        "Should throw the original commit failure, not the delete failure from abort",
+        SparkException.class,
+        "Writing job aborted",
+        RuntimeException.class,
+        "Simulated commit failure",
+        () ->
+            df.select("id", "data")
+                .sort("data")
+                .write()
+                .format("org.apache.iceberg.spark.source.ManualSource")
+                .option(ManualSource.TABLE_NAME, manualTableName)
+                .mode(SaveMode.Append)
+                .save(location.toString()));
   }
 
   public enum IcebergOptionsType {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -652,6 +652,59 @@ public class TestSparkDataWrite {
   }
 
   @Test
+  public void testAbortDeleteFailureSurfacesWhenSuppressDisabled() throws IOException {
+    File parent = temp.newFolder(format.toString());
+    File location = new File(parent, "abort_suppress_off");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_ABORT_SUPPRESS_DELETE_FAILURES, "false")
+        .commit();
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+
+    AppendFiles append = table.newAppend();
+    AppendFiles spyAppend = spy(append);
+    doThrow(new RuntimeException("Simulated commit failure")).when(spyAppend).commit();
+
+    Table spyTable = spy(table);
+    when(spyTable.newAppend()).thenReturn(spyAppend);
+    FileIO spyIO = spy(table.io());
+    doThrow(new RuntimeException("Simulated HDFS delete failure"))
+        .when(spyIO)
+        .deleteFile(anyString());
+    when(spyTable.io()).thenReturn(spyIO);
+
+    SparkTable sparkTable = new SparkTable(spyTable, false);
+    String manualTableName = "abort_delete_propagate";
+    ManualSource.setTable(manualTableName, sparkTable);
+
+    // With suppression disabled, the delete failure during abort surfaces as the cause
+    // instead of the original commit failure.
+    AssertHelpers.assertThrowsWithCause(
+        "Should throw the delete failure when suppression is disabled",
+        SparkException.class,
+        "Writing job aborted",
+        RuntimeException.class,
+        "Simulated HDFS delete failure",
+        () ->
+            df.select("id", "data")
+                .sort("data")
+                .write()
+                .format("org.apache.iceberg.spark.source.ManualSource")
+                .option(ManualSource.TABLE_NAME, manualTableName)
+                .mode(SaveMode.Append)
+                .save(location.toString()));
+  }
+
+  @Test
   public void testAbortDeleteFailureDoesNotMaskCommitFailure() throws IOException {
     File parent = temp.newFolder(format.toString());
     File location = new File(parent, "abort_suppress");


### PR DESCRIPTION
This PR copies https://github.com/linkedin/iceberg/pull/237, and addressed the comments by changing 2 things:

1. Add toggle on the suppress. User can configure the table property to suppress or unsuppress the error message.
2. Remove retries from the executor abort to avoid burden / latency increase to hdfs during issues. Leave the driver abort with retries.