### PR TITLE
Add flag to spark write abort to disable error suppress and retry

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -296,6 +296,13 @@ public class TableProperties {
   public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
   public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
+  public static final String SPARK_WRITE_ABORT_SUPPRESS_FAILURE_ENABLED =
+      "write.spark.abort.suppress-failure.enabled";
+  public static final boolean SPARK_WRITE_ABORT_SUPPRESS_FAILURE_ENABLED_DEFAULT = true;
+
+  public static final String SPARK_WRITE_ABORT_RETRY_ENABLED = "write.spark.abort.retry.enabled";
+  public static final boolean SPARK_WRITE_ABORT_RETRY_ENABLED_DEFAULT = true;
+
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED =
       "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.extensions;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
@@ -38,7 +39,11 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -80,9 +85,16 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
     super(catalogName, implementation, config);
   }
 
+  @Before
+  public void resetCustomIOState() {
+    CustomFileIO.deleteAttempts.set(0);
+    CustomFileIO.failDeletes = false;
+  }
+
   @After
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+    CustomFileIO.failDeletes = false;
   }
 
   @Test
@@ -127,7 +139,131 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
             catalogName, tableName, System.currentTimeMillis() + 5000, dataLocation));
   }
 
+  @Test
+  public void testAbortRetriesByDefault() throws Exception {
+    // Bulk path doesn't retry per file (a single deleteFiles call), so this assertion is only
+    // meaningful for the non-bulk FileIO.
+    Assume.assumeFalse(catalogName.equals("testhivebulk"));
+
+    String dataLocation = temp.newFolder().toString();
+    CustomFileIO.failDeletes = true;
+
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) "
+            + "USING iceberg "
+            + "PARTITIONED BY (data)"
+            + "TBLPROPERTIES ('%s' '%s')",
+        tableName, TableProperties.WRITE_DATA_LOCATION, dataLocation);
+
+    triggerFailingAppend();
+
+    // With retry enabled (default), each path should be attempted retry(3)+1 = 4 times.
+    Assert.assertTrue(
+        "Expected at least 4 delete attempts when retry is enabled by default, but got "
+            + CustomFileIO.deleteAttempts.get(),
+        CustomFileIO.deleteAttempts.get() >= 4);
+  }
+
+  @Test
+  public void testAbortRetryDisabledByTableProperty() throws Exception {
+    // Bulk path is not affected by the retry flag.
+    Assume.assumeFalse(catalogName.equals("testhivebulk"));
+
+    String dataLocation = temp.newFolder().toString();
+    CustomFileIO.failDeletes = true;
+
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) "
+            + "USING iceberg "
+            + "PARTITIONED BY (data)"
+            + "TBLPROPERTIES ('%s' '%s', '%s' '%s')",
+        tableName,
+        TableProperties.WRITE_DATA_LOCATION,
+        dataLocation,
+        TableProperties.SPARK_WRITE_ABORT_RETRY_ENABLED,
+        "false");
+
+    triggerFailingAppend();
+
+    // With retry disabled, each path should be attempted exactly once. We don't know the exact
+    // number of files written before the task failed, but it should be small (coalesce(1) on
+    // 4 input rows). The default retry would produce >= 4 attempts per file.
+    int attempts = CustomFileIO.deleteAttempts.get();
+    Assert.assertTrue(
+        "Expected at least one delete attempt, got " + attempts, attempts >= 1);
+    Assert.assertTrue(
+        "Expected fewer than 4 delete attempts when retry is disabled, but got " + attempts,
+        attempts < 4);
+  }
+
+  @Test
+  public void testAbortSuppressFailureDisabledByTableProperty() throws Exception {
+    String dataLocation = temp.newFolder().toString();
+    CustomFileIO.failDeletes = true;
+
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) "
+            + "USING iceberg "
+            + "PARTITIONED BY (data)"
+            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s')",
+        tableName,
+        TableProperties.WRITE_DATA_LOCATION,
+        dataLocation,
+        TableProperties.SPARK_WRITE_ABORT_SUPPRESS_FAILURE_ENABLED,
+        "false",
+        // Disable retries to keep the failure surface small; the suppress-vs-throw decision is
+        // independent of retry behavior.
+        TableProperties.SPARK_WRITE_ABORT_RETRY_ENABLED,
+        "false");
+
+    List<SimpleRecord> records =
+        ImmutableList.of(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "a"),
+            new SimpleRecord(4, "b"));
+    Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
+
+    // With suppress disabled, the simulated FileIO failure should surface in the exception chain
+    // rather than being silently swallowed by the cleanup utility.
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                inputDF.coalesce(1).sortWithinPartitions("id").writeTo(tableName).append();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .hasStackTraceContaining("simulated FileIO delete failure");
+  }
+
+  private void triggerFailingAppend() {
+    List<SimpleRecord> records =
+        ImmutableList.of(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "a"),
+            new SimpleRecord(4, "b"));
+    Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
+
+    AssertHelpers.assertThrows(
+        "Write must fail",
+        SparkException.class,
+        "Writing job aborted",
+        () -> {
+          try {
+            // incoming records are not ordered by partitions so the job must fail
+            inputDF.coalesce(1).sortWithinPartitions("id").writeTo(tableName).append();
+          } catch (NoSuchTableException e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
   public static class CustomFileIO implements FileIO {
+
+    static final AtomicInteger deleteAttempts = new AtomicInteger(0);
+    static volatile boolean failDeletes = false;
 
     private final FileIO delegate = new HadoopFileIO(new Configuration());
 
@@ -149,6 +285,10 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
 
     @Override
     public void deleteFile(String path) {
+      deleteAttempts.incrementAndGet();
+      if (failDeletes) {
+        throw new RuntimeException("simulated FileIO delete failure");
+      }
       delegate.deleteFile(path);
     }
 
@@ -179,8 +319,18 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
 
     @Override
     public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
+      int count = 0;
       for (String path : paths) {
-        delegate().deleteFile(path);
+        count++;
+        deleteAttempts.incrementAndGet();
+        if (!failDeletes) {
+          delegate().deleteFile(path);
+        }
+      }
+      if (failDeletes) {
+        BulkDeletionFailureException ex = new BulkDeletionFailureException(count);
+        ex.initCause(new RuntimeException("simulated FileIO delete failure"));
+        throw ex;
       }
     }
   }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -189,8 +189,7 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
     // number of files written before the task failed, but it should be small (coalesce(1) on
     // 4 input rows). The default retry would produce >= 4 attempts per file.
     int attempts = CustomFileIO.deleteAttempts.get();
-    Assert.assertTrue(
-        "Expected at least one delete attempt, got " + attempts, attempts >= 1);
+    Assert.assertTrue("Expected at least one delete attempt, got " + attempts, attempts >= 1);
     Assert.assertTrue(
         "Expected fewer than 4 delete attempts when retry is disabled, but got " + attempts,
         attempts < 4);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -48,13 +48,20 @@ class SparkCleanupUtil {
    * Attempts to delete as many files produced by a task as possible.
    *
    * <p>Note this method will log Spark task info and is supposed to be called only on executors.
-   * Use {@link #deleteFiles(String, FileIO, List)} to delete files on the driver.
+   * Use {@link #deleteFiles(String, FileIO, List, boolean, boolean)} to delete files on the driver.
    *
    * @param io a {@link FileIO} instance used for deleting files
    * @param files a list of files to delete
+   * @param suppressFailure whether to suppress per-file failures and continue; when false, the
+   *     first failure is rethrown after the run completes
+   * @param enableRetry whether to retry individual file deletions on transient failures
    */
-  public static void deleteTaskFiles(FileIO io, List<? extends ContentFile<?>> files) {
-    deleteFiles(taskInfo(), io, files);
+  public static void deleteTaskFiles(
+      FileIO io,
+      List<? extends ContentFile<?>> files,
+      boolean suppressFailure,
+      boolean enableRetry) {
+    deleteFiles(taskInfo(), io, files, suppressFailure, enableRetry);
   }
 
   // the format matches what Spark uses for internal logging
@@ -79,22 +86,36 @@ class SparkCleanupUtil {
    * @param context a helpful description of the operation invoking this method
    * @param io a {@link FileIO} instance used for deleting files
    * @param files a list of files to delete
+   * @param suppressFailure whether to suppress per-file failures and continue; when false, the
+   *     first failure is rethrown after the run completes
+   * @param enableRetry whether to retry individual file deletions on transient failures
    */
-  public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
+  public static void deleteFiles(
+      String context,
+      FileIO io,
+      List<? extends ContentFile<?>> files,
+      boolean suppressFailure,
+      boolean enableRetry) {
     List<String> paths = Lists.transform(files, file -> file.path().toString());
-    deletePaths(context, io, paths);
+    deletePaths(context, io, paths, suppressFailure, enableRetry);
   }
 
-  private static void deletePaths(String context, FileIO io, List<String> paths) {
+  private static void deletePaths(
+      String context,
+      FileIO io,
+      List<String> paths,
+      boolean suppressFailure,
+      boolean enableRetry) {
     if (io instanceof SupportsBulkOperations) {
       SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
-      bulkDelete(context, bulkIO, paths);
+      bulkDelete(context, bulkIO, paths, suppressFailure);
     } else {
-      delete(context, io, paths);
+      delete(context, io, paths, suppressFailure, enableRetry);
     }
   }
 
-  private static void bulkDelete(String context, SupportsBulkOperations io, List<String> paths) {
+  private static void bulkDelete(
+      String context, SupportsBulkOperations io, List<String> paths, boolean suppressFailure) {
     try {
       io.deleteFiles(paths);
       LOG.info("Deleted {} file(s) using bulk deletes ({})", paths.size(), context);
@@ -106,28 +127,40 @@ class SparkCleanupUtil {
           deletedFilesCount,
           paths.size(),
           context);
+      if (!suppressFailure) {
+        throw e;
+      }
     }
   }
 
-  private static void delete(String context, FileIO io, List<String> paths) {
+  private static void delete(
+      String context, FileIO io, List<String> paths, boolean suppressFailure, boolean enableRetry) {
     AtomicInteger deletedFilesCount = new AtomicInteger(0);
 
-    Tasks.foreach(paths)
-        .executeWith(ThreadPools.getWorkerPool())
-        .stopRetryOn(NotFoundException.class)
-        .suppressFailureWhenFinished()
-        .onFailure((path, exc) -> LOG.warn("Failed to delete {} ({})", path, context, exc))
-        .retry(DELETE_NUM_RETRIES)
-        .exponentialBackoff(
-            DELETE_MIN_RETRY_WAIT_MS,
-            DELETE_MAX_RETRY_WAIT_MS,
-            DELETE_TOTAL_RETRY_TIME_MS,
-            2 /* exponential */)
-        .run(
-            path -> {
-              io.deleteFile(path);
-              deletedFilesCount.incrementAndGet();
-            });
+    Tasks.Builder<String> builder =
+        Tasks.foreach(paths)
+            .executeWith(ThreadPools.getWorkerPool())
+            .stopRetryOn(NotFoundException.class)
+            .throwFailureWhenFinished(!suppressFailure)
+            .onFailure((path, exc) -> LOG.warn("Failed to delete {} ({})", path, context, exc));
+
+    if (enableRetry) {
+      builder
+          .retry(DELETE_NUM_RETRIES)
+          .exponentialBackoff(
+              DELETE_MIN_RETRY_WAIT_MS,
+              DELETE_MAX_RETRY_WAIT_MS,
+              DELETE_TOTAL_RETRY_TIME_MS,
+              2 /* exponential */);
+    } else {
+      builder.noRetry();
+    }
+
+    builder.run(
+        path -> {
+          io.deleteFile(path);
+          deletedFilesCount.incrementAndGet();
+        });
 
     if (deletedFilesCount.get() < paths.size()) {
       LOG.warn("Deleted only {} of {} file(s) ({})", deletedFilesCount, paths.size(), context);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -101,11 +101,7 @@ class SparkCleanupUtil {
   }
 
   private static void deletePaths(
-      String context,
-      FileIO io,
-      List<String> paths,
-      boolean suppressFailure,
-      boolean enableRetry) {
+      String context, FileIO io, List<String> paths, boolean suppressFailure, boolean enableRetry) {
     if (io instanceof SupportsBulkOperations) {
       SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
       bulkDelete(context, bulkIO, paths, suppressFailure);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.expressions.Expression;
@@ -57,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -92,6 +94,8 @@ class SparkWrite {
   private final StructType dsSchema;
   private final Map<String, String> extraSnapshotMetadata;
   private final boolean partitionedFanoutEnabled;
+  private final boolean suppressFailureOnAbort;
+  private final boolean retryOnAbort;
   /** Pending schema update when mergeSchema was used; committed in commit() before data commit. */
   private final UpdateSchema pendingSchemaUpdate;
 
@@ -143,6 +147,16 @@ class SparkWrite {
     this.dsSchema = dsSchema;
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
+    this.suppressFailureOnAbort =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            TableProperties.SPARK_WRITE_ABORT_SUPPRESS_FAILURE_ENABLED,
+            TableProperties.SPARK_WRITE_ABORT_SUPPRESS_FAILURE_ENABLED_DEFAULT);
+    this.retryOnAbort =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            TableProperties.SPARK_WRITE_ABORT_RETRY_ENABLED,
+            TableProperties.SPARK_WRITE_ABORT_RETRY_ENABLED_DEFAULT);
     this.pendingSchemaUpdate = pendingSchemaUpdate;
   }
 
@@ -189,7 +203,14 @@ class SparkWrite {
     Broadcast<Table> tableBroadcast =
         sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     return new WriterFactory(
-        tableBroadcast, format, targetFileSize, writeSchema, dsSchema, partitionedFanoutEnabled);
+        tableBroadcast,
+        format,
+        targetFileSize,
+        writeSchema,
+        dsSchema,
+        partitionedFanoutEnabled,
+        suppressFailureOnAbort,
+        retryOnAbort);
   }
 
   private void commitOperation(SnapshotUpdate<?> operation, String description) {
@@ -230,7 +251,8 @@ class SparkWrite {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      SparkCleanupUtil.deleteFiles("job abort", table.io(), files(messages));
+      SparkCleanupUtil.deleteFiles(
+          "job abort", table.io(), files(messages), suppressFailureOnAbort, retryOnAbort);
     } else {
       LOG.warn("Skipping cleanup of written files");
     }
@@ -577,6 +599,8 @@ class SparkWrite {
     private final Schema writeSchema;
     private final StructType dsSchema;
     private final boolean partitionedFanoutEnabled;
+    private final boolean suppressFailureOnAbort;
+    private final boolean retryOnAbort;
 
     protected WriterFactory(
         Broadcast<Table> tableBroadcast,
@@ -584,13 +608,17 @@ class SparkWrite {
         long targetFileSize,
         Schema writeSchema,
         StructType dsSchema,
-        boolean partitionedFanoutEnabled) {
+        boolean partitionedFanoutEnabled,
+        boolean suppressFailureOnAbort,
+        boolean retryOnAbort) {
       this.tableBroadcast = tableBroadcast;
       this.format = format;
       this.targetFileSize = targetFileSize;
       this.writeSchema = writeSchema;
       this.dsSchema = dsSchema;
       this.partitionedFanoutEnabled = partitionedFanoutEnabled;
+      this.suppressFailureOnAbort = suppressFailureOnAbort;
+      this.retryOnAbort = retryOnAbort;
     }
 
     @Override
@@ -614,7 +642,14 @@ class SparkWrite {
               .build();
 
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
+        return new UnpartitionedDataWriter(
+            writerFactory,
+            fileFactory,
+            io,
+            spec,
+            targetFileSize,
+            suppressFailureOnAbort,
+            retryOnAbort);
 
       } else {
         return new PartitionedDataWriter(
@@ -625,7 +660,9 @@ class SparkWrite {
             writeSchema,
             dsSchema,
             targetFileSize,
-            partitionedFanoutEnabled);
+            partitionedFanoutEnabled,
+            suppressFailureOnAbort,
+            retryOnAbort);
       }
     }
   }
@@ -633,16 +670,22 @@ class SparkWrite {
   private static class UnpartitionedDataWriter implements DataWriter<InternalRow> {
     private final FileWriter<InternalRow, DataWriteResult> delegate;
     private final FileIO io;
+    private final boolean suppressFailureOnAbort;
+    private final boolean retryOnAbort;
 
     private UnpartitionedDataWriter(
         SparkFileWriterFactory writerFactory,
         OutputFileFactory fileFactory,
         FileIO io,
         PartitionSpec spec,
-        long targetFileSize) {
+        long targetFileSize,
+        boolean suppressFailureOnAbort,
+        boolean retryOnAbort) {
       this.delegate =
           new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
+      this.suppressFailureOnAbort = suppressFailureOnAbort;
+      this.retryOnAbort = retryOnAbort;
     }
 
     @Override
@@ -665,7 +708,8 @@ class SparkWrite {
       close();
 
       DataWriteResult result = delegate.result();
-      SparkCleanupUtil.deleteTaskFiles(io, result.dataFiles());
+      SparkCleanupUtil.deleteTaskFiles(
+          io, result.dataFiles(), suppressFailureOnAbort, retryOnAbort);
     }
 
     @Override
@@ -680,6 +724,8 @@ class SparkWrite {
     private final PartitionSpec spec;
     private final PartitionKey partitionKey;
     private final InternalRowWrapper internalRowWrapper;
+    private final boolean suppressFailureOnAbort;
+    private final boolean retryOnAbort;
 
     private PartitionedDataWriter(
         SparkFileWriterFactory writerFactory,
@@ -689,7 +735,9 @@ class SparkWrite {
         Schema dataSchema,
         StructType dataSparkType,
         long targetFileSize,
-        boolean fanoutEnabled) {
+        boolean fanoutEnabled,
+        boolean suppressFailureOnAbort,
+        boolean retryOnAbort) {
       if (fanoutEnabled) {
         this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       } else {
@@ -699,6 +747,8 @@ class SparkWrite {
       this.spec = spec;
       this.partitionKey = new PartitionKey(spec, dataSchema);
       this.internalRowWrapper = new InternalRowWrapper(dataSparkType);
+      this.suppressFailureOnAbort = suppressFailureOnAbort;
+      this.retryOnAbort = retryOnAbort;
     }
 
     @Override
@@ -722,7 +772,8 @@ class SparkWrite {
       close();
 
       DataWriteResult result = delegate.result();
-      SparkCleanupUtil.deleteTaskFiles(io, result.dataFiles());
+      SparkCleanupUtil.deleteTaskFiles(
+          io, result.dataFiles(), suppressFailureOnAbort, retryOnAbort);
     }
 
     @Override


### PR DESCRIPTION
Follow up PR of https://github.com/linkedin/iceberg/pull/239. Add flags to disable error suppress and disable retry respectfully during spark write abort.