### PR TITLE
Docs: fix grammar in IcebergDecoder Javadoc

### DIFF
--- a/core/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/IcebergDecoder.java
@@ -57,8 +57,8 @@ public class IcebergDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    * Creates a new decoder that constructs datum instances described by an {@link
    * org.apache.iceberg.Schema Iceberg schema}.
    *
-   * <p>The {@code readSchema} is as used the expected schema (read schema). Datum instances created
-   * by this class will are described by the expected schema.
+   * <p>The {@code readSchema} is used as the expected schema (read schema). Datum instances created
+   * by this class will be described by the expected schema.
    *
    * <p>The schema used to decode incoming buffers is determined by the schema fingerprint encoded
    * in the message header. This class can decode messages that were encoded using the {@code
@@ -75,8 +75,8 @@ public class IcebergDecoder<D> extends MessageDecoder.BaseDecoder<D> {
    * Creates a new decoder that constructs datum instances described by an {@link
    * org.apache.iceberg.Schema Iceberg schema}.
    *
-   * <p>The {@code readSchema} is as used the expected schema (read schema). Datum instances created
-   * by this class will are described by the expected schema.
+   * <p>The {@code readSchema} is used as the expected schema (read schema). Datum instances created
+   * by this class will be described by the expected schema.
    *
    * <p>The schema used to decode incoming buffers is determined by the schema fingerprint encoded
    * in the message header. This class can decode messages that were encoded using the {@code


### PR DESCRIPTION
## Summary

Fix two grammar issues in `IcebergDecoder.java` Javadoc comments (both constructors):

- `is as used` → `is used as` (word order)
- `will are described` → `will be described` (verb agreement)

No functional changes — Javadoc only.