### PR TITLE
Cherry-pick #11738 onto openhouse-1.5.2: Fix CachingCatalog primary tables with metadata-table-type names

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -143,14 +143,16 @@ public class CachingCatalog implements Catalog {
       return cached;
     }
 
-    if (MetadataTableUtils.hasMetadataTableName(canonicalized)) {
+    Table table = tableCache.get(canonicalized, catalog::loadTable);
+
+    if (table instanceof BaseMetadataTable) {
+      // Cache underlying table
       TableIdentifier originTableIdentifier =
           TableIdentifier.of(canonicalized.namespace().levels());
       Table originTable = tableCache.get(originTableIdentifier, catalog::loadTable);
 
-      // share TableOperations instance of origin table for all metadata tables, so that metadata
-      // table instances are
-      // also refreshed as well when origin table instance is refreshed.
+      // Share TableOperations instance of origin table for all metadata tables, so that metadata
+      // table instances are refreshed as well when origin table instance is refreshed.
       if (originTable instanceof HasTableOperations) {
         TableOperations ops = ((HasTableOperations) originTable).operations();
         MetadataTableType type = MetadataTableType.from(canonicalized.name());
@@ -163,7 +165,7 @@ public class CachingCatalog implements Catalog {
       }
     }
 
-    return tableCache.get(canonicalized, catalog::loadTable);
+    return table;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.hadoop;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import java.io.IOException;
 import java.time.Duration;
@@ -29,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.MetadataTableType;
@@ -38,6 +42,7 @@ import org.apache.iceberg.TestableCachingCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.FakeTicker;
@@ -162,6 +167,43 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     Assertions.assertThat(snapshotsTable.name())
         .as("Name must match")
         .isEqualTo("hadoop.db.ns1.ns2.tbl.snapshots");
+  }
+
+  @Test
+  public void testNonExistingTable() throws Exception {
+    Catalog catalog = CachingCatalog.wrap(hadoopCatalog());
+
+    TableIdentifier tableIdent = TableIdentifier.of("otherDB", "otherTbl");
+
+    assertThatThrownBy(() -> catalog.loadTable(tableIdent))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessage("Table does not exist: otherDB.otherTbl");
+  }
+
+  @Test
+  public void testTableWithMetadataTableName() throws Exception {
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "partitions");
+    TableIdentifier metaTableIdent =
+        TableIdentifier.of("db", "ns1", "ns2", "partitions", "partitions");
+
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
+    catalog.cache().invalidateAll();
+
+    Table table = catalog.loadTable(tableIdent);
+    assertThat(table.name()).isEqualTo("hadoop.db.ns1.ns2.partitions");
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(catalog.cache().asMap()).doesNotContainKey(metaTableIdent);
+
+    catalog.cache().invalidateAll();
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+
+    Table metaTable = catalog.loadTable(metaTableIdent);
+    assertThat(metaTable).isInstanceOf(BaseMetadataTable.class);
+    assertThat(metaTable.name()).isEqualTo("hadoop.db.ns1.ns2.partitions.partitions");
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(catalog.cache().asMap()).containsKey(metaTableIdent);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Cherry-pick of upstream Apache Iceberg PR [#11738](https://github.com/apache/iceberg/pull/11738) (commit \`cf8b354c4\`, merged Jan 14 2025, released in Apache Iceberg 1.8.0+) onto the \`openhouse-1.5.2\` branch — companion to [#240](https://github.com/linkedin/iceberg/pull/240) which targets \`openhouse-1.2.0\`.

The bug, originally reported in [#11123](https://github.com/apache/iceberg/issues/11123): when a regular table has a name matching an Iceberg \`MetadataTableType\` (e.g. \`history\`, \`partitions\`, \`snapshots\`), \`CachingCatalog.loadTable\` eagerly assumes the identifier is a metadata-table access, computes a collapsed-base origin identifier with empty namespace, and asks the underlying catalog to load it. For OpenHouse — whose catalogs use single-level namespaces — that collapsed identifier is invalid; the inner load throws \`NoSuchTableException\` (or, on older deployments, issues a malformed \`GET /databases//tables/<X>\` request that the gateway 503s). Either way the exception propagates out of \`CachingCatalog\` and Spark surfaces "Table or view not found", making any user-created table whose name collides with a metadata-type unreadable cross-session.

The fix flips the algorithm: load the original identifier first, then check \`if (table instanceof BaseMetadataTable)\` instead of checking the name. Catalogs that don't manufacture \`BaseMetadataTable\` from a normal load (OpenHouse) just return the user's primary \`BaseTable\` directly.

## Conflict notes

\`CachingCatalog.java\` and \`TestCachingCatalog.java\` both auto-merged cleanly. The new test methods rely on static \`assertThat\` / \`assertThatThrownBy\` AssertJ imports that this branch's \`TestCachingCatalog\` didn't have; folded those imports into the same commit so the file compiles.

Author of the original commit (\`gaborkaszab@cloudera.com\`) preserved.

## Test plan

- [x] \`./gradlew :iceberg-core:test --tests "org.apache.iceberg.hadoop.TestCachingCatalog"\` passes locally (JDK 11). The two new upstream tests \`testNonExistingTable\` and \`testTableWithMetadataTableName\` pass; existing tests remain green.
- [ ] CI (run on this PR).

## Follow-ups

After this lands, cut a new patch tag (next would be \`v1.5.2.11\` after the current \`v1.5.2.10\`) and bump \`li-openhouse\`'s iceberg dependency for the Spark 3.5 module.