### PR TITLE
Propagate delete file replication factor for Hadoop ORC files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopOutputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopOutputFile.java
@@ -157,6 +157,11 @@ public class HadoopOutputFile implements OutputFile, NativelyEncryptedFile {
     return fs;
   }
 
+  /** Returns the configured replication factor, or a non-positive value when not set. */
+  public short replication() {
+    return replication;
+  }
+
   @Override
   public String location() {
     return path.toString();

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -809,7 +809,10 @@ public class ORC {
 
   static Writer newFileWriter(
       OutputFile file, OrcFile.WriterOptions options, Map<String, byte[]> metadata) {
-    if (file instanceof HadoopOutputFile) {
+    // the raw Hadoop filesystem opens its own stream with the filesystem default replication,
+    // so it cannot be used when a custom replication factor is configured; OutputFileSystem
+    // routes stream creation back through the Iceberg output file, which applies it
+    if (file instanceof HadoopOutputFile && ((HadoopOutputFile) file).replication() <= 0) {
       options.fileSystem(((HadoopOutputFile) file).getFileSystem());
     } else {
       options.fileSystem(new FileIOFSUtil.OutputFileSystem(file));

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -82,7 +82,9 @@ class OrcFileAppender<D> implements FileAppender<D> {
     this.batch = orcSchema.createRowBatch(this.batchSize);
 
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf).useUTCTimestamp(true);
-    if (file instanceof HadoopOutputFile) {
+    // ORC.newFileWriter picks the filesystem; the raw Hadoop shortcut is only valid when no
+    // custom replication factor is configured on the output file
+    if (file instanceof HadoopOutputFile && ((HadoopOutputFile) file).replication() <= 0) {
       options.fileSystem(((HadoopOutputFile) file).getFileSystem());
     }
     options.setSchema(orcSchema);

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcReplication.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcReplication.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestOrcReplication {
+
+  private static final Schema SCHEMA = new Schema(optional(1, "id", Types.IntegerType.get()));
+  private static final short CUSTOM_REPLICATION = 5;
+
+  @TempDir private File tempDir;
+
+  @Test
+  public void testReplicationPropagatesThroughFileAppender() throws IOException {
+    Configuration conf = captureConf();
+    Path path = newPath("data-file.orc");
+    OutputFile out = HadoopOutputFile.fromPath(path, conf, CUSTOM_REPLICATION);
+    assertThat(((HadoopOutputFile) out).replication()).isEqualTo(CUSTOM_REPLICATION);
+
+    try (FileAppender<Record> appender =
+        ORC.write(out).schema(SCHEMA).createWriterFunc(GenericOrcWriter::buildWriter).build()) {
+      appender.add(record(1));
+    }
+
+    assertThat(CaptureReplicationFileSystem.capturedReplication(path))
+        .isEqualTo(CUSTOM_REPLICATION);
+
+    // the file written through the OutputFileSystem path must still be valid ORC
+    List<Record> rows = Lists.newArrayList();
+    try (CloseableIterable<Record> reader =
+        ORC.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(SCHEMA, fileSchema))
+            .build()) {
+      reader.forEach(rows::add);
+    }
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getField("id")).isEqualTo(1);
+  }
+
+  @Test
+  public void testReplicationPropagatesThroughPositionDeleteWriter() throws IOException {
+    Configuration conf = captureConf();
+    Path path = newPath("position-deletes.orc");
+    OutputFile out = HadoopOutputFile.fromPath(path, conf, CUSTOM_REPLICATION);
+
+    PositionDeleteWriter<Record> deleteWriter =
+        ORC.writeDeletes(out)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .withSpec(PartitionSpec.unpartitioned())
+            .buildPositionWriter();
+
+    PositionDelete<Record> delete = PositionDelete.create();
+    try (PositionDeleteWriter<Record> writer = deleteWriter) {
+      writer.write(delete.set("file:/data/data-file.orc", 0L, null));
+    }
+
+    assertThat(deleteWriter.toDeleteFile().recordCount()).isEqualTo(1L);
+    assertThat(CaptureReplicationFileSystem.capturedReplication(path))
+        .isEqualTo(CUSTOM_REPLICATION);
+  }
+
+  @Test
+  public void testFilesystemDefaultReplicationWhenNotConfigured() throws IOException {
+    Configuration conf = captureConf();
+    Path path = newPath("default-replication.orc");
+    OutputFile out = HadoopOutputFile.fromPath(path, conf);
+
+    try (FileAppender<Record> appender =
+        ORC.write(out).schema(SCHEMA).createWriterFunc(GenericOrcWriter::buildWriter).build()) {
+      appender.add(record(2));
+    }
+
+    short fsDefault = path.getFileSystem(conf).getDefaultReplication(path);
+    assertThat(CaptureReplicationFileSystem.capturedReplication(path)).isEqualTo(fsDefault);
+  }
+
+  private Path newPath(String name) {
+    return new Path(new File(tempDir, name).toURI());
+  }
+
+  private Configuration captureConf() {
+    Configuration conf = new Configuration();
+    conf.setClass("fs.file.impl", CaptureReplicationFileSystem.class, FileSystem.class);
+    conf.setBoolean("fs.file.impl.disable.cache", true);
+    return conf;
+  }
+
+  private Record record(int id) {
+    Record record = GenericRecord.create(SCHEMA);
+    record.setField("id", id);
+    return record;
+  }
+
+  /** Local filesystem that records the replication factor passed to each stream creation. */
+  public static class CaptureReplicationFileSystem extends RawLocalFileSystem {
+    private static final Map<String, Short> CAPTURED = Maps.newConcurrentMap();
+
+    static short capturedReplication(Path path) {
+      Short replication = CAPTURED.get(path.getName());
+      assertThat(replication).as("No stream was created for %s", path).isNotNull();
+      return replication;
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path path,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      CAPTURED.put(path.getName(), replication);
+      return super.create(path, overwrite, bufferSize, replication, blockSize, progress);
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path path,
+        FsPermission permission,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      CAPTURED.put(path.getName(), replication);
+      return super.create(
+          path, permission, overwrite, bufferSize, replication, blockSize, progress);
+    }
+  }
+}

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestOrcDeleteFileReplication.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestOrcDeleteFileReplication.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end SQL tests for delete file replication with ORC.
+ *
+ * <p>The catalog warehouse lives on a dedicated {@code capturefs:} filesystem that records the
+ * replication factor passed to every {@link FileSystem#create} call, which is what HDFS would
+ * receive in production. The full write path is exercised through SQL only: {@code CREATE TABLE}
+ * with merge-on-read ORC, {@code INSERT}, {@code DELETE}, and the {@code delete_files} metadata
+ * table for locating the produced position delete files.
+ */
+public class TestOrcDeleteFileReplication extends TestBase {
+
+  private static final String CATALOG = "repltestcat";
+  private static final String TABLE = CATALOG + ".default.orc_repl_test";
+
+  @BeforeAll
+  public static void setUpCatalog() throws IOException {
+    // session confs are copied into sessionState().newHadoopConf(), which SparkCatalog uses
+    spark.conf().set("fs.capturefs.impl", CaptureReplicationFileSystem.class.getName());
+    spark.conf().set("fs.capturefs.impl.disable.cache", "true");
+
+    String warehouse = Files.createTempDirectory("orc-repl-warehouse").toString();
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", "capturefs:" + warehouse);
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    spark.conf().unset(SparkSQLProperties.DELETE_FILE_REPLICATION);
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @Test
+  public void testDeleteFileReplicationFromTableProperty() {
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='2', "
+            + "'write.delete.mode'='merge-on-read', "
+            + "'write.format.default'='orc', "
+            + "'write.delete-file-replication'='5')",
+        TABLE);
+
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')", TABLE);
+    sql("DELETE FROM %s WHERE id IN (1, 2)", TABLE);
+
+    // the delete files must reach the filesystem with the configured replication factor
+    List<Object[]> deleteFiles = sql("SELECT file_path FROM %s.delete_files", TABLE);
+    assertThat(deleteFiles).isNotEmpty();
+    for (Object[] row : deleteFiles) {
+      String location = (String) row[0];
+      assertThat(location).endsWith(".orc");
+      assertThat(CaptureReplicationFileSystem.capturedReplication(location))
+          .as("Delete file %s should be created with the configured replication", location)
+          .isEqualTo((short) 5);
+    }
+
+    // data files are not covered by the delete file replication setting
+    List<Object[]> dataFiles = sql("SELECT file_path FROM %s.files WHERE content = 0", TABLE);
+    assertThat(dataFiles).isNotEmpty();
+    for (Object[] row : dataFiles) {
+      String location = (String) row[0];
+      assertThat(CaptureReplicationFileSystem.capturedReplication(location))
+          .as("Data file %s should keep the filesystem default replication", location)
+          .isNotEqualTo((short) 5);
+    }
+
+    // merge-on-read must still resolve the deletes on read
+    assertThat(sql("SELECT id FROM %s ORDER BY id", TABLE))
+        .extracting(row -> row[0])
+        .containsExactly(3, 4, 5);
+  }
+
+  @Test
+  public void testDeleteFileReplicationFromSqlSessionConf() {
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='2', "
+            + "'write.delete.mode'='merge-on-read', "
+            + "'write.format.default'='orc')",
+        TABLE);
+
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')", TABLE);
+
+    // the key contains hyphens, so the Spark SQL parser requires backquotes
+    sql("SET `%s`=7", SparkSQLProperties.DELETE_FILE_REPLICATION);
+    sql("DELETE FROM %s WHERE id IN (1, 2)", TABLE);
+
+    List<Object[]> deleteFiles = sql("SELECT file_path FROM %s.delete_files", TABLE);
+    assertThat(deleteFiles).isNotEmpty();
+    for (Object[] row : deleteFiles) {
+      String location = (String) row[0];
+      assertThat(location).endsWith(".orc");
+      assertThat(CaptureReplicationFileSystem.capturedReplication(location))
+          .as("Delete file %s should be created with the session conf replication", location)
+          .isEqualTo((short) 7);
+    }
+
+    assertThat(sql("SELECT id FROM %s ORDER BY id", TABLE))
+        .extracting(row -> row[0])
+        .containsExactly(3, 4, 5);
+  }
+
+  /**
+   * Local filesystem under a dedicated {@code capturefs:} scheme that records the replication
+   * factor passed to each stream creation.
+   */
+  public static class CaptureReplicationFileSystem extends RawLocalFileSystem {
+    private static final Map<String, Short> CAPTURED = Maps.newConcurrentMap();
+
+    static short capturedReplication(String location) {
+      String name = new Path(location).getName();
+      Short replication = CAPTURED.get(name);
+      assertThat(replication).as("No stream was created for %s", location).isNotNull();
+      return replication;
+    }
+
+    @Override
+    public String getScheme() {
+      return "capturefs";
+    }
+
+    @Override
+    public URI getUri() {
+      return URI.create("capturefs:///");
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path path,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      CAPTURED.put(path.getName(), replication);
+      return super.create(path, overwrite, bufferSize, replication, blockSize, progress);
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path path,
+        FsPermission permission,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      CAPTURED.put(path.getName(), replication);
+      return super.create(
+          path, permission, overwrite, bufferSize, replication, blockSize, progress);
+    }
+  }
+}


### PR DESCRIPTION
## Problem Summary

PRs #219 and #229 added support for configuring the replication factor of delete files
(`delete-file-replication` write option, `spark.sql.iceberg.delete-file-replication` session
conf, `write.delete-file-replication` table property). The configured value is resolved
correctly by `SparkWriteConf` and carried all the way into Iceberg's `HadoopOutputFile`, but
for **ORC delete files it never reaches HDFS**.

Root cause: `ORC.newFileWriter` short-circuits Hadoop-backed output files by handing ORC the
raw Hadoop `FileSystem`:

```java
if (file instanceof HadoopOutputFile) {
  options.fileSystem(((HadoopOutputFile) file).getFileSystem());
}
```
ORC's PhysicalFsWriter then opens the output stream itself via `fs.create(path, overwrite, bufferSize, fs.getDefaultReplication(path), blockSize)` — using the filesystem default replication and discarding the replication factor carried by the Iceberg HadoopOutputFile. Iceberg's HadoopOutputFile.create(), the only place the configured replication is applied, is never invoked. As a result, merge-on-read DELETE/UPDATE/MERGE on ORC tables always produces delete files with the cluster default replication regardless of configuration.

## Solution

- Expose the configured replication on HadoopOutputFile via a replication() accessor (non-positive means "not configured").
- In ORC.newFileWriter (and the matching spot in OrcFileAppender), take the raw-filesystem shortcut only when no custom replication is configured. When a replication factor is set, route the file through FileIOFSUtil.OutputFileSystem — the same path already used for non-Hadoop FileIO implementations — so the output stream is created by Iceberg's HadoopOutputFile.create(), which passes the configured replication to `fs.create(...)`.

Behavior is unchanged when no replication is configured: the raw-filesystem shortcut is still
used and files inherit the filesystem default.

## Testing Done

Unit tests — orc:TestOrcReplication (new): writes through the plain ORC FileAppender and the position-delete writer against a RawLocalFileSystem subclass that records the replication factor passed to every FileSystem.create(...) call:
- configured replication (5) reaches stream creation for data appender and position-delete writer; the file written through the OutputFileSystem path reads back as valid OR
- with nothing configured, the filesystem default replication is used (shortcut preserved)

Integration tests (SQL-only) — spark 3.5:TestOrcDeleteFileReplication (new): the catalog warehouse lives on a capturing filesystem, and the whole flow is driven through 

CREATE TABLE (format-version 2, merge-on-read, ORC) → INSERT → DELETE →
SELECT file_path FROM t.delete_files:
- write.delete-file-replication'='5' table property → all position delete files created with
replication 5; data files keep the filesystem default; SELECT after DELETE return
rows (deletes apply on read)
- SET `spark.sql.iceberg.delete-file-replication`=7 session conf → delete files c
with replication 7 (note: the hyphenated key must be backquoted in Spark SQL SET)

