### PR TITLE
Backport NPE fix for NULL partition conflict handling (#10680) to 1.5.2

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -200,7 +200,7 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
           StringBuilder partitionStringBuilder = new StringBuilder();
           partitionStringBuilder.append(structType.fields().get(i).name());
           partitionStringBuilder.append("=");
-          partitionStringBuilder.append(s.get(i, Object.class).toString());
+          partitionStringBuilder.append(s.get(i, Object.class));
           partitionDataJoiner.add(partitionStringBuilder.toString());
         }
       }

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -65,6 +65,34 @@ public class TestReplacePartitions extends TableTestBase {
           .withRecordCount(1)
           .build();
 
+  static final DataFile FILE_NULL_PARTITION =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-null-partition.parquet")
+          .withFileSizeInBytes(0)
+          .withPartitionPath("data_bucket=__HIVE_DEFAULT_PARTITION__")
+          .withRecordCount(0)
+          .build();
+
+  // Partition spec with VOID partition transform ("alwaysNull" in Java code.)
+  static final PartitionSpec SPEC_VOID =
+      PartitionSpec.builderFor(SCHEMA).alwaysNull("id").bucket("data", BUCKETS_NUMBER).build();
+
+  static final DataFile FILE_A_VOID_PARTITION =
+      DataFiles.builder(SPEC_VOID)
+          .withPath("/path/to/data-a-void-partition.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("id_null=__HIVE_DEFAULT_PARTITION__/data_bucket=0")
+          .withRecordCount(1)
+          .build();
+
+  static final DataFile FILE_B_VOID_PARTITION =
+      DataFiles.builder(SPEC_VOID)
+          .withPath("/path/to/data-b-void-partition.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("id_null=__HIVE_DEFAULT_PARTITION__/data_bucket=1")
+          .withRecordCount(10)
+          .build();
+
   static final DeleteFile FILE_UNPARTITIONED_A_DELETES =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofPositionDeletes()
@@ -345,6 +373,55 @@ public class TestReplacePartitions extends TableTestBase {
         .hasMessage(
             "Found conflicting files that can contain records matching partitions "
                 + "[data_bucket=0, data_bucket=1]: [/path/to/data-a.parquet]");
+  }
+
+  @Test
+  public void testValidateWithNullPartition() {
+    commit(table, table.newReplacePartitions().addFile(FILE_NULL_PARTITION), branch);
+
+    // Concurrent Replace Partitions should fail with ValidationException
+    ReplacePartitions replace = table.newReplacePartitions();
+    Assertions.assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    replace
+                        .addFile(FILE_NULL_PARTITION)
+                        .addFile(FILE_B)
+                        .validateNoConflictingData()
+                        .validateNoConflictingDeletes(),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Found conflicting files that can contain records matching partitions "
+                + "[data_bucket=null, data_bucket=1]: [/path/to/data-null-partition.parquet]");
+  }
+
+  @Test
+  public void testValidateWithVoidTransform() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Table tableVoid = TestTables.create(tableDir, "tablevoid", SCHEMA, SPEC_VOID, formatVersion);
+    commit(tableVoid, tableVoid.newReplacePartitions().addFile(FILE_A_VOID_PARTITION), branch);
+
+    // Concurrent Replace Partitions should fail with ValidationException
+    ReplacePartitions replace = tableVoid.newReplacePartitions();
+    Assertions.assertThatThrownBy(
+            () ->
+                commit(
+                    tableVoid,
+                    replace
+                        .addFile(FILE_A_VOID_PARTITION)
+                        .addFile(FILE_B_VOID_PARTITION)
+                        .validateNoConflictingData()
+                        .validateNoConflictingDeletes(),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Found conflicting files that can contain records matching partitions "
+                + "[id_null=null, data_bucket=1, id_null=null, data_bucket=0]: "
+                + "[/path/to/data-a-void-partition.parquet]");
   }
 
   @Test


### PR DESCRIPTION
## Type: Backport / cherry-pick

Backports the upstream Apache Iceberg fix for a `NullPointerException` during conflict handling of NULL partitions ([apache/iceberg#10680](https://github.com/apache/iceberg/pull/10680), released in 1.6.0) into the `openhouse-1.5.2` line.

**Motivation:** prerequisite for switching fork Trino from `org.apache.iceberg` (1.6.1) to `com.linkedin.iceberg` (1.5.2). Conflict validation on NULL / VOID-transform partitions currently throws an NPE instead of a proper `ValidationException`.

## Cherry-picked commit

Produced with `git cherry-pick -x` (original authorship + `(cherry picked from commit <sha>)` provenance preserved):

| Apache PR | Upstream release | Upstream commit | Description |
|-----------|------------------|-----------------|-------------|
| [apache/iceberg#10680](https://github.com/apache/iceberg/pull/10680) | 1.6.0 | `ed228f79c` | Fix NPE during conflict handling of NULL partitions (`PartitionSet`) |

## Conflicts & resolution

The production fix (`PartitionSet.java`) was cherry-picked **unchanged**.

Only the two **added tests** conflicted, because `TestReplacePartitions` in 1.5.2.x is still on **JUnit 4** while upstream had moved to JUnit 5. `testValidateWithNullPartition` and `testValidateWithVoidTransform` were adapted to the JUnit 4 harness (logic and assertions unchanged):

- `@TestTemplate` -> `@Test`
- static `assertThatThrownBy` -> `Assertions.assertThatThrownBy`
- `Files.createTempDirectory(temp, "junit")` -> `temp.newFolder()` (JUnit 4 `TemporaryFolder`)

This deviation is documented in the commit message body.

## Verification

`./gradlew :iceberg-core:test --tests org.apache.iceberg.TestReplacePartitions` — **pass** (96 run, 0 failures; JDK 17, Gradle 8.1.1 requires JDK <= 17).

## Relationship to #245
Independent of #245 (disjoint files); the two backport PRs can be reviewed and merged in any order.