### PR TITLE
Spark 3.1: fill ORC initial defaults on the row reader

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -168,7 +168,7 @@ public class SparkOrcValueReaders {
         List<OrcValueReader<?>> readers,
         Types.StructType struct,
         Map<Integer, ?> idToConstant) {
-      super(orcType, readers, struct, idToConstant);
+      super(orcType, readers, struct, idToConstant, SparkValueConverters::convertConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueConverters.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueConverters.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * Converts Iceberg internal values to the representations Spark holds in an {@code InternalRow}.
+ */
+public class SparkValueConverters {
+
+  private SparkValueConverters() {}
+
+  public static Object convertConstant(Type type, Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    switch (type.typeId()) {
+      case DECIMAL:
+        return Decimal.apply((BigDecimal) value);
+      case STRING:
+        if (value instanceof Utf8) {
+          Utf8 utf8 = (Utf8) value;
+          return UTF8String.fromBytes(utf8.getBytes(), 0, utf8.getByteLength());
+        }
+        return UTF8String.fromString(value.toString());
+      case FIXED:
+        if (value instanceof byte[]) {
+          return value;
+        } else if (value instanceof GenericData.Fixed) {
+          return ((GenericData.Fixed) value).bytes();
+        }
+        return ByteBuffers.toByteArray((ByteBuffer) value);
+      case BINARY:
+        return ByteBuffers.toByteArray((ByteBuffer) value);
+      case STRUCT:
+        StructType structType = (StructType) type;
+
+        if (structType.fields().isEmpty()) {
+          return new GenericInternalRow();
+        }
+
+        List<NestedField> fields = structType.fields();
+        Object[] values = new Object[fields.size()];
+        StructLike struct = (StructLike) value;
+
+        for (int index = 0; index < fields.size(); index++) {
+          NestedField field = fields.get(index);
+          Type fieldType = field.type();
+          values[index] =
+              convertConstant(fieldType, struct.get(index, fieldType.typeId().javaClass()));
+        }
+
+        return new GenericInternalRow(values);
+      default:
+    }
+    return value;
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -20,20 +20,15 @@ package org.apache.iceberg.spark.source;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.util.Utf8;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedInputFile;
@@ -42,15 +37,10 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.spark.data.SparkValueConverters;
 import org.apache.iceberg.types.Types.StructType;
-import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.sql.types.Decimal;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,56 +144,9 @@ abstract class BaseDataReader<T> implements Closeable {
   protected Map<Integer, ?> constantsMap(FileScanTask task, Schema readSchema) {
     if (readSchema.findField(MetadataColumns.PARTITION_COLUMN_ID) != null) {
       StructType partitionType = Partitioning.partitionType(table);
-      return PartitionUtil.constantsMap(task, partitionType, BaseDataReader::convertConstant);
+      return PartitionUtil.constantsMap(task, partitionType, SparkValueConverters::convertConstant);
     } else {
-      return PartitionUtil.constantsMap(task, BaseDataReader::convertConstant);
+      return PartitionUtil.constantsMap(task, SparkValueConverters::convertConstant);
     }
-  }
-
-  protected static Object convertConstant(Type type, Object value) {
-    if (value == null) {
-      return null;
-    }
-
-    switch (type.typeId()) {
-      case DECIMAL:
-        return Decimal.apply((BigDecimal) value);
-      case STRING:
-        if (value instanceof Utf8) {
-          Utf8 utf8 = (Utf8) value;
-          return UTF8String.fromBytes(utf8.getBytes(), 0, utf8.getByteLength());
-        }
-        return UTF8String.fromString(value.toString());
-      case FIXED:
-        if (value instanceof byte[]) {
-          return value;
-        } else if (value instanceof GenericData.Fixed) {
-          return ((GenericData.Fixed) value).bytes();
-        }
-        return ByteBuffers.toByteArray((ByteBuffer) value);
-      case BINARY:
-        return ByteBuffers.toByteArray((ByteBuffer) value);
-      case STRUCT:
-        StructType structType = (StructType) type;
-
-        if (structType.fields().isEmpty()) {
-          return new GenericInternalRow();
-        }
-
-        List<NestedField> fields = structType.fields();
-        Object[] values = new Object[fields.size()];
-        StructLike struct = (StructLike) value;
-
-        for (int index = 0; index < fields.size(); index++) {
-          NestedField field = fields.get(index);
-          Type fieldType = field.type();
-          values[index] =
-              convertConstant(fieldType, struct.get(index, fieldType.typeId().javaClass()));
-        }
-
-        return new GenericInternalRow(values);
-      default:
-    }
-    return value;
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -159,6 +159,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
             .split(task.start(), task.length())
             .createReaderFunc(
                 readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema, idToConstant))
+            .supportsInitialDefaults()
             .filter(task.residual())
             .caseSensitive(caseSensitive);
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderDefaults.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReaderDefaults.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies that the row {@code SparkOrcReader} fills a scalar {@code initial-default} only when the
+ * field declares one and is absent from a file with embedded field IDs. Vectorized ORC defaults are
+ * a follow-up.
+ */
+public class TestSparkOrcReaderDefaults {
+
+  private static final Schema WRITE_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()), optional(2, "data", Types.StringType.get()));
+
+  private static final Schema READ_SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional("country")
+              .withId(3)
+              .ofType(Types.StringType.get())
+              .withInitialDefault(Expressions.lit("US"))
+              .build());
+
+  private static final UTF8String EXPECTED_DEFAULT = UTF8String.fromString("US");
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private File writeFile() throws IOException {
+    List<InternalRow> rows =
+        Lists.newArrayList(
+            new GenericInternalRow(new Object[] {1L, UTF8String.fromString("a")}),
+            new GenericInternalRow(new Object[] {2L, UTF8String.fromString("b")}),
+            new GenericInternalRow(new Object[] {3L, UTF8String.fromString("c")}));
+    return writeFile(WRITE_SCHEMA, rows);
+  }
+
+  private File writeFile(Schema schema, List<InternalRow> rows) throws IOException {
+    File testFile = temp.newFile();
+    Assertions.assertThat(testFile.delete()).isTrue();
+    try (FileAppender<InternalRow> writer =
+        ORC.write(Files.localOutput(testFile))
+            .createWriterFunc(SparkOrcWriter::new)
+            .schema(schema)
+            .build()) {
+      writer.addAll(rows);
+    }
+    return testFile;
+  }
+
+  @Test
+  public void testFillsDefaultWhenFieldIsAbsent() throws IOException {
+    File testFile = writeFile();
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(READ_SCHEMA)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(READ_SCHEMA, readOrcSchema))
+            .supportsInitialDefaults()
+            .build()) {
+      int count = 0;
+      for (InternalRow row : reader) {
+        Assertions.assertThat(row.getUTF8String(2)).isEqualTo(EXPECTED_DEFAULT);
+        count += 1;
+      }
+      Assertions.assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  public void testSynthesizesNullWhenAbsentFieldHasNoDefault() throws IOException {
+    File testFile = writeFile();
+    Schema schemaWithoutDefault =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "country", Types.StringType.get()));
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(schemaWithoutDefault)
+            .createReaderFunc(
+                readOrcSchema -> new SparkOrcReader(schemaWithoutDefault, readOrcSchema))
+            .build()) {
+      int count = 0;
+      for (InternalRow row : reader) {
+        Assertions.assertThat(row.isNullAt(2)).isTrue();
+        count += 1;
+      }
+      Assertions.assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  public void testFillsNestedDefaultWhenFieldIsAbsent() throws IOException {
+    Schema writeSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2, "nested", Types.StructType.of(required(3, "value", Types.StringType.get()))));
+    Schema readSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2,
+                "nested",
+                Types.StructType.of(
+                    required(3, "value", Types.StringType.get()),
+                    Types.NestedField.optional("missing")
+                        .withId(4)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Expressions.lit("filled"))
+                        .build())));
+    InternalRow nested = new GenericInternalRow(new Object[] {UTF8String.fromString("present")});
+    File testFile =
+        writeFile(
+            writeSchema, Lists.newArrayList(new GenericInternalRow(new Object[] {1L, nested})));
+
+    try (CloseableIterable<InternalRow> reader =
+        ORC.read(Files.localInput(testFile))
+            .project(readSchema)
+            .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
+            .supportsInitialDefaults()
+            .build()) {
+      List<InternalRow> rows = Lists.newArrayList(reader);
+      Assertions.assertThat(rows).hasSize(1);
+      InternalRow readNested = rows.get(0).getStruct(1, 2);
+      Assertions.assertThat(readNested.getUTF8String(0))
+          .isEqualTo(UTF8String.fromString("present"));
+      Assertions.assertThat(readNested.getUTF8String(1)).isEqualTo(UTF8String.fromString("filled"));
+    }
+  }
+}

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkOrcInitialDefaultScan.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkOrcInitialDefaultScan.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.Files.localOutput;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestSparkOrcInitialDefaultScan {
+  private static final Schema TABLE_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional("country")
+              .withId(2)
+              .ofType(Types.StringType.get())
+              .withInitialDefault(Expressions.lit("US"))
+              .build(),
+          Types.NestedField.optional(3, "data", Types.StringType.get()));
+  private static final Schema OLD_FILE_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(3, "data", Types.StringType.get()));
+  private static final Configuration CONF = new Configuration();
+  private static SparkSession spark;
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private File tableLocation;
+  private Table table;
+
+  @BeforeClass
+  public static void startSpark() {
+    spark = SparkSession.builder().master("local[2]").getOrCreate();
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    spark.stop();
+    spark = null;
+  }
+
+  @Before
+  public void createMixedFileTable() throws IOException {
+    tableLocation = temp.newFolder("mixed-default-files");
+    table =
+        new HadoopTables(CONF)
+            .create(TABLE_SCHEMA, PartitionSpec.unpartitioned(), tableLocation.toString());
+    table
+        .updateProperties()
+        .set(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.ORC.name())
+        .set(TableProperties.ORC_VECTORIZATION_ENABLED, "true")
+        .commit();
+
+    Record old = GenericRecord.create(OLD_FILE_SCHEMA);
+    old.setField("id", 1L);
+    old.setField("data", "old");
+
+    Record present = GenericRecord.create(TABLE_SCHEMA);
+    present.setField("id", 2L);
+    present.setField("country", "CA");
+    present.setField("data", "new-value");
+
+    Record presentNull = GenericRecord.create(TABLE_SCHEMA);
+    presentNull.setField("id", 3L);
+    presentNull.setField("country", null);
+    presentNull.setField("data", "new-null");
+
+    table
+        .newAppend()
+        .appendFile(writeFile(OLD_FILE_SCHEMA, Lists.newArrayList(old), "old.orc"))
+        .appendFile(writeFile(TABLE_SCHEMA, Lists.newArrayList(present, presentNull), "new.orc"))
+        .commit();
+  }
+
+  @Test
+  public void testMixedFilesApplyDefaultPerFile() {
+    List<Row> rows = read().select("id", "country", "data").orderBy("id").collectAsList();
+
+    Assertions.assertThat(rows)
+        .extracting(row -> row.getLong(0), row -> row.getString(1), row -> row.getString(2))
+        .containsExactly(
+            Lists.newArrayList(1L, "US", "old"),
+            Lists.newArrayList(2L, "CA", "new-value"),
+            Lists.newArrayList(3L, null, "new-null"));
+  }
+
+  @Test
+  public void testFilterPushdownOnInitialDefaultColumnAbsentFromFile() {
+    assertIds("country = 'US'", 1L);
+    assertIds("upper(country) = 'US'", 1L);
+    assertIds("country IS NOT NULL", 1L, 2L);
+    assertIds("country = 'CA'", 2L);
+    assertIds("country IS NULL", 3L);
+  }
+
+  @Test
+  public void testSetAndRangeFiltersEvaluateMaterializedDefault() {
+    assertIds("country IN ('US', 'MX')", 1L);
+    assertIds("country NOT IN ('CA', 'MX')", 1L);
+    assertIds("country >= 'US'", 1L);
+    assertIds("country < 'ZW'", 1L, 2L);
+    assertIds("country LIKE 'U%'", 1L);
+    assertIds("country NOT LIKE 'X%'", 1L, 2L);
+  }
+
+  @Test
+  public void testFilterPushdownOnNestedInitialDefaultColumnAbsentFromFile() throws IOException {
+    File nestedLocation = temp.newFolder("nested-default-files");
+    Schema oldSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                2,
+                "loc",
+                Types.StructType.of(
+                    Types.NestedField.optional(3, "city", Types.StringType.get()))));
+    Schema currentSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                2,
+                "loc",
+                Types.StructType.of(
+                    Types.NestedField.optional(3, "city", Types.StringType.get()),
+                    Types.NestedField.optional("country")
+                        .withId(4)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Expressions.lit("US"))
+                        .build())));
+    Table nestedTable =
+        new HadoopTables(CONF)
+            .create(currentSchema, PartitionSpec.unpartitioned(), nestedLocation.toString());
+    nestedTable
+        .updateProperties()
+        .set(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.ORC.name())
+        .set(TableProperties.ORC_VECTORIZATION_ENABLED, "true")
+        .commit();
+
+    Record oldLoc = GenericRecord.create(oldSchema.findField("loc").type().asStructType());
+    oldLoc.setField("city", "San Francisco");
+    Record oldPresent = GenericRecord.create(oldSchema);
+    oldPresent.setField("id", 1L);
+    oldPresent.setField("loc", oldLoc);
+    Record oldNullParent = GenericRecord.create(oldSchema);
+    oldNullParent.setField("id", 2L);
+    oldNullParent.setField("loc", null);
+
+    Record newLoc = GenericRecord.create(currentSchema.findField("loc").type().asStructType());
+    newLoc.setField("city", "Toronto");
+    newLoc.setField("country", "CA");
+    Record newPresent = GenericRecord.create(currentSchema);
+    newPresent.setField("id", 3L);
+    newPresent.setField("loc", newLoc);
+
+    nestedTable
+        .newAppend()
+        .appendFile(
+            writeFile(
+                nestedLocation,
+                oldSchema,
+                Lists.newArrayList(oldPresent, oldNullParent),
+                "old-nested.orc"))
+        .appendFile(
+            writeFile(
+                nestedLocation, currentSchema, Lists.newArrayList(newPresent), "new-nested.orc"))
+        .commit();
+
+    assertIds(nestedLocation, "loc.country = 'US'", 1L);
+    assertIds(nestedLocation, "loc.country = 'CA'", 3L);
+    assertIds(nestedLocation, "loc.country IS NULL", 2L);
+  }
+
+  @Test
+  public void testDefaultProjectionUsesIterativeReader() {
+    Assertions.assertThat(supportsColumnarReads(null)).isFalse();
+  }
+
+  @Test
+  public void testProjectionWithoutDefaultRemainsVectorized() {
+    Assertions.assertThat(
+            supportsColumnarReads(
+                new Schema(
+                    Types.NestedField.required(1, "id", Types.LongType.get()),
+                    Types.NestedField.optional(3, "data", Types.StringType.get()))))
+        .isTrue();
+  }
+
+  private Dataset<Row> read() {
+    return spark
+        .read()
+        .format("iceberg")
+        .option(SparkReadOptions.VECTORIZATION_ENABLED, "true")
+        .load(tableLocation.toString());
+  }
+
+  private void assertIds(String filter, Long... expectedIds) {
+    assertIds(tableLocation, filter, expectedIds);
+  }
+
+  private void assertIds(File location, String filter, Long... expectedIds) {
+    List<Long> ids =
+        spark.read().format("iceberg").option(SparkReadOptions.VECTORIZATION_ENABLED, "true")
+            .load(location.toString()).filter(filter).select("id").orderBy("id").collectAsList()
+            .stream()
+            .map(row -> row.getLong(0))
+            .collect(java.util.stream.Collectors.toList());
+    Assertions.assertThat(ids).containsExactly(expectedIds);
+  }
+
+  private boolean supportsColumnarReads(Schema projection) {
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(
+            ImmutableMap.of(
+                "path", tableLocation.toString(), SparkReadOptions.VECTORIZATION_ENABLED, "true"));
+    SparkScanBuilder builder = new SparkScanBuilder(spark, table, options);
+    if (projection != null) {
+      builder.pruneColumns(SparkSchemaUtil.convert(projection));
+    }
+    Batch batch = builder.build().toBatch();
+    InputPartition partition = batch.planInputPartitions()[0];
+    PartitionReaderFactory factory = batch.createReaderFactory();
+    return factory.supportColumnarReads(partition);
+  }
+
+  private DataFile writeFile(Schema schema, List<Record> records, String name) throws IOException {
+    return writeFile(tableLocation, schema, records, name);
+  }
+
+  private DataFile writeFile(File location, Schema schema, List<Record> records, String name)
+      throws IOException {
+    File file = new File(new File(location, "data"), name);
+    Assertions.assertThat(file.getParentFile().mkdirs() || file.getParentFile().isDirectory())
+        .isTrue();
+    FileAppender<Record> appender =
+        new GenericAppenderFactory(schema).newAppender(localOutput(file), FileFormat.ORC);
+    try {
+      appender.addAll(records);
+    } finally {
+      appender.close();
+    }
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withInputFile(localInput(file))
+        .withMetrics(appender.metrics())
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

Opts the Spark 3.1 iterative ORC reader into #263's initial-default projection and supplies Spark's constant conversion to the ID-binding `StructReader`.

- `RowDataReader` explicitly calls `supportsInitialDefaults()`.
- `SparkOrcValueReaders` converts missing-field defaults into Spark's in-memory representation.
- Constant conversion lives in `SparkValueConverters`, shared with the existing partition-constant path.
- ORC scans projecting an initial default are routed away from vectorization until the vectorized reader is implemented.

## Scope

Spark 3.1 iterative ORC reads only. The vectorized ORC reader is intentionally deferred; schemas without projected initial defaults continue to vectorize normally.

Other Spark and Flink versions do not opt into #263 and retain their previous projection behavior.

## Stack

1. #265 — ID-based `StructReader` backport
2. #263 — Generic ORC initial-default fill and reader capability gate
3. **This PR** — Spark 3.1 iterative ORC initial-default fill

Review this PR's delta against `chbush/oh120-orc-default-fill`.

## Testing Done
- [x] Spark 3.1 row tests cover declared, undeclared, and nested defaults
- [x] Spark scan tests cover mixed old/new ORC files and physical value/null precedence
- [x] Spark filter tests cover top-level and nested defaults, null parents, equality, set, range, and string-prefix predicates
- [x] Reader-factory tests verify default projections use iterative reads while ordinary projections remain vectorized
- [x] Spotless passes
- [x] Spark 3.1 CI passes

