### PR TITLE
ORC: fill initial defaults for missing id-bound fields

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -66,6 +66,11 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.io.DataWriter<T>::add(T)"
       justification: "Removing deprecated method"
   "1.1.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.types.Types.NestedField"
+      new: "class org.apache.iceberg.types.Types.NestedField"
+      justification: "Added initial-default/write-default to NestedField for the column default value API; serialization id change only"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.noLongerImplementsInterface"
       old: "class org.apache.iceberg.jdbc.JdbcCatalog"

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -233,6 +233,18 @@ public class Expressions {
     return predicate(Operation.NOT_IN, expr, values);
   }
 
+  /**
+   * Create a {@link Literal} from an Object.
+   *
+   * @param value a value
+   * @param <T> Java type of value
+   * @return a Literal for the given value
+   * @throws IllegalArgumentException if the value has no literal implementation
+   */
+  public static <T> Literal<T> lit(T value) {
+    return Literals.from(value);
+  }
+
   public static <T> UnboundPredicate<T> predicate(Operation op, String name, T value) {
     return predicate(op, name, Literals.from(value));
   }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -413,27 +415,141 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type, null);
+      return new NestedField(true, id, name, type, null, null, null);
     }
 
     public static NestedField optional(int id, String name, Type type, String doc) {
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, null, null);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type, null);
+      return new NestedField(false, id, name, type, null, null, null);
     }
 
     public static NestedField required(int id, String name, Type type, String doc) {
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
-      return new NestedField(isOptional, id, name, type, null);
+      return new NestedField(isOptional, id, name, type, null, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
-      return new NestedField(isOptional, id, name, type, doc);
+      return new NestedField(isOptional, id, name, type, doc, null, null);
+    }
+
+    public static Builder from(NestedField field) {
+      return new Builder(field);
+    }
+
+    public static Builder required(String name) {
+      return new Builder(false, name);
+    }
+
+    public static Builder optional(String name) {
+      return new Builder(true, name);
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private boolean isOptional = true;
+      private String name = null;
+      private Integer id = null;
+      private Type type = null;
+      private String doc = null;
+      private Literal<?> initialDefault = null;
+      private Literal<?> writeDefault = null;
+
+      private Builder() {}
+
+      private Builder(boolean isFieldOptional, String fieldName) {
+        isOptional = isFieldOptional;
+        name = fieldName;
+      }
+
+      private Builder(NestedField toCopy) {
+        this.isOptional = toCopy.isOptional;
+        this.name = toCopy.name;
+        this.id = toCopy.id;
+        this.type = toCopy.type;
+        this.doc = toCopy.doc;
+        this.initialDefault = toCopy.initialDefault;
+        this.writeDefault = toCopy.writeDefault;
+      }
+
+      public Builder asRequired() {
+        this.isOptional = false;
+        return this;
+      }
+
+      public Builder asOptional() {
+        this.isOptional = true;
+        return this;
+      }
+
+      public Builder isOptional(boolean fieldIsOptional) {
+        this.isOptional = fieldIsOptional;
+        return this;
+      }
+
+      public Builder withName(String fieldName) {
+        this.name = fieldName;
+        return this;
+      }
+
+      public Builder withId(int fieldId) {
+        id = fieldId;
+        return this;
+      }
+
+      public Builder ofType(Type fieldType) {
+        type = fieldType;
+        return this;
+      }
+
+      public Builder withDoc(String fieldDoc) {
+        doc = fieldDoc;
+        return this;
+      }
+
+      /**
+       * Set the initial default using an Object.
+       *
+       * @deprecated will be removed in 2.0.0; use {@link #withInitialDefault(Literal)} instead.
+       */
+      @Deprecated
+      public Builder withInitialDefault(Object fieldInitialDefault) {
+        return withInitialDefault(Expressions.lit(fieldInitialDefault));
+      }
+
+      public Builder withInitialDefault(Literal<?> fieldInitialDefault) {
+        initialDefault = fieldInitialDefault;
+        return this;
+      }
+
+      /**
+       * Set the write default using an Object.
+       *
+       * @deprecated will be removed in 2.0.0; use {@link #withWriteDefault(Literal)} instead.
+       */
+      @Deprecated
+      public Builder withWriteDefault(Object fieldWriteDefault) {
+        return withWriteDefault(Expressions.lit(fieldWriteDefault));
+      }
+
+      public Builder withWriteDefault(Literal<?> fieldWriteDefault) {
+        writeDefault = fieldWriteDefault;
+        return this;
+      }
+
+      public NestedField build() {
+        Preconditions.checkNotNull(id, "Id cannot be null");
+        // the constructor validates the other fields
+        return new NestedField(isOptional, id, name, type, doc, initialDefault, writeDefault);
+      }
     }
 
     private final boolean isOptional;
@@ -441,8 +557,17 @@ public class Types {
     private final String name;
     private final Type type;
     private final String doc;
+    private final Literal<?> initialDefault;
+    private final Literal<?> writeDefault;
 
-    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+    private NestedField(
+        boolean isOptional,
+        int id,
+        String name,
+        Type type,
+        String doc,
+        Literal<?> initialDefault,
+        Literal<?> writeDefault) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
       this.isOptional = isOptional;
@@ -450,6 +575,22 @@ public class Types {
       this.name = name;
       this.type = type;
       this.doc = doc;
+      this.initialDefault = castDefault(initialDefault, type);
+      this.writeDefault = castDefault(writeDefault, type);
+    }
+
+    private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
+      if (type.isNestedType() && defaultValue != null) {
+        throw new IllegalArgumentException(
+            String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
+      } else if (defaultValue != null) {
+        Literal<?> typedDefault = defaultValue.to(type);
+        Preconditions.checkArgument(
+            typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
+        return typedDefault;
+      }
+
+      return null;
     }
 
     public boolean isOptional() {
@@ -460,7 +601,7 @@ public class Types {
       if (isOptional) {
         return this;
       }
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public boolean isRequired() {
@@ -471,7 +612,7 @@ public class Types {
       if (!isOptional) {
         return this;
       }
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public int fieldId() {
@@ -490,9 +631,26 @@ public class Types {
       return doc;
     }
 
+    public Literal<?> initialDefaultLiteral() {
+      return initialDefault;
+    }
+
+    public Object initialDefault() {
+      return initialDefault != null ? initialDefault.value() : null;
+    }
+
+    public Literal<?> writeDefaultLiteral() {
+      return writeDefault;
+    }
+
+    public Object writeDefault() {
+      return writeDefault != null ? writeDefault.value() : null;
+    }
+
     @Override
     public String toString() {
-      return String.format("%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type)
+      return String.format(
+              Locale.ROOT, "%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type)
           + (doc != null ? " (" + doc + ")" : "");
     }
 
@@ -513,8 +671,14 @@ public class Types {
         return false;
       } else if (!Objects.equals(doc, that.doc)) {
         return false;
+      } else if (!type.equals(that.type)) {
+        return false;
+      } else if (!Objects.equals(initialDefault, that.initialDefault)) {
+        return false;
+      } else if (!Objects.equals(writeDefault, that.writeDefault)) {
+        return false;
       }
-      return type.equals(that.type);
+      return true;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -55,6 +57,8 @@ public class SchemaParser {
   private static final String REQUIRED = "required";
   private static final String ELEMENT_REQUIRED = "element-required";
   private static final String VALUE_REQUIRED = "value-required";
+  private static final String INITIAL_DEFAULT = "initial-default";
+  private static final String WRITE_DEFAULT = "write-default";
 
   private static void toJson(Types.StructType struct, JsonGenerator generator) throws IOException {
     toJson(struct, null, null, generator);
@@ -88,6 +92,17 @@ public class SchemaParser {
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
       }
+
+      if (field.initialDefault() != null) {
+        generator.writeFieldName(INITIAL_DEFAULT);
+        SingleValueParser.toJson(field.type(), field.initialDefault(), generator);
+      }
+
+      if (field.writeDefault() != null) {
+        generator.writeFieldName(WRITE_DEFAULT);
+        SingleValueParser.toJson(field.type(), field.writeDefault(), generator);
+      }
+
       generator.writeEndObject();
     }
     generator.writeEndArray();
@@ -200,16 +215,39 @@ public class SchemaParser {
       String name = JsonUtil.getString(NAME, field);
       Type type = typeFromJson(JsonUtil.get(TYPE, field));
 
+      Literal<?> initialDefault = defaultFromJson(INITIAL_DEFAULT, type, field);
+      Literal<?> writeDefault = defaultFromJson(WRITE_DEFAULT, type, field);
+
       String doc = JsonUtil.getStringOrNull(DOC, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
-      if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type, doc));
-      } else {
-        fields.add(Types.NestedField.optional(id, name, type, doc));
-      }
+      fields.add(
+          fieldBuilder(isRequired, name)
+              .withId(id)
+              .ofType(type)
+              .withDoc(doc)
+              .withInitialDefault(initialDefault)
+              .withWriteDefault(writeDefault)
+              .build());
     }
 
     return Types.StructType.of(fields);
+  }
+
+  private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
+    if (json.has(defaultField)) {
+      Object value = SingleValueParser.fromJson(type, json.get(defaultField));
+      return Expressions.lit(value);
+    }
+
+    return null;
+  }
+
+  private static Types.NestedField.Builder fieldBuilder(boolean isRequired, String name) {
+    if (isRequired) {
+      return Types.NestedField.required(name);
+    } else {
+      return Types.NestedField.optional(name);
+    }
   }
 
   private static Types.ListType listFromJson(JsonNode json) {

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestSchemaParser {
+
+  @Test
+  public void testDocStrings() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get(), "unique identifier"),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withDoc("payload")
+                .build());
+
+    Schema serialized = SchemaParser.fromJson(SchemaParser.toJson(schema));
+    assertThat(serialized.findField("id").doc()).isEqualTo("unique identifier");
+    assertThat(serialized.findField("data").doc()).isEqualTo("payload");
+  }
+
+  private static Stream<Arguments> primitiveTypesAndDefaults() {
+    return Stream.of(
+        Arguments.of(Types.BooleanType.get(), Literal.of(false)),
+        Arguments.of(Types.IntegerType.get(), Literal.of(34)),
+        Arguments.of(Types.LongType.get(), Literal.of(4900000000L)),
+        Arguments.of(Types.FloatType.get(), Literal.of(12.21F)),
+        Arguments.of(Types.DoubleType.get(), Literal.of(-0.0D)),
+        Arguments.of(Types.DateType.get(), Literal.of(DateTimeUtil.isoDateToDays("2024-12-17"))),
+        // Arguments.of(Types.TimeType.get(), DateTimeUtil.isoTimeToMicros("23:59:59.999999")),
+        Arguments.of(
+            Types.TimestampType.withZone(),
+            Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
+        Arguments.of(
+            Types.TimestampType.withoutZone(),
+            Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
+        Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
+        Arguments.of(
+            Types.FixedType.ofLength(4),
+            Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d}))),
+        Arguments.of(Types.BinaryType.get(), Literal.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b}))),
+        Arguments.of(Types.DecimalType.of(9, 2), Literal.of(new BigDecimal("12.34"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("primitiveTypesAndDefaults")
+  public void testPrimitiveTypeDefaultValues(Type.PrimitiveType type, Literal<?> defaultValue) {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.required("col_with_default")
+                .withId(2)
+                .ofType(type)
+                .withInitialDefault(defaultValue)
+                .withWriteDefault(defaultValue)
+                .build());
+
+    Schema serialized = SchemaParser.fromJson(SchemaParser.toJson(schema));
+    assertThat(serialized.findField("col_with_default").initialDefault())
+        .isEqualTo(defaultValue.value());
+    assertThat(serialized.findField("col_with_default").writeDefault())
+        .isEqualTo(defaultValue.value());
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericOrcReaderIdBinding.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.orc;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests specifically targeting the id-based field binding path of {@link GenericOrcReaders}. These
+ * exercise branches of the id-binding {@code StructReader} constructor that the shared projection
+ * tests do not, and assert that id-binding produces the same results positional binding would.
+ */
+public class TestGenericOrcReaderIdBinding {
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private List<Record> writeAndRead(
+      String desc, Schema writeSchema, Schema readSchema, List<Record> records) throws IOException {
+    return writeAndRead(desc, writeSchema, readSchema, records, ImmutableMap.of());
+  }
+
+  private List<Record> writeAndRead(
+      String desc,
+      Schema writeSchema,
+      Schema readSchema,
+      List<Record> records,
+      Map<Integer, ?> idToConstant)
+      throws IOException {
+    File file = temp.newFile(desc + ".orc");
+    Assert.assertTrue("Delete should succeed", file.delete());
+
+    try (FileAppender<Record> appender =
+        ORC.write(Files.localOutput(file))
+            .schema(writeSchema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .build()) {
+      appender.addAll(records);
+    }
+
+    // Project only fields that physically exist in the file (excluding metadata columns) so that
+    // buildOrcProjection succeeds, but hand the reader the full read schema so the id-binding
+    // constructor resolves metadata/constant fields.
+    Schema projection = TypeUtil.selectNot(readSchema, MetadataColumns.metadataFieldIds());
+    try (CloseableIterable<Record> reader =
+        ORC.read(Files.localInput(file))
+            .project(projection)
+            .createReaderFunc(
+                fileSchema -> GenericOrcReader.buildReader(readSchema, fileSchema, idToConstant))
+            .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+
+  @Test
+  public void testTypePromotion() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "f", Types.FloatType.get()),
+            required(3, "dec", Types.DecimalType.of(9, 2)));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("id", 42);
+    record.setField("f", 1.5f);
+    record.setField("dec", new BigDecimal("123.45"));
+
+    Schema promotedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "f", Types.DoubleType.get()),
+            required(3, "dec", Types.DecimalType.of(11, 2)));
+
+    Record projected =
+        writeAndRead("type_promotion", writeSchema, promotedSchema, Lists.newArrayList(record))
+            .get(0);
+
+    Assert.assertEquals("int should be promoted to long", 42L, projected.getField("id"));
+    Assert.assertEquals(
+        "float should be promoted to double", 1.5d, (double) projected.getField("f"), 0.0d);
+    Assert.assertEquals(
+        "decimal precision should widen", new BigDecimal("123.45"), projected.getField("dec"));
+  }
+
+  @Test
+  public void testReorderedProjectionValues() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "a", Types.LongType.get()),
+            optional(2, "b", Types.StringType.get()),
+            required(3, "c", Types.IntegerType.get()));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("a", 10L);
+    record.setField("b", "hello");
+    record.setField("c", 7);
+
+    // Read schema requests the fields in a different order than the file's physical column order.
+    Schema reordered =
+        new Schema(
+            required(3, "c", Types.IntegerType.get()),
+            required(1, "a", Types.LongType.get()),
+            optional(2, "b", Types.StringType.get()));
+
+    Record projected =
+        writeAndRead("reordered", writeSchema, reordered, Lists.newArrayList(record)).get(0);
+
+    Assert.assertEquals("c should bind by id", 7, projected.getField("c"));
+    Assert.assertEquals("a should bind by id", 10L, projected.getField("a"));
+    Assert.assertEquals("b should bind by id", "hello", projected.getField("b").toString());
+  }
+
+  @Test
+  public void testMetadataColumns() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+    List<Record> records = Lists.newArrayList();
+    for (long i = 0; i < 5; i++) {
+      Record record = GenericRecord.create(writeSchema.asStruct());
+      record.setField("id", i);
+      record.setField("data", "row" + i);
+      records.add(record);
+    }
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            MetadataColumns.ROW_POSITION,
+            MetadataColumns.IS_DELETED);
+
+    List<Record> projected = writeAndRead("metadata_columns", writeSchema, readSchema, records);
+
+    Assert.assertEquals(5, projected.size());
+    for (int i = 0; i < projected.size(); i++) {
+      Record record = projected.get(i);
+      Assert.assertEquals("id should read from file", (long) i, record.getField("id"));
+      Assert.assertEquals(
+          "data should read from file", "row" + i, record.getField("data").toString());
+      Assert.assertEquals(
+          "_pos should be the row position",
+          (long) i,
+          record.getField(MetadataColumns.ROW_POSITION.name()));
+      Assert.assertEquals(
+          "_deleted should be false", false, record.getField(MetadataColumns.IS_DELETED.name()));
+    }
+  }
+
+  @Test
+  public void testIdToConstant() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+    Record record = GenericRecord.create(writeSchema.asStruct());
+    record.setField("id", 1L);
+    record.setField("data", "value");
+
+    // Read schema adds an identity-partition-style constant field (id 3) not present in the file.
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "part", Types.StringType.get()));
+
+    Record projected =
+        writeAndRead(
+                "id_to_constant",
+                writeSchema,
+                readSchema,
+                Lists.newArrayList(record),
+                ImmutableMap.of(3, "constant-partition"))
+            .get(0);
+
+    Assert.assertEquals("id should read from file", 1L, projected.getField("id"));
+    Assert.assertEquals(
+        "data should read from file", "value", projected.getField("data").toString());
+    Assert.assertEquals(
+        "part should resolve from idToConstant", "constant-partition", projected.getField("part"));
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -76,7 +76,7 @@ public class GenericOrcReader implements OrcRowReader<Record> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return GenericOrcReaders.struct(fields, expected, idToConstant);
+      return GenericOrcReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override
@@ -96,6 +96,10 @@ public class GenericOrcReader implements OrcRowReader<Record> {
 
     @Override
     public OrcValueReader<?> primitive(Type.PrimitiveType iPrimitive, TypeDescription primitive) {
+      if (iPrimitive == null) {
+        return null;
+      }
+
       switch (primitive.getCategory()) {
         case BOOLEAN:
           return OrcValueReaders.booleans();

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
@@ -238,7 +239,8 @@ public class GenericOrcReaders {
         List<OrcValueReader<?>> readers,
         Types.StructType structType,
         Map<Integer, ?> idToConstant) {
-      super(orcType, readers, structType, idToConstant);
+      super(
+          orcType, readers, structType, idToConstant, IdentityPartitionConverters::convertConstant);
       this.template = GenericRecord.create(structType);
     }
 

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -51,9 +52,23 @@ public class GenericOrcReaders {
 
   private GenericOrcReaders() {}
 
+  /**
+   * @deprecated Use {@link #struct(TypeDescription, List, Types.StructType, Map)} instead. This
+   *     method uses position-based binding which may cause field misalignment in MOR and lineage
+   *     scenarios.
+   */
+  @Deprecated
   public static OrcValueReader<Record> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
     return new StructReader(readers, struct, idToConstant);
+  }
+
+  public static OrcValueReader<Record> struct(
+      TypeDescription orcType,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(orcType, readers, struct, idToConstant);
   }
 
   public static OrcValueReader<List<?>> array(OrcValueReader<?> elementReader) {
@@ -204,12 +219,27 @@ public class GenericOrcReaders {
   private static class StructReader extends OrcValueReaders.StructReader<Record> {
     private final GenericRecord template;
 
+    /**
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     and lineage scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers,
         Types.StructType structType,
         Map<Integer, ?> idToConstant) {
       super(readers, structType, idToConstant);
-      this.template = structType != null ? GenericRecord.create(structType) : null;
+      this.template = GenericRecord.create(structType);
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType structType,
+        Map<Integer, ?> idToConstant) {
+      super(orcType, readers, structType, idToConstant);
+      this.template = GenericRecord.create(structType);
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -261,18 +261,37 @@ public final class ORCSchemaUtil {
    */
   public static TypeDescription buildOrcProjection(
       Schema schema, TypeDescription originalOrcSchema) {
+    return buildOrcProjection(schema, originalOrcSchema, false);
+  }
+
+  static TypeDescription buildOrcProjection(
+      Schema schema, TypeDescription originalOrcSchema, boolean applyDefaults) {
     final Map<Integer, OrcField> icebergToOrc = icebergToOrcMapping("root", originalOrcSchema);
-    return buildOrcProjection(Integer.MIN_VALUE, schema.asStruct(), true, icebergToOrc);
+    return buildOrcProjection(
+        Integer.MIN_VALUE, schema.asStruct(), true, applyDefaults, icebergToOrc);
+  }
+
+  private static boolean isOmittableDefault(
+      Types.NestedField field, boolean applyDefaults, Map<Integer, OrcField> mapping) {
+    return applyDefaults && field.initialDefault() != null && !mapping.containsKey(field.fieldId());
   }
 
   private static TypeDescription buildOrcProjection(
-      Integer fieldId, Type type, boolean isRequired, Map<Integer, OrcField> mapping) {
+      Integer fieldId,
+      Type type,
+      boolean isRequired,
+      boolean applyDefaults,
+      Map<Integer, OrcField> mapping) {
     final TypeDescription orcType;
 
     switch (type.typeId()) {
       case STRUCT:
         orcType = TypeDescription.createStruct();
         for (Types.NestedField nestedField : type.asStructType().fields()) {
+          if (isOmittableDefault(nestedField, applyDefaults, mapping)) {
+            continue;
+          }
+
           // Using suffix _r to avoid potential underlying issues in ORC reader
           // with reused column names between ORC and Iceberg;
           // e.g. renaming column c -> d and adding new column d
@@ -285,6 +304,7 @@ public final class ORCSchemaUtil {
                   nestedField.fieldId(),
                   nestedField.type(),
                   isRequired && nestedField.isRequired(),
+                  applyDefaults,
                   mapping);
           orcType.addField(name, childType);
         }
@@ -296,16 +316,21 @@ public final class ORCSchemaUtil {
                 list.elementId(),
                 list.elementType(),
                 isRequired && list.isElementRequired(),
+                applyDefaults,
                 mapping);
         orcType = TypeDescription.createList(elementType);
         break;
       case MAP:
         Types.MapType map = (Types.MapType) type;
         TypeDescription keyType =
-            buildOrcProjection(map.keyId(), map.keyType(), isRequired, mapping);
+            buildOrcProjection(map.keyId(), map.keyType(), isRequired, applyDefaults, mapping);
         TypeDescription valueType =
             buildOrcProjection(
-                map.valueId(), map.valueType(), isRequired && map.isValueRequired(), mapping);
+                map.valueId(),
+                map.valueType(),
+                isRequired && map.isValueRequired(),
+                applyDefaults,
+                mapping);
         orcType = TypeDescription.createMap(keyType, valueType);
         break;
       default:

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -86,7 +86,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     TypeDescription fileSchema = orcFileReader.getSchema();
     final TypeDescription readOrcSchema;
     if (ORCSchemaUtil.hasIds(fileSchema)) {
-      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, fileSchema);
+      readOrcSchema = ORCSchemaUtil.buildOrcProjection(schema, fileSchema, true);
     } else {
       if (nameMapping == null) {
         nameMapping = MappingUtil.create(schema);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.orc;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
@@ -183,6 +185,15 @@ public class OrcValueReaders {
         List<OrcValueReader<?>> readers,
         Types.StructType struct,
         Map<Integer, ?> idToConstant) {
+      this(orcType, readers, struct, idToConstant, null);
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant,
+        BiFunction<Type, Object, Object> convertConstant) {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
@@ -208,6 +219,10 @@ public class OrcValueReaders {
           this.isConstantOrMetadataField[pos] = false;
           this.orcFieldIndex[pos] = fieldIdToOrcIndex.getOrDefault(field.fieldId(), -1);
           this.readers[pos] = fileReader;
+        } else if (field.initialDefault() != null && convertConstant != null) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] =
+              constants(convertConstant.apply(field.type(), field.initialDefault()));
         } else if (MetadataColumns.isMetadataColumn(field.name())) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(null);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -22,7 +22,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DoubleColumnVector;
@@ -134,12 +137,27 @@ public class OrcValueReaders {
   public abstract static class StructReader<T> implements OrcValueReader<T> {
     private final OrcValueReader<?>[] readers;
     private final boolean[] isConstantOrMetadataField;
+    // Maps each projected struct field position to the matching child index in the ORC schema.
+    // This allows fields to be read by Iceberg field ID when the projected struct order differs
+    // from the file schema.
+    private final int[] orcFieldIndex;
 
+    /**
+     * @param readers readers for each field
+     * @param struct struct type
+     * @param idToConstant constant values by field id
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
+      this.orcFieldIndex = null;
+
       for (int pos = 0, readerIndex = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
         if (idToConstant.containsKey(field.fieldId())) {
@@ -152,13 +170,79 @@ public class OrcValueReaders {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(false);
         } else if (MetadataColumns.isMetadataColumn(field.name())) {
-          // in case of any other metadata field, fill with nulls
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(null);
         } else {
           this.readers[pos] = readers.get(readerIndex++);
         }
       }
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      List<Types.NestedField> fields = struct.fields();
+      this.readers = new OrcValueReader[fields.size()];
+      this.isConstantOrMetadataField = new boolean[fields.size()];
+      this.orcFieldIndex = new int[fields.size()];
+
+      Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(orcType, readers);
+      Map<Integer, Integer> fieldIdToOrcIndex = buildFieldIdToOrcIndex(orcType);
+
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Types.NestedField field = fields.get(pos);
+        OrcValueReader<?> fileReader = readersById.get(field.fieldId());
+
+        if (idToConstant.containsKey(field.fieldId())) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(idToConstant.get(field.fieldId()));
+        } else if (field.equals(MetadataColumns.ROW_POSITION)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = new RowPositionReader();
+        } else if (field.equals(MetadataColumns.IS_DELETED)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(false);
+        } else if (fileReader != null) {
+          this.isConstantOrMetadataField[pos] = false;
+          this.orcFieldIndex[pos] = fieldIdToOrcIndex.getOrDefault(field.fieldId(), -1);
+          this.readers[pos] = fileReader;
+        } else if (MetadataColumns.isMetadataColumn(field.name())) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(null);
+        } else {
+          throw new IllegalArgumentException(
+              String.format("Missing ORC reader for field %s (%s)", field.name(), field.fieldId()));
+        }
+      }
+    }
+
+    private Map<Integer, Integer> buildFieldIdToOrcIndex(TypeDescription orcType) {
+      List<TypeDescription> children = orcType.getChildren();
+      Map<Integer, Integer> mapping = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i++) {
+        mapping.put(ORCSchemaUtil.fieldId(children.get(i)), i);
+      }
+
+      return mapping;
+    }
+
+    private Map<Integer, OrcValueReader<?>> readersByFieldId(
+        TypeDescription orcType, List<OrcValueReader<?>> readerList) {
+      List<TypeDescription> children = orcType.getChildren();
+      Preconditions.checkState(
+          children.size() == readerList.size(),
+          "Invalid ORC reader binding: children=%s readers=%s",
+          children.size(),
+          readerList.size());
+
+      Map<Integer, OrcValueReader<?>> readersById = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i += 1) {
+        readersById.put(ORCSchemaUtil.fieldId(children.get(i)), readerList.get(i));
+      }
+
+      return readersById;
     }
 
     protected abstract T create();
@@ -176,14 +260,17 @@ public class OrcValueReaders {
     }
 
     private T readInternal(T struct, ColumnVector[] columnVectors, int row) {
-      for (int c = 0, vectorIndex = 0; c < readers.length; ++c) {
+      int vectorIndex = 0;
+      for (int c = 0; c < readers.length; ++c) {
         ColumnVector vector;
         if (isConstantOrMetadataField[c]) {
           vector = null;
+        } else if (orcFieldIndex != null) {
+          vector = columnVectors[orcFieldIndex[c]];
         } else {
-          vector = columnVectors[vectorIndex];
-          vectorIndex++;
+          vector = columnVectors[vectorIndex++];
         }
+
         set(struct, c, reader(c).read(vector, row));
       }
       return struct;

--- a/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestBuildOrcProjection.java
@@ -21,8 +21,11 @@ package org.apache.iceberg.orc;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.assertj.core.api.Assertions;
@@ -158,5 +161,137 @@ public class TestBuildOrcProjection {
             () -> ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Field 4 of type long is required and was not found.");
+  }
+
+  @Test
+  public void testTopLevelScalarDefaultOmittedWhenFileIdentityIsTrustworthy() {
+    Schema baseSchema = new Schema(required(1, "id", Types.LongType.get()));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("country")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Expressions.lit("US"))
+                .build());
+
+    // The file carries embedded field IDs, so the absent field can be identified safely.
+    TypeDescription projection =
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, true);
+    assertEquals(1, projection.getChildren().size());
+    assertNotNull(projection.findSubtype("id"));
+    assertFalse(
+        "defaulted column must be omitted from the read projection",
+        projection.getFieldNames().contains("country_r2"));
+  }
+
+  @Test
+  public void testTopLevelScalarDefaultSynthesizedWithoutTrustedFileIdentity() {
+    Schema baseSchema = new Schema(required(1, "id", Types.LongType.get()));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("country")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Expressions.lit("US"))
+                .build());
+
+    // Without trustworthy file identity, synthesize NULL rather than guessing that the field is
+    // absent and applying its default.
+    TypeDescription projection = ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema);
+    assertEquals(2, projection.getChildren().size());
+    assertEquals(2, projection.findSubtype("country_r2").getId());
+    assertEquals(
+        TypeDescription.Category.STRING, projection.findSubtype("country_r2").getCategory());
+  }
+
+  @Test
+  public void testTopLevelRequiredScalarDefaultOmitted() {
+    Schema baseSchema = new Schema(required(1, "id", Types.LongType.get()));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    // A required top-level field that is absent from the file but declares a default must be
+    // omitted (then filled), not rejected by the required-missing check.
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.required("code")
+                .withId(2)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Expressions.lit(7))
+                .build());
+
+    TypeDescription projection =
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, true);
+    assertEquals(1, projection.getChildren().size());
+    assertFalse(
+        "required defaulted column must be omitted, not throw",
+        projection.getFieldNames().contains("code_r2"));
+  }
+
+  @Test
+  public void testNestedScalarDefaultOmitted() {
+    Schema baseSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "s", Types.StructType.of(required(3, "a", Types.LongType.get()))));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    // A scalar default on a field nested inside a struct is omitted so the reader can fill it.
+    // The present sibling "a" keeps the struct non-empty.
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(
+                2,
+                "s",
+                Types.StructType.of(
+                    required(3, "a", Types.LongType.get()),
+                    Types.NestedField.optional("b")
+                        .withId(4)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Expressions.lit("x"))
+                        .build())));
+
+    TypeDescription projection =
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, true);
+    TypeDescription nested = projection.findSubtype("s");
+    assertEquals(1, nested.getChildren().size());
+    assertFalse("nested defaulted column must be omitted", nested.getFieldNames().contains("b_r4"));
+  }
+
+  @Test
+  public void testNestedStructEmptiedByOmit() {
+    // Base file: s { a }. Project only a new defaulted subfield s { b default 'x' } (drop a). Every
+    // projected subfield of s is absent + defaulted, so the nested read struct is omitted down to
+    // empty; the reader fills b (see TestOrcDefaultValues end-to-end coverage).
+    Schema baseSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "s", Types.StructType.of(required(3, "a", Types.LongType.get()))));
+    TypeDescription baseOrcSchema = ORCSchemaUtil.convert(baseSchema);
+
+    Schema evolvedSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2,
+                "s",
+                Types.StructType.of(
+                    Types.NestedField.optional("b")
+                        .withId(4)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Expressions.lit("x"))
+                        .build())));
+
+    TypeDescription projection =
+        ORCSchemaUtil.buildOrcProjection(evolvedSchema, baseOrcSchema, true);
+    TypeDescription nested = projection.findSubtype("s");
+    assertEquals(0, nested.getChildren().size());
   }
 }

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDefaultValues.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDefaultValues.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Verifies that scalar {@code initial-default}s are filled on ORC read. */
+public class TestOrcDefaultValues {
+
+  private static final Schema WRITE_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+  // Evolved: adds a top-level scalar with an initial-default that is absent from the written file.
+  private static final Schema READ_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional("country")
+              .withId(3)
+              .ofType(Types.StringType.get())
+              .withInitialDefault(Expressions.lit("US"))
+              .build());
+
+  private List<Record> records;
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  @Before
+  public void createRecords() {
+    GenericRecord record = GenericRecord.create(WRITE_SCHEMA);
+    records =
+        Lists.newArrayList(
+            record.copy(ImmutableMap.of("id", 1L, "data", "a")),
+            record.copy(ImmutableMap.of("id", 2L, "data", "b")),
+            record.copy(ImmutableMap.of("id", 3L, "data", "c")));
+  }
+
+  private OutputFile writeFile() throws IOException {
+    OutputFile file = Files.localOutput(temp.newFile());
+    DataWriter<Record> writer =
+        ORC.writeData(file)
+            .schema(WRITE_SCHEMA)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try {
+      for (Record record : records) {
+        writer.write(record);
+      }
+    } finally {
+      writer.close();
+    }
+    return file;
+  }
+
+  @Test
+  public void testReadFillsTopLevelScalarDefault() throws IOException {
+    OutputFile file = writeFile();
+
+    List<Record> read;
+    try (CloseableIterable<Record> reader =
+        ORC.read(file.toInputFile())
+            .project(READ_SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(READ_SCHEMA, fileSchema))
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    Assertions.assertThat(read).hasSize(records.size());
+    for (int i = 0; i < read.size(); i += 1) {
+      Assertions.assertThat(read.get(i).getField("id")).isEqualTo(records.get(i).getField("id"));
+      Assertions.assertThat(read.get(i).getField("data"))
+          .isEqualTo(records.get(i).getField("data"));
+      Assertions.assertThat(read.get(i).getField("country")).isEqualTo("US");
+    }
+  }
+
+  @Test
+  public void testReadSelectsOnlyDefaultColumn() throws IOException {
+    OutputFile file = writeFile();
+
+    Schema onlyDefault =
+        new Schema(
+            Types.NestedField.optional("country")
+                .withId(3)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Expressions.lit("US"))
+                .build());
+
+    List<Record> read;
+    try (CloseableIterable<Record> reader =
+        ORC.read(file.toInputFile())
+            .project(onlyDefault)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(onlyDefault, fileSchema))
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    Assertions.assertThat(read).hasSize(records.size());
+    for (Record record : read) {
+      Assertions.assertThat(record.getField("country")).isEqualTo("US");
+    }
+  }
+
+  @Test
+  public void testReadFillsScalarDefaultsAllTypes() throws IOException {
+    OutputFile file = writeFile();
+
+    Schema typed =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            defaulted(10, "b", Types.BooleanType.get(), Expressions.lit(true)),
+            defaulted(11, "i", Types.IntegerType.get(), Expressions.lit(42)),
+            defaulted(12, "l", Types.LongType.get(), Expressions.lit(100L)),
+            defaulted(13, "f", Types.FloatType.get(), Expressions.lit(1.5f)),
+            defaulted(14, "d", Types.DoubleType.get(), Expressions.lit(2.5d)),
+            defaulted(15, "s", Types.StringType.get(), Expressions.lit("x")),
+            defaulted(
+                16, "dec", Types.DecimalType.of(9, 2), Expressions.lit(new BigDecimal("1.50"))));
+
+    List<Record> read;
+    try (CloseableIterable<Record> reader =
+        ORC.read(file.toInputFile())
+            .project(typed)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(typed, fileSchema))
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    Assertions.assertThat(read).hasSize(records.size());
+    for (Record record : read) {
+      Assertions.assertThat(record.getField("b")).isEqualTo(true);
+      Assertions.assertThat(record.getField("i")).isEqualTo(42);
+      Assertions.assertThat(record.getField("l")).isEqualTo(100L);
+      Assertions.assertThat(record.getField("f")).isEqualTo(1.5f);
+      Assertions.assertThat(record.getField("d")).isEqualTo(2.5d);
+      Assertions.assertThat(record.getField("s")).isEqualTo("x");
+      Assertions.assertThat(record.getField("dec")).isEqualTo(new BigDecimal("1.50"));
+    }
+  }
+
+  @Test
+  public void testReadFillsRequiredScalarDefault() throws IOException {
+    OutputFile file = writeFile();
+
+    // A required field absent from the file but declaring a default must be filled, not rejected.
+    Schema requiredDefault =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.required("code")
+                .withId(20)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Expressions.lit(7))
+                .build());
+
+    List<Record> read;
+    try (CloseableIterable<Record> reader =
+        ORC.read(file.toInputFile())
+            .project(requiredDefault)
+            .createReaderFunc(
+                fileSchema -> GenericOrcReader.buildReader(requiredDefault, fileSchema))
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    Assertions.assertThat(read).hasSize(records.size());
+    for (Record record : read) {
+      Assertions.assertThat(record.getField("code")).isEqualTo(7);
+    }
+  }
+
+  @Test
+  public void testReadDoesNotApplyDefaultToIdLessFile() throws IOException {
+    File file = writeIdLessFile();
+
+    List<Record> read;
+    try (CloseableIterable<Record> reader =
+        ORC.read(Files.localInput(file))
+            .project(READ_SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(READ_SCHEMA, fileSchema))
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    Assertions.assertThat(read).hasSize(records.size());
+    for (int i = 0; i < read.size(); i += 1) {
+      Assertions.assertThat(read.get(i).getField("id")).isEqualTo(records.get(i).getField("id"));
+      Assertions.assertThat(read.get(i).getField("data"))
+          .isEqualTo(records.get(i).getField("data"));
+      Assertions.assertThat(read.get(i).getField("country")).isNull();
+    }
+  }
+
+  @Test
+  public void testReadDoesNotOverridePresentColumn() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "country", Types.StringType.get()));
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    present.setField("data", "a");
+    present.setField("country", "CA");
+    Record presentNull = GenericRecord.create(writeSchema);
+    presentNull.setField("id", 2L);
+    presentNull.setField("data", "b");
+    presentNull.setField("country", null);
+
+    OutputFile file = writeRecords(writeSchema, Lists.newArrayList(present, presentNull));
+    List<Record> read = read(file, READ_SCHEMA);
+
+    Assertions.assertThat(read).hasSize(2);
+    Assertions.assertThat(read.get(0).getField("country")).isEqualTo("CA");
+    Assertions.assertThat(read.get(1).getField("country")).isNull();
+  }
+
+  @Test
+  public void testNestedStructScalarDefault() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3, "nested", Types.StructType.of(required(4, "inner", Types.StringType.get()))));
+    Types.StructType writeNested = writeSchema.findField("nested").type().asStructType();
+
+    List<Record> recs = Lists.newArrayList();
+    for (int i = 0; i < 3; i += 1) {
+      Record nested = GenericRecord.create(writeNested);
+      nested.setField("inner", "v" + i);
+      Record rec = GenericRecord.create(writeSchema);
+      rec.setField("id", (long) i);
+      rec.setField("nested", nested);
+      recs.add(rec);
+    }
+    // Row with a null nested struct: a default must not be fabricated when the parent struct is
+    // null (the struct stays null; the absent-only fill applies to present structs).
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 3L);
+    nullNested.setField("nested", null);
+    recs.add(nullNested);
+
+    OutputFile file = writeRecords(writeSchema, recs);
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "nested",
+                Types.StructType.of(
+                    required(4, "inner", Types.StringType.get()),
+                    defaulted(5, "missing", Types.FloatType.get(), Expressions.lit(-0.0F)))));
+
+    List<Record> read = read(file, readSchema);
+    Assertions.assertThat(read).hasSize(recs.size());
+    for (int i = 0; i < 3; i += 1) {
+      Record nested = (Record) read.get(i).getField("nested");
+      Assertions.assertThat(nested.getField("inner")).isEqualTo("v" + i);
+      Assertions.assertThat(nested.getField("missing")).isEqualTo(-0.0F);
+    }
+    Assertions.assertThat(read.get(3).getField("nested")).isNull();
+  }
+
+  @Test
+  public void testMapNestedScalarDefault() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "m",
+                Types.MapType.ofOptional(
+                    4,
+                    5,
+                    Types.StringType.get(),
+                    Types.StructType.of(required(6, "v_str", Types.StringType.get())))));
+    Types.StructType writeValue =
+        writeSchema.findField("m").type().asMapType().valueType().asStructType();
+
+    Record value = GenericRecord.create(writeValue);
+    value.setField("v_str", "s");
+    Record rec = GenericRecord.create(writeSchema);
+    rec.setField("id", 1L);
+    rec.setField("m", Collections.singletonMap("k", value));
+    OutputFile file = writeRecords(writeSchema, Lists.newArrayList(rec));
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "m",
+                Types.MapType.ofOptional(
+                    4,
+                    5,
+                    Types.StringType.get(),
+                    Types.StructType.of(
+                        required(6, "v_str", Types.StringType.get()),
+                        defaulted(7, "v_int", Types.IntegerType.get(), Expressions.lit(34))))));
+
+    List<Record> read = read(file, readSchema);
+    Assertions.assertThat(read).hasSize(1);
+    Map<?, ?> map = (Map<?, ?>) read.get(0).getField("m");
+    Assertions.assertThat(map).hasSize(1);
+    Record readValue = (Record) map.values().iterator().next();
+    Assertions.assertThat(readValue.getField("v_str")).isEqualTo("s");
+    Assertions.assertThat(readValue.getField("v_int")).isEqualTo(34);
+  }
+
+  @Test
+  public void testListNestedScalarDefault() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "l",
+                Types.ListType.ofOptional(
+                    4, Types.StructType.of(required(5, "e_str", Types.StringType.get())))));
+    Types.StructType writeElement =
+        writeSchema.findField("l").type().asListType().elementType().asStructType();
+
+    Record element = GenericRecord.create(writeElement);
+    element.setField("e_str", "e");
+    Record rec = GenericRecord.create(writeSchema);
+    rec.setField("id", 1L);
+    rec.setField("l", Collections.singletonList(element));
+    OutputFile file = writeRecords(writeSchema, Lists.newArrayList(rec));
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "l",
+                Types.ListType.ofOptional(
+                    4,
+                    Types.StructType.of(
+                        required(5, "e_str", Types.StringType.get()),
+                        defaulted(7, "e_int", Types.IntegerType.get(), Expressions.lit(34))))));
+
+    List<Record> read = read(file, readSchema);
+    Assertions.assertThat(read).hasSize(1);
+    List<?> list = (List<?>) read.get(0).getField("l");
+    Assertions.assertThat(list).hasSize(1);
+    Record readElement = (Record) list.get(0);
+    Assertions.assertThat(readElement.getField("e_str")).isEqualTo("e");
+    Assertions.assertThat(readElement.getField("e_int")).isEqualTo(34);
+  }
+
+  @Test
+  public void testNestedStructAllSubfieldsDefaulted() throws IOException {
+    // File: nested { a }. Read projects only a new defaulted subfield nested { b default 'x' }
+    // (a dropped), so the nested read struct is empty. The default must still fill.
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(3, "nested", Types.StructType.of(required(4, "a", Types.LongType.get()))));
+    Types.StructType writeNested = writeSchema.findField("nested").type().asStructType();
+
+    Record nested = GenericRecord.create(writeNested);
+    nested.setField("a", 9L);
+    Record rec = GenericRecord.create(writeSchema);
+    rec.setField("id", 1L);
+    rec.setField("nested", nested);
+    OutputFile file = writeRecords(writeSchema, Lists.newArrayList(rec));
+
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                3,
+                "nested",
+                Types.StructType.of(
+                    defaulted(5, "b", Types.StringType.get(), Expressions.lit("x")))));
+
+    List<Record> read = read(file, readSchema);
+    Assertions.assertThat(read).hasSize(1);
+    Record readNested = (Record) read.get(0).getField("nested");
+    Assertions.assertThat(readNested.getField("b")).isEqualTo("x");
+  }
+
+  private OutputFile writeRecords(Schema schema, List<Record> recs) throws IOException {
+    OutputFile file = Files.localOutput(temp.newFile());
+    DataWriter<Record> writer =
+        ORC.writeData(file)
+            .schema(schema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try {
+      for (Record rec : recs) {
+        writer.write(rec);
+      }
+    } finally {
+      writer.close();
+    }
+    return file;
+  }
+
+  private File writeIdLessFile() throws IOException {
+    File file = temp.newFile();
+    Assertions.assertThat(file.delete()).isTrue();
+    TypeDescription writerSchema = TypeDescription.fromString("struct<id:bigint,data:string>");
+    try (org.apache.orc.Writer writer =
+        OrcFile.createWriter(
+            new Path(file.toString()),
+            OrcFile.writerOptions(new Configuration()).setSchema(writerSchema))) {
+      VectorizedRowBatch batch = writerSchema.createRowBatch();
+      LongColumnVector ids = (LongColumnVector) batch.cols[0];
+      BytesColumnVector data = (BytesColumnVector) batch.cols[1];
+      for (Record record : records) {
+        int row = batch.size++;
+        ids.vector[row] = (Long) record.getField("id");
+        data.setVal(row, record.getField("data").toString().getBytes(StandardCharsets.UTF_8));
+      }
+      writer.addRowBatch(batch);
+    }
+    return file;
+  }
+
+  private List<Record> read(OutputFile file, Schema readSchema) throws IOException {
+    try (CloseableIterable<Record> reader =
+        ORC.read(file.toInputFile())
+            .project(readSchema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(readSchema, fileSchema))
+            .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+
+  private static Types.NestedField defaulted(
+      int id,
+      String name,
+      org.apache.iceberg.types.Type type,
+      org.apache.iceberg.expressions.Literal<?> initial) {
+    return Types.NestedField.optional(name)
+        .withId(id)
+        .ofType(type)
+        .withInitialDefault(initial)
+        .build();
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -63,9 +64,23 @@ public class SparkOrcValueReaders {
     }
   }
 
+  /**
+   * @deprecated Use {@link #struct(TypeDescription, List, Types.StructType, Map)} instead. This
+   *     method uses position-based binding which may cause field misalignment in MOR and lineage
+   *     scenarios.
+   */
+  @Deprecated
   static OrcValueReader<?> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
     return new StructReader(readers, struct, idToConstant);
+  }
+
+  static OrcValueReader<?> struct(
+      TypeDescription orcType,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(orcType, readers, struct, idToConstant);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -136,9 +151,24 @@ public class SparkOrcValueReaders {
   static class StructReader extends OrcValueReaders.StructReader<InternalRow> {
     private final int numFields;
 
+    /**
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     and lineage scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
       super(readers, struct, idToConstant);
+      this.numFields = struct.fields().size();
+    }
+
+    protected StructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(orcType, readers, struct, idToConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.source.BaseDataReader;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
@@ -168,7 +169,7 @@ public class SparkOrcValueReaders {
         List<OrcValueReader<?>> readers,
         Types.StructType struct,
         Map<Integer, ?> idToConstant) {
-      super(orcType, readers, struct, idToConstant);
+      super(orcType, readers, struct, idToConstant, BaseDataReader::convertConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> is the Java class returned by this reader whose objects contain one or more rows.
  */
-abstract class BaseDataReader<T> implements Closeable {
+public abstract class BaseDataReader<T> implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseDataReader.class);
 
   private final Table table;
@@ -160,7 +160,7 @@ abstract class BaseDataReader<T> implements Closeable {
     }
   }
 
-  protected static Object convertConstant(Type type, Object value) {
+  public static Object convertConstant(Type type, Object value) {
     if (value == null) {
       return null;
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderDefaults.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderDefaults.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the row {@code SparkOrcReader} fills a scalar {@code initial-default} only when the
+ * field declares one and is absent from a file with embedded field IDs. Vectorized ORC defaults are
+ * a follow-up.
+ */
+public class TestSparkOrcReaderDefaults {
+
+  private static final Schema WRITE_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+  private static final Schema READ_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional("country")
+              .withId(3)
+              .ofType(Types.StringType.get())
+              .withInitialDefault(Expressions.lit("US"))
+              .build());
+
+  private static final UTF8String EXPECTED_DEFAULT = UTF8String.fromString("US");
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private File writeFile() throws IOException {
+    List<InternalRow> rows =
+        Lists.newArrayList(
+            new GenericInternalRow(new Object[] {1L, UTF8String.fromString("a")}),
+            new GenericInternalRow(new Object[] {2L, UTF8String.fromString("b")}),
+            new GenericInternalRow(new Object[] {3L, UTF8String.fromString("c")}));
+    return writeFile(WRITE_SCHEMA, rows);
+  }
+
+  private File writeFile(Schema schema, List<InternalRow> rows) throws IOException {
+    File testFile = temp.newFile();
+    Assertions.assertThat(testFile.delete()).isTrue();
+    try (FileAppender<InternalRow> writer =
+        ORC.write(Files.localOutput(testFile))
+            .createWriterFunc(SparkOrcWriter::new)
+            .schema(schema)
+            .build()) {
+      writer.addAll(rows);
+    }
+    return testFile;
+  }
+
+  @Test
+  public void testRowReadFillsDeclaredDefault() throws IOException {
+    File testFile = writeFile();
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(READ_SCHEMA)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(READ_SCHEMA, readOrcSchema))
+            .build()) {
+      int count = 0;
+      for (InternalRow row : reader) {
+        Assertions.assertThat(row.getUTF8String(2)).isEqualTo(EXPECTED_DEFAULT);
+        count += 1;
+      }
+      Assertions.assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  public void testRowReadReadsNullWhenFieldHasNoDefault() throws IOException {
+    File testFile = writeFile();
+    Schema schemaWithoutDefault =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "country", Types.StringType.get()));
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(schemaWithoutDefault)
+            .createReaderFunc(
+                readOrcSchema -> new SparkOrcReader(schemaWithoutDefault, readOrcSchema))
+            .build()) {
+      int count = 0;
+      for (InternalRow row : reader) {
+        Assertions.assertThat(row.isNullAt(2)).isTrue();
+        count += 1;
+      }
+      Assertions.assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  public void testRowReadFillsNestedDeclaredDefault() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2, "nested", Types.StructType.of(required(3, "value", Types.StringType.get()))));
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2,
+                "nested",
+                Types.StructType.of(
+                    required(3, "value", Types.StringType.get()),
+                    Types.NestedField.optional("missing")
+                        .withId(4)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Expressions.lit("filled"))
+                        .build())));
+    InternalRow nested = new GenericInternalRow(new Object[] {UTF8String.fromString("present")});
+    File testFile =
+        writeFile(
+            writeSchema, Lists.newArrayList(new GenericInternalRow(new Object[] {1L, nested})));
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(readSchema)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
+            .build()) {
+      List<InternalRow> rows = Lists.newArrayList(reader);
+      Assertions.assertThat(rows).hasSize(1);
+      InternalRow readNested = rows.get(0).getStruct(1, 2);
+      Assertions.assertThat(readNested.getUTF8String(0))
+          .isEqualTo(UTF8String.fromString("present"));
+      Assertions.assertThat(readNested.getUTF8String(1)).isEqualTo(UTF8String.fromString("filled"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Build on #256's id-bound Generic and Spark 3.1 row readers to materialize `initial-default` only when the field is absent from an id-bearing ORC file.
- Backport the `NestedField` column-default model API and schema JSON round-trip from #250 / Apache Iceberg #9502.
- Preserve physical values and explicit nulls; id-less/name-mapped files retain legacy null synthesis. Default values are converted through each reader's existing constant converter, not `idToConstant`.

## Dependencies
- Stacked on #256. This PR's branch contains #256's commit as its base, so until #256 merges the GitHub diff includes it. After #256 merges into `1.2.x`, this PR auto-reduces to the two step-2 commits below.

## Reviewer orientation
- **Review this PR's actual change here (step 2 only, excludes #256):** https://github.com/linkedin/iceberg/compare/592778c52...cbb330:chbush/orc-initial-default-id-binding
  - 2 commits, 14 files: `API: add column-default model support` + `ORC: fill initial defaults for missing id-bound fields`.
- Do **not** review from an apache/main overlay compare; whole-file overlays against upstream are dominated by unrelated 1.2.x-vs-main drift (RevAPI ledger, Spark 3.1 sources absent upstream) and misrepresent this change. The production ORC reader delta here is ~60 lines.

## Supported scope
- Generic ORC row reader
- Spark 3.1 ORC row reader
- Scalar defaults at any struct nesting level, including structs within list elements and map values

Vectorized ORC, other Spark/Flink readers, and predicate pushdown on omitted default columns remain deferred; opted-in tables must stay on the supported row paths.

## Testing Done
- [x] Added projection tests for trusted-id omission, id-less null synthesis, required defaults, and nested defaults
- [x] Added Generic ORC end-to-end tests for scalar types, required/nested/list/map defaults, present values/nulls, empty/null parent structs, and id-less files
- [x] Added Spark 3.1 row tests for declared, undeclared, and nested defaults
- [x] Full `iceberg-api`, `iceberg-core`, `iceberg-orc`, and `iceberg-data` test suites passed
- [x] Full Spark 3.1 test suite passed
- [x] API/Core/ORC RevAPI passed
- [x] API/Core/ORC/Spark 3.1 checkstyle and formatting passed

---
Tests generated with [unit-tests](https://github.com/linkedin-multiproduct/li-productivity-agents/tree/master/linkedin-plugins/development/unit-tests) plugin
<!-- Tests generated with unit-tests plugin: https://github.com/linkedin-multiproduct/li-productivity-agents/tree/master/linkedin-plugins/development/unit-tests -->

Made with [Cursor](https://cursor.com)