### PR TITLE
Spark 3.5: Default partitioned write distribution mode to NONE

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -316,7 +316,7 @@ public class SparkWriteConf {
     if (table.sortOrder().isSorted()) {
       return RANGE;
     } else if (table.spec().isPartitioned()) {
-      return HASH;
+      return NONE;
     } else {
       return NONE;
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -125,8 +125,11 @@ public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
   //
   // PARTITIONED BY date, days(ts) UNORDERED
   // -------------------------------------------------------------------------
-  // write mode is NOT SET -> CLUSTER BY date, days(ts) + LOCALLY ORDER BY date, days(ts)
-  // write mode is NOT SET (fanout) -> CLUSTER BY date, days(ts) + empty ordering
+  // NOTE: in this fork the default write distribution mode for partitioned tables is NONE
+  // (not HASH), so "write mode is NOT SET" behaves like "write mode is NONE" below
+  // (see SparkWriteConf#defaultWriteDistributionMode).
+  // write mode is NOT SET -> unspecified distribution + LOCALLY ORDER BY date, days(ts)
+  // write mode is NOT SET (fanout) -> unspecified distribution + empty ordering
   // write mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, days(ts)
   // write mode is NONE (fanout) -> unspecified distribution + empty ordering
   // write mode is HASH -> CLUSTER BY date, days(ts) + LOCALLY ORDER BY date, days(ts)
@@ -243,21 +246,19 @@ public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
 
     disableFanoutWriters(table);
 
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
+    // The default distribution mode for partitioned tables is NONE in this fork, so no clustering
+    // is requested; only the local ordering on the partition columns is retained.
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
           Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
         };
 
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
 
     enableFanoutWriters(table);
 
-    checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -160,6 +160,11 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   public void testAdvisoryPartitionSize() {
     Table table = validationCatalog.loadTable(tableIdent);
 
+    // An advisory partition size is only reported when a distribution is requested (Spark prohibits
+    // requesting a size without distribution). Since the default for partitioned tables is NONE in
+    // this fork, explicitly request HASH so the advisory size resolution can be exercised.
+    table.updateProperties().set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
     SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
 
     long value1 = writeConf.writeRequirements().advisoryPartitionSize();
@@ -180,7 +185,17 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
 
     SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
 
-    checkMode(DistributionMode.HASH, writeConf);
+    // In this fork, normal writes to a partitioned (unsorted) table default to NONE rather than
+    // HASH to avoid an Iceberg-injected shuffle that interacts poorly with Celeborn (see
+    // SparkWriteConf#defaultWriteDistributionMode). Row-level operations (DELETE/UPDATE/MERGE)
+    // are unaffected and still default to HASH.
+    assertThat(writeConf.distributionMode()).isEqualTo(DistributionMode.NONE);
+    assertThat(writeConf.copyOnWriteDistributionMode(DELETE)).isEqualTo(DistributionMode.HASH);
+    assertThat(writeConf.positionDeltaDistributionMode(DELETE)).isEqualTo(DistributionMode.HASH);
+    assertThat(writeConf.copyOnWriteDistributionMode(UPDATE)).isEqualTo(DistributionMode.HASH);
+    assertThat(writeConf.positionDeltaDistributionMode(UPDATE)).isEqualTo(DistributionMode.HASH);
+    assertThat(writeConf.copyOnWriteDistributionMode(MERGE)).isEqualTo(DistributionMode.HASH);
+    assertThat(writeConf.positionDeltaDistributionMode(MERGE)).isEqualTo(DistributionMode.HASH);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -676,7 +676,12 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
         TableProperties.FORMAT_VERSION,
         "2",
         TableProperties.DEFAULT_FILE_FORMAT,
-        format.toString());
+        format.toString(),
+        // This fork defaults partitioned writes to NONE distribution; these tests expect data to be
+        // clustered into one file per partition, so request HASH explicitly to keep file counts
+        // deterministic regardless of input parallelism.
+        TableProperties.WRITE_DISTRIBUTION_MODE,
+        TableProperties.WRITE_DISTRIBUTION_MODE_HASH);
   }
 
   private void writeRecords(Table table, int files, int numRecords) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1600,6 +1600,12 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
   public void testPartitionsTableDeleteStats() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    // This fork defaults partitioned writes to NONE distribution; request HASH so each partition's
+    // rows are clustered into a single data file, as this test's file_count assertions expect.
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_DISTRIBUTION_MODE, TableProperties.WRITE_DISTRIBUTION_MODE_HASH)
+        .commit();
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
     Dataset<Row> df1 =
         spark.createDataFrame(


### PR DESCRIPTION
## Summary

Iceberg 1.5 implements `RequiresDistributionAndOrdering`, so every Spark 3.5 write to a partitioned table now requests a **HASH** distribution by default (`SparkWriteConf.defaultWriteDistributionMode`). Spark plans this as a `RebalancePartitions` / REBALANCE shuffle on the partition columns.

REBALANCE is poorly handled by **Celeborn 0.4** and has already caused production incidents (notably Kyoto CDC writes overloading Celeborn and impacting other tenants). Celeborn 0.6 fixes this but is still a couple of months out, while Spark 3.5 traffic is about to ramp significantly with the Python 3.12 migration this half.

This PR flips the default write distribution mode for **partitioned, unsorted** tables from `HASH` to `NONE`, restoring the Spark 3.1 status quo:

- **Scope is intentionally narrow.** Only normal (batch/append) writes are affected. `DELETE`/`UPDATE`/`MERGE` keep their existing `HASH` defaults, which covers the CDC merge-into case separately.
- **Ordering is unchanged.** We keep the local sort, so users don't need to add `.sortWithinPartitions()` in their code.
- **Explicit requests still work.** Users who want a distribution can still request it via the write option, session conf, or table property.
- Any small files that result are handled by Open House's post-write compaction. We can revisit re-enabling the default distribution once Celeborn 0.6 is rolled out.

This also avoids the Iceberg-injected shuffle silently overriding user intent (e.g. `DaliSpark.OUTPUT_PARALLELISM`) and the extra resource usage it adds.

## Testing Done

- [x] Local code review completed
- [x] Unit tests updated to reflect the new default
- [x] Targeted test suites pass on JDK 11

Updated tests:
- `TestSparkWriteConf#testSparkWriteConfDistributionDefault` — now asserts `NONE` for normal writes and `HASH` for row-level operations (DELETE/UPDATE/MERGE).
- `TestSparkWriteConf#testAdvisoryPartitionSize` — explicitly requests `HASH` so an advisory partition size is reported (Spark only reports one when a distribution is requested).
- `TestSparkDistributionAndOrderingUtil#testDefaultWritePartitionedUnsortedTable` — now expects an unspecified distribution with the local ordering retained.

Ran `TestSparkWriteConf`, `TestSparkDistributionAndOrderingUtil`, and `TestRequiredDistributionAndOrdering` (both `spark` and `spark-extensions` modules) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
