### PR TITLE
ORC: bind struct fields by Iceberg field id in generic and Spark 3.5 readers

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.orc;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests specifically targeting the id-based field binding path of {@link GenericOrcReaders}. These
+ * exercise branches of the id-binding {@code StructReader} constructor that the shared projection
+ * tests do not, and assert that id-binding produces the same results positional binding would.
+ */
+public class TestGenericOrcReaderIdBinding {
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private List<Record> writeAndRead(
+      String desc, Schema writeSchema, Schema readSchema, List<Record> records) throws IOException {
+    return writeAndRead(desc, writeSchema, readSchema, records, ImmutableMap.of());
+  }
+
+  private List<Record> writeAndRead(
+      String desc,
+      Schema writeSchema,
+      Schema readSchema,
+      List<Record> records,
+      Map<Integer, ?> idToConstant)
+      throws IOException {
+    File file = temp.newFile(desc + ".orc");
+    Assert.assertTrue("Delete should succeed", file.delete());
+
+    try (FileAppender<Record> appender =
+        ORC.write(Files.localOutput(file))
+            .schema(writeSchema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .build()) {
+      appender.addAll(records);
+    }
+
+    // Project only fields that physically exist in the file (excluding metadata columns) so that
+    // buildOrcProjection succeeds, but hand the reader the full read schema so the id-binding
+    // constructor resolves metadata/constant fields.
+    Schema projection = TypeUtil.selectNot(readSchema, MetadataColumns.metadataFieldIds());
+    try (CloseableIterable<Record> reader =
+        ORC.read(Files.localInput(file))
+            .project(projection)
+            .createReaderFunc(
+                fileSchema -> GenericOrcReader.buildReader(readSchema, fileSchema, idToConstant))
+            .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+
+  @Test
+  public void testTypePromotion() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "f", Types.FloatType.get()),
+            required(3, "dec", Types.DecimalType.of(9, 2)));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("id", 42);
+    record.setField("f", 1.5f);
+    record.setField("dec", new BigDecimal("123.45"));
+
+    Schema promotedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "f", Types.DoubleType.get()),
+            required(3, "dec", Types.DecimalType.of(11, 2)));
+
+    Record projected =
+        writeAndRead("type_promotion", writeSchema, promotedSchema, Lists.newArrayList(record))
+            .get(0);
+
+    Assert.assertEquals("int should be promoted to long", 42L, projected.getField("id"));
+    Assert.assertEquals(
+        "float should be promoted to double", 1.5d, (double) projected.getField("f"), 0.0d);
+    Assert.assertEquals(
+        "decimal precision should widen", new BigDecimal("123.45"), projected.getField("dec"));
+  }
+
+  @Test
+  public void testReorderedProjectionValues() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "a", Types.LongType.get()),
+            optional(2, "b", Types.StringType.get()),
+            required(3, "c", Types.IntegerType.get()));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("a", 10L);
+    record.setField("b", "hello");
+    record.setField("c", 7);
+
+    // Read schema requests the fields in a different order than the file's physical column order.
+    Schema reordered =
+        new Schema(
+            required(3, "c", Types.IntegerType.get()),
+            required(1, "a", Types.LongType.get()),
+            optional(2, "b", Types.StringType.get()));
+
+    Record projected =
+        writeAndRead("reordered", writeSchema, reordered, Lists.newArrayList(record)).get(0);
+
+    Assert.assertEquals("c should bind by id", 7, projected.getField("c"));
+    Assert.assertEquals("a should bind by id", 10L, projected.getField("a"));
+    Assert.assertEquals("b should bind by id", "hello", projected.getField("b").toString());
+  }
+
+  @Test
+  public void testMetadataColumns() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+    List<Record> records = Lists.newArrayList();
+    for (long i = 0; i < 5; i++) {
+      Record record = GenericRecord.create(writeSchema.asStruct());
+      record.setField("id", i);
+      record.setField("data", "row" + i);
+      records.add(record);
+    }
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            MetadataColumns.ROW_POSITION,
+            MetadataColumns.IS_DELETED);
+
+    List<Record> projected = writeAndRead("metadata_columns", writeSchema, readSchema, records);
+
+    Assert.assertEquals(5, projected.size());
+    for (int i = 0; i < projected.size(); i++) {
+      Record record = projected.get(i);
+      Assert.assertEquals("id should read from file", (long) i, record.getField("id"));
+      Assert.assertEquals(
+          "data should read from file", "row" + i, record.getField("data").toString());
+      Assert.assertEquals(
+          "_pos should be the row position",
+          (long) i,
+          record.getField(MetadataColumns.ROW_POSITION.name()));
+      Assert.assertEquals(
+          "_deleted should be false", false, record.getField(MetadataColumns.IS_DELETED.name()));
+    }
+  }
+
+  @Test
+  public void testIdToConstant() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("id", 1L);
+    record.setField("data", "value");
+
+    // Read schema adds an identity-partition-style constant field (id 3) not present in the file.
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "part", Types.StringType.get()));
+
+    Record projected =
+        writeAndRead(
+                "id_to_constant",
+                writeSchema,
+                readSchema,
+                Lists.newArrayList(record),
+                ImmutableMap.of(3, "constant-partition"))
+            .get(0);
+
+    Assert.assertEquals("id should read from file", 1L, projected.getField("id"));
+    Assert.assertEquals(
+        "data should read from file", "value", projected.getField("data").toString());
+    Assert.assertEquals(
+        "part should resolve from idToConstant", "constant-partition", projected.getField("part"));
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
@@ -24,8 +24,11 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
@@ -34,10 +37,21 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.orc.ORCSchemaUtil;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -148,6 +162,35 @@ public class TestGenericOrcReaderIdBinding {
   }
 
   @Test
+  public void testNonIdentityFieldIdMapping() {
+    Schema expectedSchema =
+        new Schema(
+            required(10, "first", Types.LongType.get()),
+            required(20, "second", Types.StringType.get()));
+    Schema orcSchema =
+        new Schema(
+            required(20, "second", Types.StringType.get()),
+            required(10, "first", Types.LongType.get()));
+    TypeDescription orcType = ORCSchemaUtil.convert(orcSchema);
+
+    List<OrcValueReader<?>> readers =
+        Lists.newArrayList(GenericOrcReaders.strings(), OrcValueReaders.longs());
+    OrcValueReader<Record> reader =
+        GenericOrcReaders.struct(orcType, readers, expectedSchema.asStruct(), ImmutableMap.of());
+
+    BytesColumnVector second = new BytesColumnVector(1);
+    byte[] secondValue = "value".getBytes(StandardCharsets.UTF_8);
+    second.setRef(0, secondValue, 0, secondValue.length);
+    LongColumnVector first = new LongColumnVector(1);
+    first.vector[0] = 34L;
+    StructColumnVector vector = new StructColumnVector(1, new ColumnVector[] {second, first});
+
+    Record actual = reader.read(vector, 0);
+    Assert.assertEquals("first should bind from ORC index 1", 34L, actual.get(0));
+    Assert.assertEquals("second should bind from ORC index 0", "value", actual.get(1));
+  }
+
+  @Test
   public void testMetadataColumns() throws IOException {
     Schema writeSchema =
         new Schema(
@@ -216,5 +259,76 @@ public class TestGenericOrcReaderIdBinding {
         "data should read from file", "value", projected.getField("data").toString());
     Assert.assertEquals(
         "part should resolve from idToConstant", "constant-partition", projected.getField("part"));
+  }
+
+  @Test
+  public void testIdLessFileBindsThroughNameMapping() throws IOException {
+    // Files migrated from Hive carry no Iceberg field ids. They are resolved by name mapping, which
+    // stamps ids onto the projection before the reader binds, so id-binding must still produce the
+    // values positional binding produced. A field absent from such a file must read null.
+    File file = writeIdLessFile("id_less");
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "added_after_migration", Types.StringType.get()));
+
+    List<Record> projected;
+    try (CloseableIterable<Record> reader =
+        ORC.read(Files.localInput(file))
+            .project(readSchema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(readSchema, fileSchema))
+            .build()) {
+      projected = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals(3, projected.size());
+    for (int i = 0; i < projected.size(); i++) {
+      Record record = projected.get(i);
+      Assert.assertEquals("id should bind by name mapping", (long) i, record.getField("id"));
+      Assert.assertEquals(
+          "data should bind by name mapping", "row" + i, record.getField("data").toString());
+      Assert.assertNull(
+          "field absent from an id-less file should read null",
+          record.getField("added_after_migration"));
+    }
+  }
+
+  /**
+   * Writes an ORC file directly, without the Iceberg writer, so it carries no field id attributes.
+   */
+  private File writeIdLessFile(String desc) throws IOException {
+    File file = temp.newFile(desc + ".orc");
+    Assert.assertTrue("Delete should succeed", file.delete());
+
+    TypeDescription writerSchema = TypeDescription.fromString("struct<id:bigint,data:string>");
+    try (org.apache.orc.Writer writer =
+        OrcFile.createWriter(
+            new Path(file.toString()),
+            OrcFile.writerOptions(new Configuration()).setSchema(writerSchema))) {
+      VectorizedRowBatch batch = writerSchema.createRowBatch();
+      LongColumnVector ids = (LongColumnVector) batch.cols[0];
+      BytesColumnVector data = (BytesColumnVector) batch.cols[1];
+      for (long i = 0; i < 3; i++) {
+        int row = batch.size++;
+        ids.vector[row] = i;
+        data.setVal(row, ("row" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      writer.addRowBatch(batch);
+    }
+
+    // Without this the test could silently exercise the id-bearing path it is meant to avoid.
+    try (Reader orcReader =
+        OrcFile.createReader(
+            new Path(file.toString()), OrcFile.readerOptions(new Configuration()))) {
+      for (TypeDescription child : orcReader.getSchema().getChildren()) {
+        Assert.assertNull(
+            "migrated file should carry no iceberg field ids",
+            child.getAttributeValue("iceberg.id"));
+      }
+    }
+
+    return file;
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -76,7 +76,7 @@ public class GenericOrcReader implements OrcRowReader<Record> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return GenericOrcReaders.struct(fields, expected, idToConstant);
+      return GenericOrcReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override
@@ -96,6 +96,10 @@ public class GenericOrcReader implements OrcRowReader<Record> {
 
     @Override
     public OrcValueReader<?> primitive(Type.PrimitiveType iPrimitive, TypeDescription primitive) {
+      if (iPrimitive == null) {
+        return null;
+      }
+
       switch (primitive.getCategory()) {
         case BOOLEAN:
           return OrcValueReaders.booleans();

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -51,9 +52,23 @@ public class GenericOrcReaders {
 
   private GenericOrcReaders() {}
 
+  /**
+   * @deprecated Use {@link #struct(TypeDescription, List, Types.StructType, Map)} instead. This
+   *     method uses position-based binding which may cause field misalignment in MOR and lineage
+   *     scenarios.
+   */
+  @Deprecated
   public static OrcValueReader<Record> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
     return new StructReader(readers, struct, idToConstant);
+  }
+
+  public static OrcValueReader<Record> struct(
+      TypeDescription orcType,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(orcType, readers, struct, idToConstant);
   }
 
   public static OrcValueReader<List<?>> array(OrcValueReader<?> elementReader) {
@@ -204,12 +219,27 @@ public class GenericOrcReaders {
   private static class StructReader extends OrcValueReaders.StructReader<Record> {
     private final GenericRecord template;
 
+    /**
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     and lineage scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers,
         Types.StructType structType,
         Map<Integer, ?> idToConstant) {
       super(readers, structType, idToConstant);
-      this.template = structType != null ? GenericRecord.create(structType) : null;
+      this.template = GenericRecord.create(structType);
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType structType,
+        Map<Integer, ?> idToConstant) {
+      super(orcType, readers, structType, idToConstant);
+      this.template = GenericRecord.create(structType);
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -22,7 +22,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DoubleColumnVector;
@@ -134,12 +137,27 @@ public class OrcValueReaders {
   public abstract static class StructReader<T> implements OrcValueReader<T> {
     private final OrcValueReader<?>[] readers;
     private final boolean[] isConstantOrMetadataField;
+    // Maps each projected struct field position to the matching child index in the ORC schema.
+    // This allows fields to be read by Iceberg field ID when the projected struct order differs
+    // from the file schema.
+    private final int[] orcFieldIndex;
 
+    /**
+     * @param readers readers for each field
+     * @param struct struct type
+     * @param idToConstant constant values by field id
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
+      this.orcFieldIndex = null;
+
       for (int pos = 0, readerIndex = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
         if (idToConstant.containsKey(field.fieldId())) {
@@ -152,13 +170,79 @@ public class OrcValueReaders {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(false);
         } else if (MetadataColumns.isMetadataColumn(field.name())) {
-          // in case of any other metadata field, fill with nulls
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(null);
         } else {
           this.readers[pos] = readers.get(readerIndex++);
         }
       }
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      List<Types.NestedField> fields = struct.fields();
+      this.readers = new OrcValueReader[fields.size()];
+      this.isConstantOrMetadataField = new boolean[fields.size()];
+      this.orcFieldIndex = new int[fields.size()];
+
+      Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(orcType, readers);
+      Map<Integer, Integer> fieldIdToOrcIndex = buildFieldIdToOrcIndex(orcType);
+
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Types.NestedField field = fields.get(pos);
+        OrcValueReader<?> fileReader = readersById.get(field.fieldId());
+
+        if (idToConstant.containsKey(field.fieldId())) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(idToConstant.get(field.fieldId()));
+        } else if (field.equals(MetadataColumns.ROW_POSITION)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = new RowPositionReader();
+        } else if (field.equals(MetadataColumns.IS_DELETED)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(false);
+        } else if (fileReader != null) {
+          this.isConstantOrMetadataField[pos] = false;
+          this.orcFieldIndex[pos] = fieldIdToOrcIndex.getOrDefault(field.fieldId(), -1);
+          this.readers[pos] = fileReader;
+        } else if (MetadataColumns.isMetadataColumn(field.name())) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(null);
+        } else {
+          throw new IllegalArgumentException(
+              String.format("Missing ORC reader for field %s (%s)", field.name(), field.fieldId()));
+        }
+      }
+    }
+
+    private Map<Integer, Integer> buildFieldIdToOrcIndex(TypeDescription orcType) {
+      List<TypeDescription> children = orcType.getChildren();
+      Map<Integer, Integer> mapping = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i++) {
+        mapping.put(ORCSchemaUtil.fieldId(children.get(i)), i);
+      }
+
+      return mapping;
+    }
+
+    private Map<Integer, OrcValueReader<?>> readersByFieldId(
+        TypeDescription orcType, List<OrcValueReader<?>> readerList) {
+      List<TypeDescription> children = orcType.getChildren();
+      Preconditions.checkState(
+          children.size() == readerList.size(),
+          "Invalid ORC reader binding: children=%s readers=%s",
+          children.size(),
+          readerList.size());
+
+      Map<Integer, OrcValueReader<?>> readersById = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i += 1) {
+        readersById.put(ORCSchemaUtil.fieldId(children.get(i)), readerList.get(i));
+      }
+
+      return readersById;
     }
 
     protected abstract T create();
@@ -176,14 +260,17 @@ public class OrcValueReaders {
     }
 
     private T readInternal(T struct, ColumnVector[] columnVectors, int row) {
-      for (int c = 0, vectorIndex = 0; c < readers.length; ++c) {
+      int vectorIndex = 0;
+      for (int c = 0; c < readers.length; ++c) {
         ColumnVector vector;
         if (isConstantOrMetadataField[c]) {
           vector = null;
+        } else if (orcFieldIndex != null) {
+          vector = columnVectors[orcFieldIndex[c]];
         } else {
-          vector = columnVectors[vectorIndex];
-          vectorIndex++;
+          vector = columnVectors[vectorIndex++];
         }
+
         set(struct, c, reader(c).read(vector, row));
       }
       return struct;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -69,9 +70,23 @@ public class SparkOrcValueReaders {
     }
   }
 
+  /**
+   * @deprecated Use {@link #struct(TypeDescription, List, Types.StructType, Map)} instead. This
+   *     method uses position-based binding which may cause field misalignment in MOR and lineage
+   *     scenarios.
+   */
+  @Deprecated
   static OrcValueReader<?> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
     return new StructReader(readers, struct, idToConstant);
+  }
+
+  static OrcValueReader<?> struct(
+      TypeDescription orcType,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(orcType, readers, struct, idToConstant);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -142,9 +157,24 @@ public class SparkOrcValueReaders {
   static class StructReader extends OrcValueReaders.StructReader<InternalRow> {
     private final int numFields;
 
+    /**
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     and lineage scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
       super(readers, struct, idToConstant);
+      this.numFields = struct.fields().size();
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(orcType, readers, struct, idToConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReader.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -32,10 +33,19 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.orc.ORCSchemaUtil;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.ColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
@@ -46,6 +56,37 @@ public class TestSparkOrcReader extends AvroDataTest {
     final Iterable<InternalRow> expected = RandomData.generateSpark(schema, 100, 0L);
 
     writeAndValidateRecords(schema, expected);
+  }
+
+  @Test
+  public void nonIdentityFieldIdMapping() {
+    Schema expectedSchema =
+        new Schema(
+            required(10, "first", Types.LongType.get()),
+            required(20, "second", Types.StringType.get()));
+    Schema orcSchema =
+        new Schema(
+            required(20, "second", Types.StringType.get()),
+            required(10, "first", Types.LongType.get()));
+    TypeDescription orcType = ORCSchemaUtil.convert(orcSchema);
+
+    List<OrcValueReader<?>> readers =
+        Lists.newArrayList(SparkOrcValueReaders.utf8String(), OrcValueReaders.longs());
+    OrcValueReader<?> reader =
+        SparkOrcValueReaders.struct(orcType, readers, expectedSchema.asStruct(), ImmutableMap.of());
+
+    BytesColumnVector second = new BytesColumnVector(1);
+    byte[] secondValue = "value".getBytes(StandardCharsets.UTF_8);
+    second.setRef(0, secondValue, 0, secondValue.length);
+    LongColumnVector first = new LongColumnVector(1);
+    first.vector[0] = 34L;
+    StructColumnVector vector = new StructColumnVector(1, new ColumnVector[] {second, first});
+
+    InternalRow actual = (InternalRow) reader.read(vector, 0);
+    assertThat(actual.getLong(0)).as("first should bind from ORC index 1").isEqualTo(34L);
+    assertThat(actual.getUTF8String(1).toString())
+        .as("second should bind from ORC index 0")
+        .isEqualTo("value");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Backports the upstream **id-based ORC `StructReader` binding** (apache/iceberg [`77e7dbb24`](https://github.com/apache/iceberg/commit/77e7dbb24), [PR #15776](https://github.com/apache/iceberg/pull/15776)) to the **`openhouse-1.5.2`** line. This is the 1.5.x companion to the 1.2.x backport in #256, targeting **Spark 3.5**.

**What changes:** the ORC reader used to bind struct fields **positionally** — consuming ORC column vectors in projection order, assuming projected field order matches the file's physical column order. This PR switches the converted readers to **id-based binding**: each expected field is matched to its ORC column by its **Iceberg field id**, robust to field reordering and schema evolution.

**Why it's safe:** `buildOrcProjection` already normalizes column order, so id-based binding produces **identical** results to positional binding on all current inputs. It is behavior-preserving — and the prerequisite for the follow-up work (see Next steps).

## Review this after #256 — it is nearly the same change

The ORC core of this PR is **byte-identical** to #256. Proof (renders "the branches are identical"): https://github.com/cbb330/iceberg-apache/compare/compare/orc-id-binding-shared-core...compare/orc-id-binding-shared-core-1.5.x

So the only thing that genuinely needs fresh review here is the **Spark 3.5** wiring. Everything else mirrors #256 (whose inline annotations classify each change).

## How id-based binding works (quick primer)

An ORC file stores columns in a physical order. Iceberg has an *expected schema*, and every field has a permanent numeric **field id**. Positional binding = "the Nth expected field is the Nth file column" (trusts order); id-based binding = "match each expected field to the file column with the same field id" (order-independent). The real logic lives in the shared `OrcValueReaders.StructReader` base class; the per-engine reader edits just thread the ORC file schema (`TypeDescription`) down to it and opt in.

## Provenance of each change

| Change | Classification |
|---|---|
| `OrcValueReaders`, `GenericOrcReaders`, `GenericOrcReader` | **Backported ~verbatim** — byte-identical to #256 (minus the omitted branches below) |
| `SparkOrcValueReaders` / `SparkOrcReader` (v3.5) | **Backported with adaptation** — same shape; retains the `@Deprecated` positional overload upstream deleted. Notably `SparkOrcReader`'s one-liner is **exactly what upstream `main` already ships** for Spark 3.5 (see divergence comment). |
| `TestGenericOrcReaderIdBinding` | **Net new**, modeled on shipped `TestSparkOrcReadMetadataColumns` / `TestGenericReadProjection` |

## Adaptations vs `apache/main`

1.5.x lacks the constructs the upstream commit references, so these are intentionally **omitted** (they would not compile on 1.5.x):

1. **Row-lineage** — `ROW_ID` / `LAST_UPDATED_SEQUENCE_NUMBER` branches, `handleRowIdField` / `handleLastUpdatedSeqField`, `RowIdReader` / `LastUpdatedSeqReader`.
2. **`UNKNOWN` type** clause in the metadata fallback.
3. **`VARIANT`** reader/visitor.

Everything else is aligned to upstream verbatim.

## Scope

Only `GenericOrcReaders` and **Spark 3.5** `SparkOrcValueReaders` are converted. The positional constructor/overloads are **retained and `@Deprecated`** because the unconverted readers (Spark 3.3/3.4, Flink) still call them.

## Reviewing the divergence from upstream

- Upstream source: [PR #15776](https://github.com/apache/iceberg/pull/15776) / commit [`77e7dbb24`](https://github.com/apache/iceberg/commit/77e7dbb24)
- **Interactive** compare vs `apache/main`: https://github.com/apache/iceberg/compare/main...cbb330:iceberg-apache:compare/orc-id-binding-1.5.x-vs-apache-main _(hit Retry if it says "taking too long to generate")_
- **Embedded, always-renders** copy: see the pinned **"Divergence vs `apache/main`"** comment on this PR.

## Testing Done

- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing performed

Validated on JDK 11:

- `./gradlew :iceberg-data:test --tests TestGenericOrcReaderIdBinding` — pass (type promotion, reordered projection, `_pos` / `_deleted`, `idToConstant`).
- `./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 :iceberg-spark:iceberg-spark-3.5_2.12:test` (incl. `TestSparkOrcReader`, `TestSparkOrcReadMetadataColumns`) — pass.
- `./gradlew :iceberg-orc:revapi` — pass; no `.palantir/revapi.yml` change needed.
- `spotlessApply` clean; `iceberg-orc` / `iceberg-data` / `iceberg-spark-3.5_2.12` compile.

## Next steps (this is step 1 of 2)

This PR lands **only the binding mechanism** and does not change read output. The motivating follow-up is **column default values**: once fields are bound by id, a subsequent change can use those bound ids to resolve and apply an Iceberg field's **initial-default** value for fields present in the expected schema but absent from the ORC file (which today read as `null`). Defaults are only correct once binding is keyed on field id rather than position, so this PR is the prerequisite. Defaults will land as a separate PR on top of this one.